### PR TITLE
feat(plugins): third-party plugin packages — declarative, opt-in (Phase 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ docs regenerate from the code with `npm run gen:docs`.
 - **Templates:** one-click starter groups (clock, system, network, now-playing) recreated from
   classic Rainmeter skins.
 - **Macros:** bind a button to a sequence of actions (HA service calls, media transport).
+- **Plugin packages:** drop-in template/theme bundles from the community — declarative, opt-in,
+  scanned ([authoring guide](docs/third-party-plugins.md)).
 - **Theming:** per-widget CSS (highlighting/linting editor), design-token themes, system fonts.
 - **Window zones:** define snap regions and drag any app's window into them.
 - **Perfect for secondary and side monitors**: Corsair Xeneon Edge, Lamptron, Turzx, etc.

--- a/client/src/lib/bridge/contract.ts
+++ b/client/src/lib/bridge/contract.ts
@@ -61,6 +61,9 @@ export const COMMANDS = {
 	listSacks: 'list_sacks',
 	readSack: 'read_sack',
 	writeSack: 'write_sack',
+	// third-party plugin packages (command.rs)
+	listPluginPackages: 'list_plugin_packages',
+	readPluginPackageAsset: 'read_plugin_package_asset',
 	// foreign windows / monitors / click-through (windowmgr.rs, clickthrough.rs, display.rs)
 	listWindows: 'list_windows',
 	snapWindow: 'snap_window',

--- a/client/src/lib/core/migration.ts
+++ b/client/src/lib/core/migration.ts
@@ -186,6 +186,16 @@ function isNumberArray(v: unknown): v is number[] {
 	return Array.isArray(v) && v.every((n) => typeof n === 'number' && Number.isFinite(n));
 }
 
+/**
+ * Parse ONE layout node (container or leaf) through the same structural whitelist the v2
+ * layout file goes through — for callers validating a node-shaped JSON outside a full layout
+ * (a plugin package's template tree, core/pluginPackage.ts). Malformed children inside a
+ * container are dropped (the v2 convention); a malformed root returns null. Never throws.
+ */
+export function parseLayoutNode(raw: unknown): LayoutNode | null {
+	return parseNode(raw);
+}
+
 function parseNode(raw: unknown): LayoutNode | null {
 	if (typeof raw !== 'object' || raw === null) return null;
 	const o = raw as Record<string, unknown>;

--- a/client/src/lib/core/pluginPackage.test.ts
+++ b/client/src/lib/core/pluginPackage.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import { packageTemplateId, packageTemplates, parsePluginPackage } from './pluginPackage';
+import { isLeaf } from './layoutTree';
+
+// A minimal valid leaf node (a clock widget) the structural whitelist accepts.
+const leafNode = (id = 'w1') => ({
+	id,
+	unit: { id, type: 'clock', rect: { x: 0, y: 0, w: 160, h: 40 }, config: { format: 'HH:mm' } }
+});
+
+const manifest = (over: Record<string, unknown> = {}) =>
+	JSON.stringify({
+		manifestVersion: 1,
+		id: 'weather-pack',
+		name: 'Weather pack',
+		version: '1.0.0',
+		templates: [
+			{
+				id: 'clock-tpl',
+				name: 'Big clock',
+				size: { w: 200, h: 80 },
+				params: [{ key: 'format', label: 'format', target: 'unit.config.format' }],
+				tree: leafNode()
+			}
+		],
+		...over
+	});
+
+describe('parsePluginPackage', () => {
+	it('accepts a valid manifest and maps its template', () => {
+		const r = parsePluginPackage('weather-pack', manifest());
+		expect(r.ok).toBe(true);
+		if (!r.ok) return;
+		expect(r.pkg.manifest.name).toBe('Weather pack');
+		expect(r.pkg.manifest.templates).toHaveLength(1);
+		expect(r.pkg.warnings).toEqual([]);
+	});
+
+	it('rejects bad JSON, a wrong manifestVersion, and a folder/id mismatch', () => {
+		expect(parsePluginPackage('weather-pack', '{nope').ok).toBe(false);
+		expect(parsePluginPackage('weather-pack', manifest({ manifestVersion: 2 })).ok).toBe(false);
+		const mismatch = parsePluginPackage('other-folder', manifest());
+		expect(mismatch.ok).toBe(false);
+		if (!mismatch.ok) expect(mismatch.reason).toContain('does not match its folder');
+	});
+
+	it('drops a malformed template with a warning but keeps the package', () => {
+		const r = parsePluginPackage(
+			'weather-pack',
+			manifest({
+				templates: [
+					{ id: 'bad', name: 'Bad', size: { w: 10, h: 10 }, tree: { not: 'a node' } },
+					{ id: 'good', name: 'Good', size: { w: 10, h: 10 }, tree: leafNode('g1') }
+				]
+			})
+		);
+		expect(r.ok).toBe(true);
+		if (!r.ok) return;
+		expect(r.pkg.manifest.templates.map((t) => t.id)).toEqual(['good']);
+		expect(r.pkg.warnings[0]).toContain('"bad" dropped');
+	});
+
+	it('drops a template whose param path walks the prototype chain', () => {
+		const r = parsePluginPackage(
+			'weather-pack',
+			manifest({
+				templates: [
+					{
+						id: 'evil',
+						name: 'Evil',
+						size: { w: 10, h: 10 },
+						params: [{ key: '__proto__.polluted' }],
+						tree: leafNode()
+					}
+				]
+			})
+		);
+		expect(r.ok).toBe(true);
+		if (!r.ok) return;
+		expect(r.pkg.manifest.templates).toEqual([]);
+		expect(r.pkg.warnings[0]).toContain('malformed param spec');
+	});
+
+	it('drops a theme whose file is not a plain .css name', () => {
+		const r = parsePluginPackage(
+			'weather-pack',
+			manifest({ theme: { name: 'Sky', file: '../escape.css' } })
+		);
+		expect(r.ok).toBe(true);
+		if (!r.ok) return;
+		expect(r.pkg.manifest.theme).toBeUndefined();
+		expect(r.pkg.warnings[0]).toContain('theme dropped');
+	});
+});
+
+describe('packageTemplates', () => {
+	it('namespaces ids and hands out a fresh tree per call', () => {
+		const r = parsePluginPackage('weather-pack', manifest());
+		expect(r.ok).toBe(true);
+		if (!r.ok) return;
+		const [tpl] = packageTemplates(r.pkg.manifest);
+		expect(tpl.id).toBe(packageTemplateId('weather-pack', 'clock-tpl'));
+		expect(tpl.params).toHaveLength(1);
+		const a = tpl.tree();
+		const b = tpl.tree();
+		expect(a).toEqual(b);
+		expect(a).not.toBe(b); // private copy per insert
+		expect(isLeaf(a)).toBe(true);
+	});
+});

--- a/client/src/lib/core/pluginPackage.ts
+++ b/client/src/lib/core/pluginPackage.ts
@@ -1,0 +1,264 @@
+// Third-party plugin packages (Phase 1): a package is a directory in the app-config `plugins/`
+// folder — `plugins/<id>/plugin.json` — containing ONLY declarative data: metadata + templates
+// (layout trees + ParamSpec params, the same data the templates system already speaks) + an
+// optional theme CSS file. No JS in Phase 1. This module is the PURE half: manifest parse +
+// validation (fail-closed — a malformed manifest is rejected with a reason, a malformed template
+// is dropped with a reason, nothing ever throws) and the mapping onto core/templates `Template`s.
+// The Tauri file I/O + enable/registration live in widgets/plugins/packages.ts (the adapter).
+// Co-located vitest tests in pluginPackage.test.ts.
+
+import type { LayoutNode, ParamChoice, ParamSpec } from './layoutTree';
+import { parseLayoutNode } from './migration';
+import type { Template } from './templates';
+
+/** One declarative template inside a package: the same shape as a built-in `Template`, except the
+ * tree is DATA (a layout-node JSON, validated through the layout file's structural whitelist)
+ * rather than a builder function. */
+export type PackageTemplate = {
+	id: string;
+	name: string;
+	description?: string;
+	size: { w: number; h: number };
+	params?: ParamSpec[];
+	tree: LayoutNode;
+};
+
+/** An optional theme the package ships: `file` names a sibling `.css` asset inside the package
+ * directory (read via `read_plugin_package_asset`, scanned by core/cssThreats before injection). */
+export type PackageTheme = { name: string; file: string };
+
+export type PluginPackageManifest = {
+	manifestVersion: 1;
+	id: string;
+	name: string;
+	version: string;
+	description?: string;
+	author?: string;
+	homepage?: string;
+	/** Already filtered to the structurally valid templates (invalid ones land in `warnings`). */
+	templates: PackageTemplate[];
+	theme?: PackageTheme;
+};
+
+export type ParsedPackage = {
+	manifest: PluginPackageManifest;
+	/** Dropped-template / dropped-theme reasons — the package still loads without them. */
+	warnings: string[];
+};
+
+export type PackageParseResult = { ok: true; pkg: ParsedPackage } | { ok: false; reason: string };
+
+// Mirrors the Rust `valid_name` allowlist (command.rs): 1–64 chars of [A-Za-z0-9 _-], no
+// leading/trailing space. Package + template ids become path segments / registry keys.
+function isIdToken(v: unknown): v is string {
+	return (
+		typeof v === 'string' &&
+		v.length >= 1 &&
+		v.length <= 64 &&
+		v === v.trim() &&
+		/^[A-Za-z0-9 _-]+$/.test(v)
+	);
+}
+
+// An asset filename the backend will serve: `<id token>.css` / `<id token>.json` (single segment,
+// no extra dots). Mirrors the Rust `valid_asset_name`.
+function isAssetName(v: unknown): v is string {
+	if (typeof v !== 'string') return false;
+	const dot = v.lastIndexOf('.');
+	if (dot <= 0) return false;
+	const ext = v.slice(dot + 1).toLowerCase();
+	return (ext === 'css' || ext === 'json') && isIdToken(v.slice(0, dot));
+}
+
+function isOptionalString(v: unknown): v is string | undefined {
+	return v === undefined || typeof v === 'string';
+}
+
+function isSize(v: unknown): v is { w: number; h: number } {
+	if (typeof v !== 'object' || v === null) return false;
+	const o = v as Record<string, unknown>;
+	return (
+		typeof o.w === 'number' &&
+		typeof o.h === 'number' &&
+		Number.isFinite(o.w) &&
+		Number.isFinite(o.h) &&
+		o.w > 0 &&
+		o.h > 0
+	);
+}
+
+// A param target is a dotted path written into the cloned tree by solve.ts `applyParams`. Its
+// setter is already fail-closed against auto-vivification, but a hostile path could still walk
+// `__proto__`/`constructor` up into shared prototypes — reject those segments outright.
+const FORBIDDEN_PATH_SEGMENTS = new Set(['__proto__', 'prototype', 'constructor']);
+
+function isSafePath(v: unknown): v is string {
+	if (typeof v !== 'string' || !v.length) return false;
+	return v.split('.').every((seg) => seg.length > 0 && !FORBIDDEN_PATH_SEGMENTS.has(seg));
+}
+
+function isParamChoice(v: unknown): v is ParamChoice {
+	if (typeof v !== 'object' || v === null) return false;
+	const o = v as Record<string, unknown>;
+	return typeof o.value === 'string' && typeof o.label === 'string';
+}
+
+// One ParamSpec, structurally whitelisted (the persistence convention: only listed fields
+// survive). Null = malformed → the whole template is dropped (fail-closed; a silently mangled
+// param would mis-write config at insert time).
+function parseParamSpec(raw: unknown): ParamSpec | null {
+	if (typeof raw !== 'object' || raw === null) return null;
+	const o = raw as Record<string, unknown>;
+	if (typeof o.key !== 'string' || !o.key.length || !isSafePath(o.key)) return null;
+	if (!isOptionalString(o.label)) return null;
+	if (o.target !== undefined && !isSafePath(o.target)) return null;
+	if (o.targets !== undefined && !(Array.isArray(o.targets) && o.targets.every(isSafePath))) {
+		return null;
+	}
+	if (o.choices !== undefined && !(Array.isArray(o.choices) && o.choices.every(isParamChoice))) {
+		return null;
+	}
+	const spec: ParamSpec = { key: o.key };
+	if (o.label !== undefined) spec.label = o.label;
+	if (o.default !== undefined) spec.default = o.default;
+	if (o.target !== undefined) spec.target = o.target as string;
+	if (o.targets !== undefined) spec.targets = (o.targets as string[]).slice();
+	if (o.choices !== undefined) spec.choices = (o.choices as ParamChoice[]).map((c) => ({ ...c }));
+	return spec;
+}
+
+// One template entry → PackageTemplate, or a human-readable drop reason.
+function parsePackageTemplate(raw: unknown, index: number): PackageTemplate | string {
+	const at = (id?: string) => `template ${id ? `"${id}"` : `#${index}`} dropped`;
+	if (typeof raw !== 'object' || raw === null) return `${at()}: not an object`;
+	const o = raw as Record<string, unknown>;
+	if (!isIdToken(o.id)) return `${at()}: missing/invalid "id"`;
+	const id = o.id;
+	if (typeof o.name !== 'string' || !o.name.trim()) return `${at(id)}: missing "name"`;
+	if (!isOptionalString(o.description)) return `${at(id)}: "description" must be a string`;
+	if (!isSize(o.size)) return `${at(id)}: "size" must be { w, h } with positive numbers`;
+	let params: ParamSpec[] | undefined;
+	if (o.params !== undefined) {
+		if (!Array.isArray(o.params)) return `${at(id)}: "params" must be an array`;
+		params = [];
+		for (const p of o.params) {
+			const spec = parseParamSpec(p);
+			if (spec === null) return `${at(id)}: malformed param spec`;
+			params.push(spec);
+		}
+	}
+	const tree = parseLayoutNode(o.tree);
+	if (tree === null) return `${at(id)}: "tree" is not a valid layout node`;
+	const size = o.size as { w: number; h: number };
+	return {
+		id,
+		name: o.name,
+		...(o.description !== undefined ? { description: o.description as string } : {}),
+		size: { w: size.w, h: size.h },
+		...(params && params.length ? { params } : {}),
+		tree
+	};
+}
+
+function parsePackageTheme(raw: unknown): PackageTheme | string {
+	if (typeof raw !== 'object' || raw === null) return 'theme dropped: not an object';
+	const o = raw as Record<string, unknown>;
+	if (typeof o.name !== 'string' || !o.name.trim()) return 'theme dropped: missing "name"';
+	if (!isAssetName(o.file) || !(o.file as string).toLowerCase().endsWith('.css')) {
+		return 'theme dropped: "file" must be a plain <name>.css filename inside the package';
+	}
+	return { name: o.name, file: o.file as string };
+}
+
+/**
+ * Parse + validate one raw `plugin.json` against the directory id the backend listed it under.
+ * Fail-closed: a structural problem with the manifest itself rejects the whole package (with a
+ * reason for the Plugins panel), while an individually malformed template or theme is DROPPED
+ * with a reason in `warnings` and the rest of the package still loads. Never throws.
+ */
+export function parsePluginPackage(dirId: string, raw: string): PackageParseResult {
+	const fail = (reason: string): PackageParseResult => ({ ok: false, reason });
+	let json: unknown;
+	try {
+		json = JSON.parse(raw);
+	} catch {
+		return fail('plugin.json is not valid JSON');
+	}
+	if (typeof json !== 'object' || json === null || Array.isArray(json)) {
+		return fail('manifest must be a JSON object');
+	}
+	const o = json as Record<string, unknown>;
+	if (o.manifestVersion !== 1) {
+		return fail(`unsupported manifestVersion ${JSON.stringify(o.manifestVersion)} (expected 1)`);
+	}
+	if (!isIdToken(o.id)) return fail('missing/invalid "id"');
+	if (o.id !== dirId) return fail(`manifest id "${o.id}" does not match its folder "${dirId}"`);
+	if (typeof o.name !== 'string' || !o.name.trim()) return fail('missing "name"');
+	if (typeof o.version !== 'string' || !o.version.trim()) return fail('missing "version"');
+	if (!isOptionalString(o.description)) return fail('"description" must be a string');
+	if (!isOptionalString(o.author)) return fail('"author" must be a string');
+	if (!isOptionalString(o.homepage)) return fail('"homepage" must be a string');
+
+	const warnings: string[] = [];
+	const templates: PackageTemplate[] = [];
+	if (o.templates !== undefined) {
+		if (!Array.isArray(o.templates)) return fail('"templates" must be an array');
+		const seen = new Set<string>();
+		o.templates.forEach((t, i) => {
+			const parsed = parsePackageTemplate(t, i);
+			if (typeof parsed === 'string') {
+				warnings.push(parsed);
+				return;
+			}
+			if (seen.has(parsed.id)) {
+				warnings.push(`template "${parsed.id}" dropped: duplicate id`);
+				return;
+			}
+			seen.add(parsed.id);
+			templates.push(parsed);
+		});
+	}
+
+	let theme: PackageTheme | undefined;
+	if (o.theme !== undefined) {
+		const parsed = parsePackageTheme(o.theme);
+		if (typeof parsed === 'string') warnings.push(parsed);
+		else theme = parsed;
+	}
+
+	const manifest: PluginPackageManifest = {
+		manifestVersion: 1,
+		id: o.id,
+		name: o.name,
+		version: o.version,
+		...(o.description !== undefined ? { description: o.description as string } : {}),
+		...(o.author !== undefined ? { author: o.author as string } : {}),
+		...(o.homepage !== undefined ? { homepage: o.homepage as string } : {}),
+		templates,
+		...(theme ? { theme } : {})
+	};
+	return { ok: true, pkg: { manifest, warnings } };
+}
+
+/** The registry id of a package template: namespaced so two packages (or a package and a
+ * built-in) can never collide — `pkg:<pkgId>:<tplId>`. */
+export function packageTemplateId(pkgId: string, tplId: string): string {
+	return `pkg:${pkgId}:${tplId}`;
+}
+
+/**
+ * Map a parsed manifest's templates onto the core/templates `Template` shape: the data tree is
+ * wrapped as `tree: () => structuredClone(node)` (every insert gets a private copy, exactly like
+ * a builder-function template), params carry through, ids are namespaced via packageTemplateId.
+ * Pure — registering the result is the adapter's job.
+ */
+export function packageTemplates(manifest: PluginPackageManifest): Template[] {
+	return manifest.templates.map((t) => ({
+		id: packageTemplateId(manifest.id, t.id),
+		name: t.name,
+		description: t.description ?? '',
+		size: { ...t.size },
+		...(t.params?.length ? { params: t.params } : {}),
+		tree: () => structuredClone(t.tree)
+	}));
+}

--- a/client/src/lib/core/templates.ts
+++ b/client/src/lib/core/templates.ts
@@ -339,8 +339,65 @@ export const TEMPLATES: Template[] = [
 	}
 ];
 
+// ---- template registry (groups) ---------------------------------------------------------------
+// The Add palette + widget designer used to read the TEMPLATES const directly; third-party plugin
+// packages contribute their own template lists at runtime, so consumers now go through this small
+// registry seam instead. The built-ins are the first (immutable) group — with nothing registered,
+// listTemplateGroups() is exactly [{ group: 'Built-in', templates: TEMPLATES }], so built-in
+// behavior is unchanged. Framework-agnostic: a plain subscribe/list pair (the widgets layer wraps
+// it in useSyncExternalStore via useTemplateGroups).
+
+export type TemplateGroup = { group: string; templates: Template[] };
+
+/** The built-in templates' group name (always present, always first, never unregisterable). */
+export const BUILTIN_TEMPLATE_GROUP = 'Built-in';
+
+const templateGroups = new Map<string, Template[]>([[BUILTIN_TEMPLATE_GROUP, TEMPLATES]]);
+const templateListeners = new Set<() => void>();
+// Cached list identity so useSyncExternalStore sees a stable snapshot between changes.
+let templateSnapshot: TemplateGroup[] | null = null;
+
+function notifyTemplates(): void {
+	templateSnapshot = null;
+	for (const listener of templateListeners) listener();
+}
+
+/** Register (or replace) a named template group. The built-in group cannot be overwritten. */
+export function registerTemplates(group: string, list: Template[]): void {
+	if (group === BUILTIN_TEMPLATE_GROUP) return;
+	templateGroups.set(group, list.slice());
+	notifyTemplates();
+}
+
+/** Remove a registered template group (no-op for the built-ins / an unknown group). */
+export function unregisterTemplates(group: string): void {
+	if (group === BUILTIN_TEMPLATE_GROUP) return;
+	if (templateGroups.delete(group)) notifyTemplates();
+}
+
+/** Every template group, built-ins first then registration order. Stable identity between changes. */
+export function listTemplateGroups(): TemplateGroup[] {
+	if (!templateSnapshot) {
+		templateSnapshot = Array.from(templateGroups, ([group, templates]) => ({ group, templates }));
+	}
+	return templateSnapshot;
+}
+
+/** Subscribe to registry changes (register/unregister); returns the unsubscribe. */
+export function subscribeTemplates(listener: () => void): () => void {
+	templateListeners.add(listener);
+	return () => {
+		templateListeners.delete(listener);
+	};
+}
+
+/** Find a template by id across every registered group (built-ins first). */
 export function getTemplate(id: string): Template | undefined {
-	return TEMPLATES.find((t) => t.id === id);
+	for (const list of templateGroups.values()) {
+		const t = list.find((tpl) => tpl.id === id);
+		if (t) return t;
+	}
+	return undefined;
 }
 
 /** Fill a partial option map with each template param's default, dropping unknown keys and any value

--- a/client/src/lib/devMock.ts
+++ b/client/src/lib/devMock.ts
@@ -31,9 +31,11 @@ export function installDevMock(opts: { layout?: string } = {}): void {
 			case COMMANDS.loadControls:
 			case COMMANDS.loadTheme:
 			case COMMANDS.readSack:
+			case COMMANDS.readPluginPackageAsset:
 				return null;
 			case COMMANDS.listThemes:
 			case COMMANDS.listSacks:
+			case COMMANDS.listPluginPackages:
 			case COMMANDS.listWallpapers:
 			case COMMANDS.getLogs:
 			case COMMANDS.systemFonts:

--- a/client/src/lib/widgets/Canvas.tsx
+++ b/client/src/lib/widgets/Canvas.tsx
@@ -24,6 +24,7 @@ import { actionHandlerFor, listPlugins, pluginSensorNames } from './plugin';
 import type { StudioApi } from './plugin';
 import '../telemetry/source'; // side-effect: registers the built-in `system` source
 import { registerBuiltinPlugins } from './plugins';
+import { initPackages, refreshPackages } from './plugins/packages';
 import { DEFAULT_MONITOR, type Rect, type WidgetInstance } from '../core/layout';
 import {
 	emptyRoot,
@@ -895,6 +896,17 @@ export default function Canvas({ studio = false }: Props) {
 	// myMonitor latest, for reloadLayout/persist reading inside listeners.
 	const myMonitorRef = useRef(myMonitor);
 	myMonitorRef.current = myMonitor;
+
+	// --- third-party plugin packages ---
+	// Discover + apply the enabled ones once per window (both roles — an overlay needs an enabled
+	// package's theme CSS for its instantiated widgets too), and re-scan when the Plugins section
+	// opens so a freshly dropped folder shows up without a restart.
+	useEffect(() => {
+		void initPackages();
+	}, []);
+	useEffect(() => {
+		if (studio && navSection === 'plugins') void refreshPackages();
+	}, [studio, navSection]);
 
 	// --- syncPrimaryOverlays (primary main window only) ---
 	const monitorRef = useRef(monitor);

--- a/client/src/lib/widgets/DesignerListPanel.tsx
+++ b/client/src/lib/widgets/DesignerListPanel.tsx
@@ -2,12 +2,13 @@
 // delete), the template list (preview/clone), the AI-handoff "copy widget reference" button, and
 // the empty-state explainer shown when no def is open. The def-edit actions live in Canvas
 // (canvas/useDefEditor) and arrive as one grouped prop. Lazy-loaded like the other studio panels.
-import { TEMPLATES } from '../core/templates';
+import { BUILTIN_TEMPLATE_GROUP } from '../core/templates';
 import type { Library } from '../core/layoutTree';
 import { listMetas } from '../core/widget';
 import { widgetReferenceMarkdown } from '../core/widgetDocs';
 import { copyToClipboard } from '../overlay';
 import type { DefEditor } from './canvas/useDefEditor';
+import { useTemplateGroups } from './useTemplateGroups';
 
 type Props = {
 	library: Library | undefined;
@@ -35,6 +36,8 @@ export default function DesignerListPanel({
 	designing,
 	actions
 }: Props) {
+	// Built-ins + one group per enabled plugin package (re-renders on package toggle).
+	const templateGroups = useTemplateGroups();
 	return (
 		<>
 			<div className="designer-list">
@@ -104,32 +107,39 @@ export default function DesignerListPanel({
 				) : (
 					<div className="rp-stub">No widgets yet — ＋ New, or clone a template.</div>
 				)}
-				<div className="rp-hd">Templates</div>
-				<div className="dl-items">
-					{TEMPLATES.map((t) => (
-						<div
-							key={t.id}
-							className={['dl-item', previewName === t.name && 'cur'].filter(Boolean).join(' ')}
-						>
-							<button
-								type="button"
-								className="dl-label"
-								title={`${t.description} — click to preview (read-only)`}
-								onClick={() => actions.previewTemplate(t.id)}
-							>
-								{t.name}
-							</button>
-							<button
-								type="button"
-								className="dl-icon"
-								title="Clone into a new editable library widget — instances keep the template's options as params (the Layouts Add palette inserts standalone copies instead)"
-								onClick={() => actions.newFromTemplate(t.id)}
-							>
-								⎘
-							</button>
+				{/* One section per registry group: built-ins, then each enabled plugin package. */}
+				{templateGroups.map((g) => (
+					<div key={g.group}>
+						<div className="rp-hd">
+							{g.group === BUILTIN_TEMPLATE_GROUP ? 'Templates' : `Templates · ${g.group}`}
 						</div>
-					))}
-				</div>
+						<div className="dl-items">
+							{g.templates.map((t) => (
+								<div
+									key={t.id}
+									className={['dl-item', previewName === t.name && 'cur'].filter(Boolean).join(' ')}
+								>
+									<button
+										type="button"
+										className="dl-label"
+										title={`${t.description} — click to preview (read-only)`}
+										onClick={() => actions.previewTemplate(t.id)}
+									>
+										{t.name}
+									</button>
+									<button
+										type="button"
+										className="dl-icon"
+										title="Clone into a new editable library widget — instances keep the template's options as params (the Layouts Add palette inserts standalone copies instead)"
+										onClick={() => actions.newFromTemplate(t.id)}
+									>
+										⎘
+									</button>
+								</div>
+							))}
+						</div>
+					</div>
+				))}
 			</div>
 			{!designing && (
 				<div className="designer-empty">

--- a/client/src/lib/widgets/Inspector.tsx
+++ b/client/src/lib/widgets/Inspector.tsx
@@ -25,7 +25,8 @@ import MacroEditor from './MacroEditor';
 import CssEditor from './CssEditor';
 import BoxField from './BoxField';
 import Select, { type SelectOption } from './Select';
-import { TEMPLATES, resolveTemplateOptions, type Template } from '../core/templates';
+import { BUILTIN_TEMPLATE_GROUP, resolveTemplateOptions, type Template } from '../core/templates';
+import { useTemplateGroups } from './useTemplateGroups';
 import { exprRefs, templateRefs } from '../core/textTemplate';
 import type { LayoutOp } from './ops';
 import { clampSpacing, maxGap, maxPad } from './canvas/spacingGuard';
@@ -304,6 +305,8 @@ export default function Inspector({
 	useEffect(() => {
 		setAddOpen(!hasSelection);
 	}, [hasSelection]);
+	// Built-ins + one group per enabled plugin package (re-renders on package toggle).
+	const templateGroups = useTemplateGroups();
 
 	// Sensor combobox options: friendly "Name (unit)" label, the raw id kept as the value + shown as a
 	// dim hint. A bare id (no metadata) is its own label with no hint. Drives the typeahead sensor field.
@@ -670,31 +673,39 @@ export default function Inspector({
 
 				{/* Inserting from here drops a STANDALONE inline copy (no library def) — the designer
 				    rail's ⎘ is the path that clones a template into an editable library widget. The
-				    titles say which is which; 👁 jumps to the designer's read-only preview. */}
-				<div className="palette">
-					<span className="hd">Templates</span>
-					{TEMPLATES.map((t) =>
-						t.params?.length ? (
-							<TemplateOptionsForm
-								key={t.id}
-								t={t}
-								onInsert={(options) => op({ op: 'insertTemplate', templateId: t.id, options })}
-								onPreview={onPreviewTemplate}
-							/>
-						) : (
-							<span key={t.id} className="libitem">
-								<button
-									type="button"
-									title={`${t.description} — inserts a standalone copy onto the canvas (not linked to the library)`}
-									onClick={() => op({ op: 'insertTemplate', templateId: t.id })}
-								>
-									{t.name}
-								</button>
-								{onPreviewTemplate && <TemplatePreviewButton t={t} onPreview={onPreviewTemplate} />}
-							</span>
-						)
-					)}
-				</div>
+				    titles say which is which; 👁 jumps to the designer's read-only preview. Groups come
+				    from the template registry: built-ins first, then one group per enabled plugin
+				    package (under the package's name). */}
+				{templateGroups.map((g) => (
+					<div key={g.group} className="palette">
+						<span className="hd">
+							{g.group === BUILTIN_TEMPLATE_GROUP ? 'Templates' : `Templates · ${g.group}`}
+						</span>
+						{g.templates.map((t) =>
+							t.params?.length ? (
+								<TemplateOptionsForm
+									key={t.id}
+									t={t}
+									onInsert={(options) => op({ op: 'insertTemplate', templateId: t.id, options })}
+									onPreview={onPreviewTemplate}
+								/>
+							) : (
+								<span key={t.id} className="libitem">
+									<button
+										type="button"
+										title={`${t.description} — inserts a standalone copy onto the canvas (not linked to the library)`}
+										onClick={() => op({ op: 'insertTemplate', templateId: t.id })}
+									>
+										{t.name}
+									</button>
+									{onPreviewTemplate && (
+										<TemplatePreviewButton t={t} onPreview={onPreviewTemplate} />
+									)}
+								</span>
+							)
+						)}
+					</div>
+				))}
 			</details>
 
 			{node && (

--- a/client/src/lib/widgets/NavRail.css
+++ b/client/src/lib/widgets/NavRail.css
@@ -915,6 +915,40 @@
 	cursor: default;
 }
 
+/* Third-party package rows: an enable checkbox + name/version line over a dim contents line.
+   Mirrors .pl-item's inset/rhythm; .pl-failed greys an unparseable package the same way. */
+.canvas .plugins-panel .pkg-item {
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-1);
+	margin: 0 0 var(--space-1);
+	padding: var(--space-3);
+	color: var(--ui-fg);
+	font-family: monospace;
+	font-size: var(--text-lg);
+}
+
+.canvas .plugins-panel .pkg-item.pl-failed {
+	color: var(--ui-fg-dim);
+}
+
+.canvas .plugins-panel .pkg-toggle {
+	display: flex;
+	align-items: center;
+	gap: var(--space-2);
+	cursor: pointer;
+}
+
+.canvas .plugins-panel .pkg-toggle input:disabled {
+	cursor: default;
+}
+
+.canvas .plugins-panel .pkg-item .pkg-sub {
+	font-size: var(--text-sm);
+	/* indent under the checkbox so the contents line reads as the row's subtitle */
+	margin-left: calc(13px + var(--space-2));
+}
+
 .canvas .plugins-panel .pl-item.cur {
 	background: rgba(var(--ui-accent-rgb), 0.16);
 	border-left-color: rgb(var(--ui-accent-rgb));

--- a/client/src/lib/widgets/PluginsPanel.tsx
+++ b/client/src/lib/widgets/PluginsPanel.tsx
@@ -4,9 +4,11 @@
 // behind its ErrorBoundary, the sources/widget-types fallback — renders here. Lazy-loaded like
 // the other studio panels, so the overlay never fetches it.
 import { useMemo } from 'react';
+import { useStore } from '../../stores/createStore';
 import type { TelemetryHub } from '../core/telemetry';
 import { statusDotFrom, type Plugin } from './plugin';
 import { pluginLoadErrors } from './plugins';
+import { enabledPackages, packagesStore, togglePackage, type PackageRow } from './plugins/packages';
 import ErrorBoundary from './ErrorBoundary';
 import SensorList from './SensorList';
 import { useSensor } from './useSensor';
@@ -17,6 +19,49 @@ type Props = {
 	selectedId: string | null;
 	onSelect: (id: string) => void;
 };
+
+// What a package row says under its name: contents when healthy, the failure when not.
+function packageSubtext(row: PackageRow): string {
+	if (row.error) return 'failed to load';
+	const parts: string[] = [];
+	if (row.templates) parts.push(`${row.templates} template${row.templates === 1 ? '' : 's'}`);
+	if (row.themeName) parts.push(`theme “${row.themeName}”`);
+	return parts.length ? parts.join(' · ') : 'empty';
+}
+
+// One third-party package row: opt-in enable toggle + name/version + a contents line; a parse
+// failure shows as an untoggleable warn row (the reason rides the title), dropped-template
+// warnings keep the toggle but carry a warn dot.
+function PackageItem({ row, enabled }: { row: PackageRow; enabled: boolean }) {
+	const warn = row.error ?? (row.warnings.length ? row.warnings.join('\n') : null);
+	return (
+		<div
+			className={['pkg-item', row.error && 'pl-failed'].filter(Boolean).join(' ')}
+			title={warn ?? row.description ?? ''}
+		>
+			<label className="pkg-toggle">
+				<input
+					type="checkbox"
+					checked={enabled}
+					disabled={!!row.error}
+					aria-label={`Enable ${row.name}`}
+					onChange={(e) =>
+						void togglePackage(row.id, e.currentTarget.checked, (summary) =>
+							window.confirm(
+								`This package's theme contains ${summary}. Package theme CSS runs with full ` +
+									`access to the studio. Enable anyway?`
+							)
+						)
+					}
+				/>
+				<span className="pkg-name">{row.name}</span>
+				{row.version && <span className="dim">v{row.version}</span>}
+				{warn && <span className="pl-dot pl-dot--warn" aria-label="Package warning" />}
+			</label>
+			<span className="pkg-sub dim">{packageSubtext(row)}</span>
+		</div>
+	);
+}
 
 // One Plugins-list status dot: subscribes to the plugin's declared status sensor (the same
 // `*.status` text samples the detail panels read) and renders an ok/warn/off dot. A component
@@ -35,6 +80,9 @@ export default function PluginsPanel({ hub, plugins, selectedId, onSelect }: Pro
 		() => plugins.find((p) => p.id === selectedId) ?? null,
 		[plugins, selectedId]
 	);
+	// Third-party plugin packages (plugins/<id>/plugin.json dirs) + the opt-in enabled allowlist.
+	const packageRows = useStore(packagesStore);
+	const enabledIds = useStore(enabledPackages);
 	// Capitalized so it can be used as a JSX element when the plugin ships a settings panel.
 	const SelectedPluginSettings = selectedPlugin?.settings ?? null;
 	return (
@@ -64,6 +112,19 @@ export default function PluginsPanel({ hub, plugins, selectedId, onSelect }: Pro
 						{e.name} <span className="dim">failed to load</span>
 					</div>
 				))}
+				{/* Third-party packages: declarative template/theme bundles dropped into the app-config
+				    plugins/ dir. Opt-in — discovered packages start disabled. */}
+				<div className="rp-hd">Packages</div>
+				{packageRows.length ? (
+					packageRows.map((r) => (
+						<PackageItem key={r.id} row={r} enabled={enabledIds.includes(r.id)} />
+					))
+				) : (
+					<div className="rp-stub">
+						No packages installed — drop a folder at <code>plugins\&lt;id&gt;\plugin.json</code> in
+						the app config dir. See docs/third-party-plugins.md.
+					</div>
+				)}
 			</div>
 			<div className="pl-detail">
 				{!selectedPlugin ? (

--- a/client/src/lib/widgets/plugins/packages-commands.ts
+++ b/client/src/lib/widgets/plugins/packages-commands.ts
@@ -1,0 +1,30 @@
+// The plugin-package Tauri command adapter (outer ring) — every `invoke` behind a typed function,
+// so the packages module shares the command-name strings and tests can mock this module. Both
+// commands are dumb file I/O on the app-config `plugins/` dir (command.rs); failures degrade to
+// empty/null so a broken folder can never take the studio down.
+
+import { invoke } from '@tauri-apps/api/core';
+import { COMMANDS } from '../../bridge/contract';
+
+/** One discovered `plugins/<id>/plugin.json`: the directory name + the raw, unparsed manifest. */
+export type PluginPackageFile = { id: string; manifest: string };
+
+/** Every package directory with a manifest, sorted by id. [] when none / on failure. */
+export async function listPluginPackages(): Promise<PluginPackageFile[]> {
+	try {
+		return await invoke<PluginPackageFile[]>(COMMANDS.listPluginPackages);
+	} catch (err) {
+		console.warn('list_plugin_packages failed', err);
+		return [];
+	}
+}
+
+/** The contents of `plugins/<id>/<name>` (a manifest-declared .css/.json asset), or null. */
+export async function readPluginPackageAsset(id: string, name: string): Promise<string | null> {
+	try {
+		return await invoke<string | null>(COMMANDS.readPluginPackageAsset, { id, name });
+	} catch (err) {
+		console.warn('read_plugin_package_asset failed', err);
+		return null;
+	}
+}

--- a/client/src/lib/widgets/plugins/packages.ts
+++ b/client/src/lib/widgets/plugins/packages.ts
@@ -1,0 +1,196 @@
+// Third-party plugin packages — the orchestration half (the pure parse/validate lives in
+// core/pluginPackage.ts; the raw file I/O in packages-commands.ts). Canvas calls `initPackages()`
+// once per window (both roles): discover `plugins/<id>/plugin.json`, parse every manifest
+// (failures become warn rows in the Plugins panel, like pluginLoadErrors), and apply the ENABLED
+// ones — register their templates as a named group in the Add palette / widget designer, and
+// inject their theme CSS (scanned by core/cssThreats; injected only with the user's stored
+// consent). Packages are OPT-IN: the enabled list is an explicit localStorage allowlist that
+// starts empty, so a freshly dropped folder registers nothing until the user flips its toggle.
+
+import { createStore } from '../../../stores/createStore';
+import { createPersistedStore } from '../../../stores/persist';
+import { scanCssThreats, threatSummary } from '../../core/cssThreats';
+import {
+	packageTemplates,
+	parsePluginPackage,
+	type PluginPackageManifest
+} from '../../core/pluginPackage';
+import { registerTemplates, unregisterTemplates } from '../../core/templates';
+import { listPluginPackages, readPluginPackageAsset } from './packages-commands';
+
+// One discovered package directory: either a parsed manifest (+ drop warnings) or a parse error.
+type Discovered = {
+	id: string;
+	manifest: PluginPackageManifest | null;
+	error: string | null;
+	warnings: string[];
+};
+
+/** What the Plugins panel renders per package row. */
+export type PackageRow = {
+	id: string;
+	name: string; // manifest name, or the bare folder id when the manifest failed to parse
+	version: string;
+	description?: string;
+	/** Manifest parse failure (→ warn dot + reason, no toggle). Null when parsed. */
+	error: string | null;
+	/** Dropped-template / dropped-theme reasons (→ warn dot, still toggleable). */
+	warnings: string[];
+	templates: number;
+	themeName: string | null;
+};
+
+const parseIds = (raw: unknown): string[] =>
+	Array.isArray(raw) ? raw.filter((x): x is string => typeof x === 'string') : [];
+
+/** The opt-in allowlist of enabled package ids (default: nothing enabled). */
+export const enabledPackages = createPersistedStore<string[]>(
+	'widgetsack.packages.enabled',
+	parseIds
+);
+
+// Packages whose threat-flagged theme CSS the user explicitly accepted (the first-enable
+// confirm). Without this consent a threat-flagged theme is never injected, even when enabled.
+const trustedCssPackages = createPersistedStore<string[]>(
+	'widgetsack.packages.cssTrusted',
+	parseIds
+);
+
+/** The discovered package rows, for the Plugins panel (subscribe via useStore). */
+export const packagesStore = createStore<PackageRow[]>([]);
+
+const discovered = new Map<string, Discovered>();
+
+function rowOf(d: Discovered): PackageRow {
+	return {
+		id: d.id,
+		name: d.manifest?.name ?? d.id,
+		version: d.manifest?.version ?? '',
+		...(d.manifest?.description !== undefined ? { description: d.manifest.description } : {}),
+		error: d.error,
+		warnings: d.warnings.slice(),
+		templates: d.manifest?.templates.length ?? 0,
+		themeName: d.manifest?.theme?.name ?? null
+	};
+}
+
+function publishRows(): void {
+	packagesStore.set(Array.from(discovered.values(), rowOf));
+}
+
+// ---- theme injection ---------------------------------------------------------------------------
+// A package theme is a plain <style> tag per package (data-pkg-theme="<id>") in THIS window's
+// head — independent of the user's selected theme, removed on disable. Injected only when the
+// scan is clean or the user stored consent at enable time.
+
+function removePackageTheme(id: string): void {
+	document.querySelector(`style[data-pkg-theme="${CSS.escape(id)}"]`)?.remove();
+}
+
+async function injectPackageTheme(d: Discovered): Promise<void> {
+	const theme = d.manifest?.theme;
+	if (!theme) return;
+	const css = await readPluginPackageAsset(d.id, theme.file);
+	if (css == null) return;
+	if (scanCssThreats(css).length && !trustedCssPackages.getSnapshot().includes(d.id)) return;
+	removePackageTheme(d.id);
+	const el = document.createElement('style');
+	el.setAttribute('data-pkg-theme', d.id);
+	el.textContent = css;
+	document.head.appendChild(el);
+}
+
+// ---- registration ------------------------------------------------------------------------------
+
+// Apply one package's enabled state: register/unregister its template group (keyed by the
+// package's display name — that's the heading the palette shows) and add/remove its theme style.
+async function applyPackage(d: Discovered, enabled: boolean): Promise<void> {
+	if (!d.manifest) return; // unparsed packages register nothing
+	if (enabled) {
+		if (d.manifest.templates.length) {
+			registerTemplates(d.manifest.name, packageTemplates(d.manifest));
+		}
+		await injectPackageTheme(d);
+	} else {
+		unregisterTemplates(d.manifest.name);
+		removePackageTheme(d.id);
+	}
+}
+
+/**
+ * (Re)discover the package directories and re-apply the enabled ones. Called at init and when
+ * the Plugins panel opens (so a freshly dropped folder shows up without a restart). A package
+ * that vanished from disk keeps nothing registered (its group is unregistered below).
+ */
+export async function refreshPackages(): Promise<void> {
+	const files = await listPluginPackages();
+	// Unregister groups for packages that disappeared since the last scan.
+	const liveIds = new Set(files.map((f) => f.id));
+	for (const [id, d] of discovered) {
+		if (!liveIds.has(id)) void applyPackage(d, false);
+	}
+	discovered.clear();
+	for (const f of files) {
+		const result = parsePluginPackage(f.id, f.manifest);
+		discovered.set(
+			f.id,
+			result.ok
+				? { id: f.id, manifest: result.pkg.manifest, error: null, warnings: result.pkg.warnings }
+				: { id: f.id, manifest: null, error: result.reason, warnings: [] }
+		);
+	}
+	publishRows();
+	const enabled = new Set(enabledPackages.getSnapshot());
+	for (const d of discovered.values()) {
+		if (enabled.has(d.id)) await applyPackage(d, true);
+	}
+}
+
+let initialized = false;
+
+/** One-shot init per window (Canvas mount, both roles — idempotent like registerBuiltinPlugins). */
+export async function initPackages(): Promise<void> {
+	if (initialized) return;
+	initialized = true;
+	await refreshPackages();
+}
+
+/**
+ * Flip one package's enabled state, LIVE (templates appear in / vanish from the palette without
+ * a reload; the theme style tag follows). On the FIRST enable of a package whose theme CSS scans
+ * with threats, `confirmCssThreats` is asked with a human summary (the Plugins panel passes a
+ * window.confirm mirroring the sack-import wording); declining aborts the enable. Consent is
+ * stored, so subsequent boots inject without asking again. Other windows (overlays) pick the
+ * change up on their next reload — the allowlist is shared localStorage.
+ */
+export async function togglePackage(
+	id: string,
+	enabled: boolean,
+	confirmCssThreats: (summary: string) => boolean = () => true
+): Promise<void> {
+	const d = discovered.get(id);
+	if (!d?.manifest) return; // unknown / unparsed → not toggleable
+	if (enabled && d.manifest.theme && !trustedCssPackages.getSnapshot().includes(id)) {
+		const css = await readPluginPackageAsset(id, d.manifest.theme.file);
+		const threats = css ? scanCssThreats(css) : [];
+		if (threats.length) {
+			if (!confirmCssThreats(threatSummary(threats))) return;
+			trustedCssPackages.update((ids) => [...ids, id]);
+		}
+	}
+	enabledPackages.update((ids) => {
+		const without = ids.filter((x) => x !== id);
+		return enabled ? [...without, id] : without;
+	});
+	await applyPackage(d, enabled);
+}
+
+/** TEST-ONLY: drop all module state so each test starts from a clean registry. */
+export function resetPackagesForTest(): void {
+	for (const d of discovered.values()) void applyPackage(d, false);
+	discovered.clear();
+	publishRows();
+	enabledPackages.set([]);
+	trustedCssPackages.set([]);
+	initialized = false;
+}

--- a/client/src/lib/widgets/useTemplateGroups.ts
+++ b/client/src/lib/widgets/useTemplateGroups.ts
@@ -1,0 +1,9 @@
+// React binding for the core template registry: re-renders the palette / designer list when a
+// template group registers or unregisters (a plugin package being toggled). listTemplateGroups
+// caches its snapshot identity, so useSyncExternalStore only re-renders on real changes.
+import { useSyncExternalStore } from 'react';
+import { listTemplateGroups, subscribeTemplates, type TemplateGroup } from '../core/templates';
+
+export function useTemplateGroups(): TemplateGroup[] {
+	return useSyncExternalStore(subscribeTemplates, listTemplateGroups);
+}

--- a/docs/third-party-plugins.md
+++ b/docs/third-party-plugins.md
@@ -1,0 +1,127 @@
+# Third-party plugin packages
+
+A **plugin package** is a folder you drop into the app-config `plugins/` directory that adds
+templates (ready-made widget clusters) and optionally a theme — **declarative data only, no
+code**. Packages show up in the studio's **Plugins** section under *Packages*, where each one is
+enabled per-machine (everything starts **disabled** — installing a folder runs nothing until you
+flip its toggle).
+
+```
+%APPDATA%\com.widgetsack.app\plugins\
+  ha.json, llm.json, …            ← first-party plugin configs (files — not packages)
+  my-pack\                        ← a package is a DIRECTORY
+    plugin.json                   ← the manifest (required)
+    sky.css                       ← assets the manifest declares (optional)
+```
+
+> Phase 1 is data-only on purpose: a package cannot run JavaScript or render its own components.
+> A planned Phase 2 adds sandboxed sensor sources (QuickJS, capability-gated network access). The
+> one sharp edge today is **theme CSS** — see Security below.
+
+## plugin.json
+
+```json
+{
+	"manifestVersion": 1,
+	"id": "my-pack",
+	"name": "My pack",
+	"version": "1.0.0",
+	"description": "A clock cluster and a sky theme.",
+	"author": "you",
+	"homepage": "https://github.com/you/my-pack",
+	"templates": [
+		{
+			"id": "big-clock",
+			"name": "Big clock",
+			"description": "HH:mm over a date line.",
+			"size": { "w": 200, "h": 96 },
+			"params": [
+				{
+					"key": "hour",
+					"label": "Hour format",
+					"default": "HH:mm",
+					"targets": ["children.0.unit.config.format"],
+					"choices": [
+						{ "value": "HH:mm", "label": "24-hour" },
+						{ "value": "h:mm A", "label": "12-hour" }
+					]
+				}
+			],
+			"tree": {
+				"id": "bc-root",
+				"kind": "col",
+				"align": "stretch",
+				"gap": 2,
+				"children": [
+					{
+						"id": "bc-time",
+						"unit": {
+							"id": "bc-time",
+							"type": "clock",
+							"rect": { "x": 0, "y": 0, "w": 200, "h": 60 },
+							"config": { "format": "HH:mm" }
+						}
+					},
+					{
+						"id": "bc-date",
+						"unit": {
+							"id": "bc-date",
+							"type": "clock",
+							"rect": { "x": 0, "y": 0, "w": 200, "h": 24 },
+							"config": { "format": "ddd D MMMM" }
+						}
+					}
+				]
+			}
+		}
+	],
+	"theme": { "name": "Sky", "file": "sky.css" }
+}
+```
+
+Field rules:
+
+- **`manifestVersion`** must be `1`.
+- **`id`** must equal the folder name — 1–64 chars of `A–Z a–z 0–9 space _ -`. Template ids use
+  the same alphabet; the registry namespaces them as `pkg:<id>:<templateId>` so packages can
+  never collide with built-ins or each other.
+- **`templates[].tree`** is a layout node in the same JSON grammar as `widgets.json` (a
+  container with `children`, or a leaf wrapping a widget `unit`). It goes through the layout
+  file's structural whitelist — unknown fields are stripped, a malformed template is **dropped
+  with a warning** (shown on the package's row) while the rest of the package still loads.
+  Widget `type`s must be registered types (see [the widget reference](widgets.md)); a leaf with
+  an unknown type renders as missing.
+- **`templates[].params`** are insert-time options using the same `ParamSpec` grammar as the
+  built-in templates and the widget designer: `key`, optional `label`/`default`, `target` or
+  `targets` (dotted index paths into the tree, e.g. `children.0.unit.config.format`), and
+  optional `choices` (rendering a select). See [templating & formulas](templating.md) for what
+  config fields accept.
+- **`theme.file`** must be a plain `<name>.css` filename inside the package folder (no
+  subdirectories). The CSS is injected globally while the package is enabled — set `--np-*` /
+  `--ui-*` tokens or target the stable widget hooks, exactly like a user theme
+  ([theming reference](theming.md)).
+
+## How templates surface
+
+An enabled package's templates appear under the package's name in two places: the **Layouts →
+Add palette** ("Templates · My pack" — inserts a standalone copy onto the canvas) and the
+**widget designer's** template list (preview, or ⎘-clone into an editable library widget that
+keeps your `params` as instance params).
+
+## Security model
+
+- **Opt-in:** discovered packages register nothing until enabled; the toggle is a per-machine
+  allowlist.
+- **Structural validation:** manifests are parsed fail-closed; trees go through the layout
+  whitelist; param paths that walk `__proto__`/`constructor`/`prototype` are rejected.
+- **Theme CSS is the trust boundary:** it runs with full access to the studio's DOM, so it is
+  scanned (remote `url()`/`@import`, viewport overlays — the same scan sack imports get) and a
+  flagged theme asks for explicit confirmation on first enable. Don't enable packages from
+  sources you don't trust.
+- **No code:** there is no JavaScript surface in a Phase 1 package at all.
+
+## Updating / removing
+
+Replace or delete the folder and reopen the Plugins section (it re-scans on open). Disabling a
+package live-removes its palette group and theme; other windows pick the change up on their next
+reload.

--- a/widgetsack/src/command.rs
+++ b/widgetsack/src/command.rs
@@ -534,6 +534,91 @@ pub fn delete_layout(app: tauri::AppHandle, name: String) -> Result<(), String> 
     }
 }
 
+// ---- plugin packages: declarative third-party bundles (`plugins/<id>/plugin.json`) ----
+// The app-config `plugins/` dir already holds first-party config FILES (ha.json, llm.json, …);
+// a third-party package is a SUBDIRECTORY containing a `plugin.json`, so the two coexist
+// unambiguously — only directories with a manifest are listed. Dumb I/O only: the frontend
+// parses/validates the manifest (core/pluginPackage.ts) and decides what to register.
+
+fn plugins_dir(app: &tauri::AppHandle) -> Result<PathBuf, String> {
+    let dir = app.path().app_config_dir().map_err(|e| e.to_string())?;
+    Ok(dir.join("plugins"))
+}
+
+/// A package asset filename is a single path component: `<valid_name stem>.<css|json>`. Splitting
+/// at the LAST dot and running the stem through `valid_name` rejects separators, `..`, extra dots
+/// (so no `x.css.tmp` smuggling), and oversized names by construction.
+fn valid_asset_name(name: &str) -> bool {
+    match name.rsplit_once('.') {
+        Some((stem, ext)) => {
+            (ext.eq_ignore_ascii_case("css") || ext.eq_ignore_ascii_case("json"))
+                && valid_name(stem)
+        }
+        None => false,
+    }
+}
+
+#[derive(Serialize)]
+pub struct PluginPackageFile {
+    /// The package directory name (its id; the frontend cross-checks the manifest's `id`).
+    pub id: String,
+    /// Raw `plugin.json` contents, unparsed.
+    pub manifest: String,
+}
+
+/// Every `plugins/<id>/plugin.json`, sorted by id. Directories only (first-party config FILES in
+/// `plugins/` are skipped), ids must pass `valid_name` (they become path segments in
+/// `read_plugin_package_asset`). Missing `plugins/` dir → empty vec.
+#[tauri::command]
+pub fn list_plugin_packages(app: tauri::AppHandle) -> Result<Vec<PluginPackageFile>, String> {
+    let dir = plugins_dir(&app)?;
+    let mut out = Vec::new();
+    if let Ok(entries) = fs::read_dir(&dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+            let Some(id) = path.file_name().and_then(|s| s.to_str()) else {
+                continue;
+            };
+            if !valid_name(id) {
+                continue;
+            }
+            if let Ok(manifest) = fs::read_to_string(path.join("plugin.json")) {
+                out.push(PluginPackageFile {
+                    id: id.to_string(),
+                    manifest,
+                });
+            }
+        }
+    }
+    out.sort_by(|a, b| a.id.cmp(&b.id));
+    Ok(out)
+}
+
+/// Read `plugins/<id>/<name>` — a manifest-declared asset (theme CSS / extra JSON). Both segments
+/// are sanitized (no traversal); only `.css`/`.json` files are readable. `None` if absent.
+#[tauri::command]
+pub fn read_plugin_package_asset(
+    app: tauri::AppHandle,
+    id: String,
+    name: String,
+) -> Result<Option<String>, String> {
+    if !valid_name(&id) {
+        return Err("invalid package id".to_string());
+    }
+    if !valid_asset_name(&name) {
+        return Err("invalid asset name".to_string());
+    }
+    let path = plugins_dir(&app)?.join(&id).join(&name);
+    match fs::read_to_string(&path) {
+        Ok(contents) => Ok(Some(contents)),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(err) => Err(err.to_string()),
+    }
+}
+
 /// Seed a couple of example themes on first run so the picker has something to show
 /// (the default look needs no theme). No-op once `themes/` exists.
 pub fn seed_themes(app: &tauri::AppHandle) {
@@ -740,6 +825,23 @@ mod tests {
         assert!(!valid_name(" lead")); // leading space (Windows trims → name collision)
         assert!(!valid_name("trail ")); // trailing space
         assert!(!valid_name("   ")); // all whitespace
+    }
+
+    #[test]
+    fn valid_asset_name_requires_css_or_json_and_no_traversal() {
+        assert!(super::valid_asset_name("theme.css"));
+        assert!(super::valid_asset_name("extra.JSON")); // case-insensitive ext
+        assert!(super::valid_asset_name("My Theme 2.css")); // spaces ok (valid_name stem)
+        assert!(!super::valid_asset_name("theme.css.tmp")); // wrong ext (last dot wins)
+        assert!(!super::valid_asset_name("evil.tmp.css")); // stem contains a dot
+        assert!(!super::valid_asset_name("../theme.css")); // traversal
+        assert!(!super::valid_asset_name("..css")); // empty/.. stem
+        assert!(!super::valid_asset_name("a/b.css")); // separator
+        assert!(!super::valid_asset_name("a\\b.css")); // separator
+        assert!(!super::valid_asset_name("theme.exe")); // disallowed ext
+        assert!(!super::valid_asset_name("noext")); // no extension
+        assert!(!super::valid_asset_name(".css")); // empty stem
+        assert!(!super::valid_asset_name("")); // empty
     }
 
     #[test]

--- a/widgetsack/src/main.rs
+++ b/widgetsack/src/main.rs
@@ -159,6 +159,8 @@ async fn main() -> Result<(), ()> {
             command::list_sacks,
             command::read_sack,
             command::write_sack,
+            command::list_plugin_packages,
+            command::read_plugin_package_asset,
             command::list_layouts,
             command::read_layout,
             command::save_layout_as,


### PR DESCRIPTION
First cut of third-party plugin support, per the decided direction (declarative data + sandbox later; no third-party React ever):

- A package = `plugins/<id>/plugin.json` (a DIRECTORY in the app-config plugins folder — first-party `*.json` configs coexist): **templates** (layout trees + ParamSpec params) and an optional **theme css**.
- **Opt-in**: discovered packages start disabled; enabling is live (palette group + theme appear without reload); parse failures are warn rows.
- **Fail-closed validation** in pure core (trees through the layout structural whitelist; `__proto__`-walking param paths rejected); theme CSS gets the sack-import threat scan + first-enable consent.
- Template registry seam (`registerTemplates`/`listTemplateGroups`) replaces direct `TEMPLATES` reads — built-ins byte-identical, palette/designer render one group per source.
- Rust: two dumb file-I/O commands with traversal-tested sanitizer seams.
- `docs/third-party-plugins.md` authoring guide + README line.

Phase 2 (sandboxed QuickJS sources) and Phase 3 (install from GitHub link + manual update checks) follow separately.

Verified: 1,112 unit · 32 e2e · build · check:docs · cargo test (112) · clippy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)