### PR TITLE
chore(studio): audit stragglers — Monitor label, themeable density docs, sack summaries

### DIFF
--- a/client/src/lib/core/themingDocs.ts
+++ b/client/src/lib/core/themingDocs.ts
@@ -26,7 +26,24 @@ const CHROME_TOKENS: { name: string; purpose: string }[] = [
 	{ name: '--ui-success-rgb', purpose: 'Success accent channels.' },
 	{ name: '--ui-success-fg', purpose: 'Success text.' },
 	{ name: '--ui-warn-rgb', purpose: 'Warning accent channels.' },
-	{ name: '--ui-warn-fg', purpose: 'Warning text.' }
+	{ name: '--ui-warn-fg', purpose: 'Warning text.' },
+	// Spacing / typography / shape — the studio's density knobs. Same override story as the colour
+	// tokens: set at :root in a theme. Scale: 2/4/6/8/12/16.
+	{ name: '--space-1', purpose: 'Spacing scale: hairline (2px).' },
+	{ name: '--space-2', purpose: 'Spacing scale: tight (4px).' },
+	{ name: '--space-3', purpose: 'Spacing scale: default gap (6px).' },
+	{ name: '--space-4', purpose: 'Spacing scale: section / panel inset (8px).' },
+	{ name: '--space-5', purpose: 'Spacing scale: large (12px).' },
+	{ name: '--space-6', purpose: 'Spacing scale: screen-edge / panel padding (16px).' },
+	{ name: '--text-xs', purpose: 'Type scale: smallest annotations (9px).' },
+	{ name: '--text-sm', purpose: 'Type scale: section headers / hints (10px).' },
+	{ name: '--text-md', purpose: 'Type scale: chrome body (11px).' },
+	{ name: '--text-lg', purpose: 'Type scale: emphasized body / panel text (12px).' },
+	{ name: '--text-xl', purpose: 'Type scale: panel titles (14px).' },
+	{ name: '--radius-control', purpose: 'Corner radius for inputs / buttons / chips (2px).' },
+	{ name: '--radius-panel', purpose: 'Corner radius for panels / cards / menus (4px).' },
+	{ name: '--control-h', purpose: 'Minimum height of rail/bar inputs and selects (22px).' },
+	{ name: '--disabled-opacity', purpose: 'Opacity of disabled controls (0.5).' }
 ];
 
 // One-line human description per token (the prose the value/name alone can't carry). Keyed by token
@@ -144,6 +161,11 @@ The studio chrome — title bar, rails, panels, backgrounds — is themeable too
 light studio. Their dark defaults live in \`client/src/styles.css\`; a theme only sets what it changes.
 Accent / state colours are RGB **channels** (e.g. \`--ui-accent-rgb: 119, 196, 211\`) so both the solid
 \`rgb(var(--ui-accent-rgb))\` and translucent \`rgba(var(--ui-accent-rgb), a)\` forms work.
+
+Beyond colour, the chrome's **density and typography** ride the same system: the \`--space-*\` scale,
+\`--text-*\` type ramp, \`--radius-*\` shapes, \`--control-h\`, and \`--disabled-opacity\` below are plain
+\`:root\` custom properties — a theme can compact the studio (\`--space-3: 4px; --text-md: 10px\`) or
+relax it the same way it recolours it.
 `;
 
 const BUILTIN_SECTION = `## Built-in themes

--- a/client/src/lib/widgets/Canvas.tsx
+++ b/client/src/lib/widgets/Canvas.tsx
@@ -134,7 +134,7 @@ import { usePaneSizes } from './canvas/usePaneSizes';
 import { RAIL_ORDER, type SectionId } from './canvas/studioSections';
 import { BUILTIN_THEMES, builtinGroups, builtinName } from '../core/builtinThemes';
 import { useThemes } from './canvas/useThemes';
-import { useSacks } from './canvas/useSacks';
+import { sackSummary, useSacks } from './canvas/useSacks';
 import { useSavedLayouts } from './canvas/useSavedLayouts';
 import { useBackground } from './canvas/useBackground';
 import { useDefEditor } from './canvas/useDefEditor';
@@ -1146,7 +1146,7 @@ export default function Canvas({ studio = false }: Props) {
 	dirtyRef.current = dirty;
 
 	// --- sacks (item 10): export the studio's shareable state, import + merge one back ---
-	const { sackNames, exportSack, importSack } = useSacks({
+	const { sackInfos, exportSack, importSack } = useSacks({
 		studio,
 		navSection,
 		editingDefId,
@@ -2403,8 +2403,11 @@ export default function Canvas({ studio = false }: Props) {
 										onChange={setTheme}
 										aria-label="Theme"
 									/>
+									{/* "Monitor", not "Display": Settings has a Display PAGE (monitor info), and the two
+									    sharing a name made this read as a duplicate — this switcher picks WHICH monitor's
+									    layout the studio edits. */}
 									<span className="lbl" data-tauri-drag-region>
-										Display
+										Monitor
 									</span>
 									<Select
 										className="sb-select"
@@ -2806,22 +2809,27 @@ export default function Canvas({ studio = false }: Props) {
 									<div className="rail-panel">
 										<div className="rp-hd">Sacks</div>
 										<div className="rp-stub">
-											Bundle this monitor’s widget library + theme + tokens to share or reuse.
+											A sack bundles your reusable widgets, the active theme’s CSS, and your token
+											overrides into one shareable file — <code>sacks/&lt;name&gt;.sack.json</code>{' '}
+											in the app config folder. Send the file to share your setup; importing merges
+											(it never overwrites your own widgets or themes).
 										</div>
 										<button type="button" onClick={exportSack}>
 											⤓ Export current…
 										</button>
 										<div className="rp-hd">Import</div>
-										{sackNames.length ? (
+										{sackInfos.length ? (
 											<div className="rp-list">
-												{sackNames.map((n) => (
+												{sackInfos.map((s) => (
 													<button
-														key={n}
+														key={s.name}
 														type="button"
+														className="sack-item"
 														title="Merge this sack's widgets + theme into the studio"
-														onClick={() => importSack(n)}
+														onClick={() => importSack(s.name)}
 													>
-														⤒ {n}
+														<span className="sack-name">⤒ {s.name}</span>
+														<span className="sack-sub">{sackSummary(s)}</span>
 													</button>
 												))}
 											</div>

--- a/client/src/lib/widgets/NavRail.css
+++ b/client/src/lib/widgets/NavRail.css
@@ -764,6 +764,21 @@
 	color: var(--ui-danger-fg);
 }
 
+/* Sack rows (the Sacks section's Import list): name + a dim contents summary ("5 widgets ·
+   theme "Nord" · 3 token overrides") so a sack reads as more than a bare filename. */
+.canvas .rail-panel .sack-item {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: var(--space-1);
+	text-align: left;
+}
+
+.canvas .rail-panel .sack-item .sack-sub {
+	color: var(--ui-fg-dim);
+	font-size: var(--text-sm);
+}
+
 /* Sensor source groups (the Sensors section): a collapsible header (caret + source name + count)
    above that source's responsive sensor grid. The header overrides the chunky generic button look. */
 .canvas .rail-panel .rp-group {

--- a/client/src/lib/widgets/canvas/useSacks.test.ts
+++ b/client/src/lib/widgets/canvas/useSacks.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { sackSummary } from './useSacks';
+
+describe('sackSummary', () => {
+	it('joins widgets, theme, and overrides with middots (singular/plural aware)', () => {
+		expect(sackSummary({ name: 's', widgets: 5, theme: 'Nord', tokens: 3 })).toBe(
+			'5 widgets · theme “Nord” · 3 token overrides'
+		);
+		expect(sackSummary({ name: 's', widgets: 1, theme: null, tokens: 1 })).toBe(
+			'1 widget · 1 token override'
+		);
+	});
+
+	it('reports an empty sack and an unreadable file distinctly', () => {
+		expect(sackSummary({ name: 's', widgets: 0, theme: null, tokens: 0 })).toBe('empty');
+		expect(sackSummary({ name: 's', widgets: null, theme: null, tokens: 0 })).toBe(
+			'unreadable — not a sack?'
+		);
+	});
+});

--- a/client/src/lib/widgets/canvas/useSacks.ts
+++ b/client/src/lib/widgets/canvas/useSacks.ts
@@ -31,9 +31,27 @@ type Deps = {
 	themes: Pick<Themes, 'themeLabel' | 'setThemeList' | 'adoptTheme'>;
 };
 
+export type SackInfo = {
+	name: string;
+	/** Reusable widget defs inside; null = the file exists but didn't parse as a sack. */
+	widgets: number | null;
+	theme: string | null;
+	tokens: number;
+};
+
+/** One dim summary line for a sack row — what you'd get by importing it. Pure (tested). */
+export function sackSummary(info: SackInfo): string {
+	if (info.widgets === null) return 'unreadable — not a sack?';
+	const parts: string[] = [];
+	if (info.widgets) parts.push(`${info.widgets} widget${info.widgets === 1 ? '' : 's'}`);
+	if (info.theme) parts.push(`theme “${info.theme}”`);
+	if (info.tokens) parts.push(`${info.tokens} token override${info.tokens === 1 ? '' : 's'}`);
+	return parts.length ? parts.join(' · ') : 'empty';
+}
+
 export type Sacks = {
-	/** The saved sacks (names), loaded when the Sacks section is open. */
-	sackNames: string[];
+	/** The saved sacks (name + contents summary), loaded when the Sacks section is open. */
+	sackInfos: SackInfo[];
 	exportSack: () => Promise<void>;
 	importSack: (name: string) => Promise<void>;
 };
@@ -49,7 +67,28 @@ export function useSacks({
 	themes
 }: Deps): Sacks {
 	const { themeLabel, setThemeList, adoptTheme } = themes;
-	const [sackNames, setSackNames] = useState<string[]>([]);
+	const [sackInfos, setSackInfos] = useState<SackInfo[]>([]);
+
+	// Names + a peek inside each (count of defs, theme name, override count) so the Import list can
+	// say what a sack contains instead of a bare filename. Sacks are small local JSON; reading each
+	// on section-open is cheap. A file that doesn't parse still lists (widgets: null → "unreadable").
+	const refreshSacks = useCallback(async () => {
+		const names = await listSacks();
+		const infos = await Promise.all(
+			names.map(async (name): Promise<SackInfo> => {
+				const raw = await readSack(name);
+				const sack = raw ? unpackSack(raw) : null;
+				if (!sack) return { name, widgets: null, theme: null, tokens: 0 };
+				return {
+					name,
+					widgets: sack.library?.defs.length ?? 0,
+					theme: sack.theme?.name ?? null,
+					tokens: sack.tokens ? Object.keys(sack.tokens).length : 0
+				};
+			})
+		);
+		setSackInfos(infos);
+	}, []);
 
 	const exportSack = useCallback(async () => {
 		if (editingDefId != null) {
@@ -70,9 +109,9 @@ export function useSacks({
 			tokens: tokenOverrides
 		});
 		const path = await writeSack(name, JSON.stringify(sack, null, '\t'));
-		setSackNames(await listSacks());
+		await refreshSacks();
 		if (path) window.alert(`Saved sack:\n${path}`);
-	}, [editingDefId, selectedTheme, themeLabel, library, tokenOverrides]);
+	}, [editingDefId, selectedTheme, themeLabel, library, tokenOverrides, refreshSacks]);
 
 	const importSack = useCallback(
 		async (name: string) => {
@@ -127,10 +166,10 @@ export function useSacks({
 		[editingDefId, commitOp, setThemeList, adoptTheme]
 	);
 
-	// Load the saved sack names when the Sacks section opens.
+	// Load the saved sacks (+ their summaries) when the Sacks section opens.
 	useEffect(() => {
-		if (studio && navSection === 'sacks') listSacks().then(setSackNames);
-	}, [studio, navSection]);
+		if (studio && navSection === 'sacks') void refreshSacks();
+	}, [studio, navSection, refreshSacks]);
 
-	return { sackNames, exportSack, importSack };
+	return { sackInfos, exportSack, importSack };
 }

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -45,6 +45,11 @@ light studio. Their dark defaults live in `client/src/styles.css`; a theme only 
 Accent / state colours are RGB **channels** (e.g. `--ui-accent-rgb: 119, 196, 211`) so both the solid
 `rgb(var(--ui-accent-rgb))` and translucent `rgba(var(--ui-accent-rgb), a)` forms work.
 
+Beyond colour, the chrome's **density and typography** ride the same system: the `--space-*` scale,
+`--text-*` type ramp, `--radius-*` shapes, `--control-h`, and `--disabled-opacity` below are plain
+`:root` custom properties — a theme can compact the studio (`--space-3: 4px; --text-md: 10px`) or
+relax it the same way it recolours it.
+
 | token | purpose |
 | --- | --- |
 | `--ui-bg` | Base window + opaque panel background. |
@@ -65,6 +70,21 @@ Accent / state colours are RGB **channels** (e.g. `--ui-accent-rgb: 119, 196, 21
 | `--ui-success-fg` | Success text. |
 | `--ui-warn-rgb` | Warning accent channels. |
 | `--ui-warn-fg` | Warning text. |
+| `--space-1` | Spacing scale: hairline (2px). |
+| `--space-2` | Spacing scale: tight (4px). |
+| `--space-3` | Spacing scale: default gap (6px). |
+| `--space-4` | Spacing scale: section / panel inset (8px). |
+| `--space-5` | Spacing scale: large (12px). |
+| `--space-6` | Spacing scale: screen-edge / panel padding (16px). |
+| `--text-xs` | Type scale: smallest annotations (9px). |
+| `--text-sm` | Type scale: section headers / hints (10px). |
+| `--text-md` | Type scale: chrome body (11px). |
+| `--text-lg` | Type scale: emphasized body / panel text (12px). |
+| `--text-xl` | Type scale: panel titles (14px). |
+| `--radius-control` | Corner radius for inputs / buttons / chips (2px). |
+| `--radius-panel` | Corner radius for panels / cards / menus (4px). |
+| `--control-h` | Minimum height of rail/bar inputs and selects (22px). |
+| `--disabled-opacity` | Opacity of disabled controls (0.5). |
 
 ## Built-in themes
 


### PR DESCRIPTION
The last three small items from the UI audit:

- App-bar "Display" → **Monitor** (Settings keeps its Display page; the duplicate name was the confusion)
- `--space-*` / `--text-*` / `--radius-*` / `--control-h` / `--disabled-opacity` documented in the theming reference — themes can compact/relax studio density at `:root` like they recolour it
- Sacks panel: real explainer copy + per-sack contents summaries in the Import list (pure `sackSummary`, tested)

Verified: 1,106 unit tests · 32 e2e · tsc · lint · build · check:docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)