### PR TITLE
feat(plugins): sandboxed package sensor sources (Phase 2)

### DIFF
--- a/client/src/lib/bridge/contract.ts
+++ b/client/src/lib/bridge/contract.ts
@@ -67,6 +67,7 @@ export const COMMANDS = {
 	installPluginPackage: 'install_plugin_package',
 	checkPluginPackageUpdate: 'check_plugin_package_update',
 	removePluginPackage: 'remove_plugin_package',
+	packageFetch: 'package_fetch',
 	// foreign windows / monitors / click-through (windowmgr.rs, clickthrough.rs, display.rs)
 	listWindows: 'list_windows',
 	snapWindow: 'snap_window',

--- a/client/src/lib/core/plugin.test.ts
+++ b/client/src/lib/core/plugin.test.ts
@@ -5,7 +5,8 @@ import {
 	registerSource,
 	sourceCatalogEntries,
 	sourceCatalogIds,
-	startAllSources
+	startAllSources,
+	unregisterSource
 } from './plugin';
 
 describe('sensor sources', () => {
@@ -67,5 +68,18 @@ describe('sensor sources', () => {
 		expect(cpu).toEqual({ id: 'cpu.total' });
 		// Deduped: one entry per id.
 		expect(entries.filter((e) => e.id === 'ha.light.kitchen')).toHaveLength(1);
+	});
+
+	it('unregisterSource drops the source and its catalog entries live (no-op when absent)', () => {
+		registerSource({
+			id: 'pkg:wx',
+			start: async () => () => undefined,
+			catalogEntries: () => [{ id: 'pkg.wx.temp', label: 'Temperature' }]
+		});
+		expect(sourceCatalogEntries().some((e) => e.id === 'pkg.wx.temp')).toBe(true);
+		unregisterSource('pkg:wx');
+		expect(listSources().some((s) => s.id === 'pkg:wx')).toBe(false);
+		expect(sourceCatalogEntries().some((e) => e.id === 'pkg.wx.temp')).toBe(false);
+		unregisterSource('pkg:wx'); // absent → no-op, no throw
 	});
 });

--- a/client/src/lib/core/plugin.ts
+++ b/client/src/lib/core/plugin.ts
@@ -29,6 +29,13 @@ export function registerSource(source: SensorSource): void {
 	sources.set(source.id, source);
 }
 
+/** Drop a source by id (no-op when absent) — its catalog entries vanish from the next
+ * `sourceCatalogEntries()` read. Used by toggleable sources (third-party packages); built-ins
+ * never unregister. Does NOT stop a started source — the registrant owns that lifecycle. */
+export function unregisterSource(id: string): void {
+	sources.delete(id);
+}
+
 export function listSources(): SensorSource[] {
 	return Array.from(sources.values());
 }

--- a/client/src/lib/core/pluginPackage.test.ts
+++ b/client/src/lib/core/pluginPackage.test.ts
@@ -1,10 +1,17 @@
 import { describe, expect, it } from 'vitest';
 import {
+	consentFingerprint,
+	enableConsentMessage,
+	MAX_SOURCE_REQUESTS,
+	MAX_SOURCE_SAMPLES,
+	packageSensorId,
 	packageTemplateId,
 	packageTemplates,
 	parseInstallSidecar,
 	parsePluginPackage,
 	reinstallSource,
+	validateSourceRequests,
+	validateSourceSamples,
 	versionsDiffer
 } from './pluginPackage';
 import { isLeaf } from './layoutTree';
@@ -97,6 +104,183 @@ describe('parsePluginPackage', () => {
 		if (!r.ok) return;
 		expect(r.pkg.manifest.theme).toBeUndefined();
 		expect(r.pkg.warnings[0]).toContain('theme dropped');
+	});
+});
+
+describe('parsePluginPackage — source + sensors (Phase 2)', () => {
+	const source = (over: Record<string, unknown> = {}) => ({
+		file: 'source.js',
+		pollSeconds: 60,
+		hosts: ['api.open-meteo.com'],
+		...over
+	});
+	const sensors = [
+		{ id: 'temp', label: 'Temperature', unit: '°C' },
+		{ id: 'humidity', label: 'Humidity', unit: '%' }
+	];
+	const parse = (over: Record<string, unknown>) => {
+		const r = parsePluginPackage('weather-pack', manifest(over));
+		expect(r.ok).toBe(true);
+		if (!r.ok) throw new Error('unreachable');
+		return r.pkg;
+	};
+
+	it('accepts a valid source + sensors', () => {
+		const pkg = parse({ source: source(), sensors });
+		expect(pkg.manifest.source).toEqual({
+			file: 'source.js',
+			pollSeconds: 60,
+			hosts: ['api.open-meteo.com']
+		});
+		expect(pkg.manifest.sensors).toEqual(sensors);
+		expect(pkg.warnings).toEqual([]);
+	});
+
+	it('defaults sensors to [] and leaves source undefined when undeclared', () => {
+		const pkg = parse({});
+		expect(pkg.manifest.source).toBeUndefined();
+		expect(pkg.manifest.sensors).toEqual([]);
+		expect(pkg.warnings).toEqual([]);
+	});
+
+	it('clamps pollSeconds to [15, 3600] and defaults a missing one to 60', () => {
+		expect(parse({ source: source({ pollSeconds: 1 }) }).manifest.source?.pollSeconds).toBe(15);
+		expect(parse({ source: source({ pollSeconds: 99999 }) }).manifest.source?.pollSeconds).toBe(
+			3600
+		);
+		expect(parse({ source: source({ pollSeconds: undefined }) }).manifest.source?.pollSeconds).toBe(
+			60
+		);
+	});
+
+	it('drops a source (with a warning) when the file is not a plain .js name', () => {
+		for (const file of ['source.css', '../escape.js', 'a.b.js', 'noext', 'source.mjs']) {
+			const pkg = parse({ source: source({ file }) });
+			expect(pkg.manifest.source).toBeUndefined();
+			expect(pkg.warnings[0]).toContain('source dropped');
+		}
+	});
+
+	it('drops a source on bad hosts: empty, uppercase, scheme/port/path/wildcard, IP literal', () => {
+		const bad = [
+			[],
+			['API.Open-Meteo.com'],
+			['https://api.open-meteo.com'],
+			['api.open-meteo.com:443'],
+			['api.open-meteo.com/v1'],
+			['*.open-meteo.com'],
+			['192.168.1.10'],
+			['ok.example.com', ''] // one bad entry poisons the list
+		];
+		for (const hosts of bad) {
+			const pkg = parse({ source: source({ hosts }) });
+			expect(pkg.manifest.source).toBeUndefined();
+			expect(pkg.warnings[0]).toContain('"hosts"');
+		}
+	});
+
+	it('drops a non-numeric pollSeconds with a warning', () => {
+		const pkg = parse({ source: source({ pollSeconds: 'fast' }) });
+		expect(pkg.manifest.source).toBeUndefined();
+		expect(pkg.warnings[0]).toContain('pollSeconds');
+	});
+
+	it('drops malformed sensors (bad id, duplicate, non-string label) but keeps the package', () => {
+		for (const bad of [
+			[{ id: 'a/b' }],
+			[{ id: 'x' }, { id: 'x' }],
+			[{ id: 'x', label: 42 }],
+			['nope']
+		]) {
+			const pkg = parse({ source: source(), sensors: bad });
+			expect(pkg.manifest.sensors).toEqual([]);
+			expect(pkg.warnings[0]).toContain('sensors dropped');
+			expect(pkg.manifest.source).toBeDefined(); // source survives a sensors drop
+		}
+	});
+});
+
+describe('packageSensorId / consentFingerprint / enableConsentMessage', () => {
+	it('namespaces sensor ids under pkg.<pkgId>.', () => {
+		expect(packageSensorId('weather-pack', 'temp')).toBe('pkg.weather-pack.temp');
+	});
+
+	it('fingerprints hosts order-insensitively but change-sensitively', () => {
+		expect(consentFingerprint(['b.com', 'a.com'])).toBe(consentFingerprint(['a.com', 'b.com']));
+		expect(consentFingerprint(['a.com'])).not.toBe(consentFingerprint(['a.com', 'b.com']));
+		expect(consentFingerprint(['a.com'])).not.toBe(consentFingerprint(['c.com']));
+	});
+
+	it('states the network facts, the css facts, or both in ONE message', () => {
+		const net = enableConsentMessage({ hosts: ['api.open-meteo.com'], pollSeconds: 60 });
+		expect(net).toContain('polls the network every 60s: api.open-meteo.com');
+		expect(net).toContain('Enable?');
+		const css = enableConsentMessage({ cssSummary: '1 remote import' });
+		expect(css).toContain('theme contains 1 remote import');
+		expect(css).toContain('Enable anyway?');
+		const both = enableConsentMessage({
+			cssSummary: '1 remote import',
+			hosts: ['a.com', 'b.com'],
+			pollSeconds: 300
+		});
+		expect(both).toContain('theme contains');
+		expect(both).toContain('every 300s: a.com, b.com');
+	});
+});
+
+describe('validateSourceRequests', () => {
+	it('keeps https string URLs and reports everything else', () => {
+		const r = validateSourceRequests(['https://a.com/x', 'http://a.com', 42, 'ftp://x']);
+		expect(r.urls).toEqual(['https://a.com/x']);
+		expect(r.dropped).toHaveLength(3);
+	});
+
+	it('caps at MAX_SOURCE_REQUESTS and rejects non-arrays', () => {
+		const many = Array.from({ length: 20 }, (_, i) => `https://a.com/${i}`);
+		const r = validateSourceRequests(many);
+		expect(r.urls).toHaveLength(MAX_SOURCE_REQUESTS);
+		expect(r.dropped[0]).toContain('cap');
+		expect(validateSourceRequests('nope').urls).toEqual([]);
+		expect(validateSourceRequests('nope').dropped[0]).toContain('array');
+	});
+});
+
+describe('validateSourceSamples', () => {
+	const declared = ['temp', 'label'];
+
+	it('keeps declared finite-number and bounded-string samples', () => {
+		const r = validateSourceSamples(declared, [
+			{ sensor: 'temp', value: 21.5 },
+			{ sensor: 'label', value: 'sunny' }
+		]);
+		expect(r.samples).toEqual([
+			{ sensor: 'temp', value: 21.5 },
+			{ sensor: 'label', value: 'sunny' }
+		]);
+		expect(r.dropped).toEqual([]);
+	});
+
+	it('drops undeclared sensors, non-finite numbers, oversized strings, junk entries', () => {
+		const r = validateSourceSamples(declared, [
+			{ sensor: 'sneaky', value: 1 },
+			{ sensor: 'temp', value: Infinity },
+			{ sensor: 'temp', value: NaN },
+			{ sensor: 'label', value: 'x'.repeat(2000) },
+			{ sensor: 'temp', value: { nested: true } },
+			'junk',
+			{ value: 1 }
+		]);
+		expect(r.samples).toEqual([]);
+		expect(r.dropped).toHaveLength(7);
+		expect(r.dropped[0]).toContain('undeclared sensor "sneaky"');
+	});
+
+	it('caps at MAX_SOURCE_SAMPLES and rejects non-arrays', () => {
+		const many = Array.from({ length: 100 }, () => ({ sensor: 'temp', value: 1 }));
+		const r = validateSourceSamples(declared, many);
+		expect(r.samples).toHaveLength(MAX_SOURCE_SAMPLES);
+		expect(r.dropped[0]).toContain('cap');
+		expect(validateSourceSamples(declared, null).dropped[0]).toContain('array');
 	});
 });
 

--- a/client/src/lib/core/pluginPackage.ts
+++ b/client/src/lib/core/pluginPackage.ts
@@ -27,6 +27,16 @@ export type PackageTemplate = {
  * directory (read via `read_plugin_package_asset`, scanned by core/cssThreats before injection). */
 export type PackageTheme = { name: string; file: string };
 
+/** An optional sandboxed sensor source (Phase 2): `file` names a sibling `.js` asset run inside
+ * the zero-capability QuickJS sandbox; `hosts` is the exact-match https allowlist the Rust
+ * `package_fetch` proxy enforces; `pollSeconds` is the tick cadence (clamped to
+ * [MIN_POLL_SECONDS, MAX_POLL_SECONDS]). */
+export type PackageSourceSpec = { file: string; pollSeconds: number; hosts: string[] };
+
+/** One sensor the package's source declares. `id` becomes `pkg.<pkgId>.<id>` in the hub/catalog
+ * (see `packageSensorId`); samples for undeclared ids are dropped by `validateSourceSamples`. */
+export type PackageSensorDecl = { id: string; label?: string; unit?: string };
+
 export type PluginPackageManifest = {
 	manifestVersion: 1;
 	id: string;
@@ -38,6 +48,10 @@ export type PluginPackageManifest = {
 	/** Already filtered to the structurally valid templates (invalid ones land in `warnings`). */
 	templates: PackageTemplate[];
 	theme?: PackageTheme;
+	/** Sandboxed sensor source (absent when undeclared OR when malformed — see `warnings`). */
+	source?: PackageSourceSpec;
+	/** The source's declared sensors ([] when undeclared or malformed). */
+	sensors: PackageSensorDecl[];
 };
 
 export type ParsedPackage = {
@@ -60,14 +74,14 @@ function isIdToken(v: unknown): v is string {
 	);
 }
 
-// An asset filename the backend will serve: `<id token>.css` / `<id token>.json` (single segment,
+// An asset filename the backend will serve: `<id token>.css` / `.json` / `.js` (single segment,
 // no extra dots). Mirrors the Rust `valid_asset_name`.
 function isAssetName(v: unknown): v is string {
 	if (typeof v !== 'string') return false;
 	const dot = v.lastIndexOf('.');
 	if (dot <= 0) return false;
 	const ext = v.slice(dot + 1).toLowerCase();
-	return (ext === 'css' || ext === 'json') && isIdToken(v.slice(0, dot));
+	return (ext === 'css' || ext === 'json' || ext === 'js') && isIdToken(v.slice(0, dot));
 }
 
 function isOptionalString(v: unknown): v is string | undefined {
@@ -170,6 +184,68 @@ function parsePackageTheme(raw: unknown): PackageTheme | string {
 	return { name: o.name, file: o.file as string };
 }
 
+// ---- sandboxed sensor sources (Phase 2) ----------------------------------------------------------
+
+export const MIN_POLL_SECONDS = 15;
+export const MAX_POLL_SECONDS = 3600;
+const DEFAULT_POLL_SECONDS = 60;
+
+// One allowlist entry: a bare lowercase hostname — labels of [a-z0-9-] joined by dots. No scheme,
+// port, path, userinfo, or wildcard (their characters fall outside the label alphabet), and no
+// IPv4 literal (an all-numeric label sequence). Uppercase is rejected so the manifest string is
+// byte-comparable with a parsed URL host. The Rust `host_allowed` seam is the enforcement point;
+// this keeps malformed allowlists from ever reaching it.
+function isHostname(v: unknown): v is string {
+	if (typeof v !== 'string' || v.length < 1 || v.length > 253) return false;
+	const labels = v.split('.');
+	if (!labels.every((l) => /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/.test(l))) return false;
+	return !labels.every((l) => /^[0-9]+$/.test(l)); // dotted-digits = an IP literal, not a hostname
+}
+
+function parsePackageSource(raw: unknown): PackageSourceSpec | string {
+	if (typeof raw !== 'object' || raw === null) return 'source dropped: not an object';
+	const o = raw as Record<string, unknown>;
+	if (!isAssetName(o.file) || !(o.file as string).toLowerCase().endsWith('.js')) {
+		return 'source dropped: "file" must be a plain <name>.js filename inside the package';
+	}
+	let pollSeconds = DEFAULT_POLL_SECONDS;
+	if (o.pollSeconds !== undefined) {
+		if (typeof o.pollSeconds !== 'number' || !Number.isFinite(o.pollSeconds)) {
+			return 'source dropped: "pollSeconds" must be a number';
+		}
+		pollSeconds = Math.min(MAX_POLL_SECONDS, Math.max(MIN_POLL_SECONDS, Math.round(o.pollSeconds)));
+	}
+	if (!Array.isArray(o.hosts) || o.hosts.length === 0 || !o.hosts.every(isHostname)) {
+		return (
+			'source dropped: "hosts" must be a non-empty array of lowercase hostnames ' +
+			'(no scheme/port/path/wildcards)'
+		);
+	}
+	return { file: o.file, pollSeconds, hosts: (o.hosts as string[]).slice() };
+}
+
+function parsePackageSensors(raw: unknown): PackageSensorDecl[] | string {
+	if (!Array.isArray(raw)) return 'sensors dropped: not an array';
+	const out: PackageSensorDecl[] = [];
+	const seen = new Set<string>();
+	for (const s of raw) {
+		if (typeof s !== 'object' || s === null) return 'sensors dropped: entry is not an object';
+		const o = s as Record<string, unknown>;
+		if (!isIdToken(o.id)) return 'sensors dropped: entry has a missing/invalid "id"';
+		if (!isOptionalString(o.label) || !isOptionalString(o.unit)) {
+			return `sensors dropped: "${o.id}" label/unit must be strings`;
+		}
+		if (seen.has(o.id)) return `sensors dropped: duplicate id "${o.id}"`;
+		seen.add(o.id);
+		out.push({
+			id: o.id,
+			...(o.label !== undefined ? { label: o.label as string } : {}),
+			...(o.unit !== undefined ? { unit: o.unit as string } : {})
+		});
+	}
+	return out;
+}
+
 /**
  * Parse + validate one raw `plugin.json` against the directory id the backend listed it under.
  * Fail-closed: a structural problem with the manifest itself rejects the whole package (with a
@@ -226,6 +302,21 @@ export function parsePluginPackage(dirId: string, raw: string): PackageParseResu
 		else theme = parsed;
 	}
 
+	// A malformed source/sensors block is DROPPED with a warning (package still loads) — same
+	// fail-soft contract as templates/theme; the poll loop simply never starts.
+	let source: PackageSourceSpec | undefined;
+	if (o.source !== undefined) {
+		const parsed = parsePackageSource(o.source);
+		if (typeof parsed === 'string') warnings.push(parsed);
+		else source = parsed;
+	}
+	let sensors: PackageSensorDecl[] = [];
+	if (o.sensors !== undefined) {
+		const parsed = parsePackageSensors(o.sensors);
+		if (typeof parsed === 'string') warnings.push(parsed);
+		else sensors = parsed;
+	}
+
 	const manifest: PluginPackageManifest = {
 		manifestVersion: 1,
 		id: o.id,
@@ -235,7 +326,9 @@ export function parsePluginPackage(dirId: string, raw: string): PackageParseResu
 		...(o.author !== undefined ? { author: o.author as string } : {}),
 		...(o.homepage !== undefined ? { homepage: o.homepage as string } : {}),
 		templates,
-		...(theme ? { theme } : {})
+		...(theme ? { theme } : {}),
+		...(source ? { source } : {}),
+		sensors
 	};
 	return { ok: true, pkg: { manifest, warnings } };
 }
@@ -311,4 +404,118 @@ export function packageTemplates(manifest: PluginPackageManifest): Template[] {
 		...(t.params?.length ? { params: t.params } : {}),
 		tree: () => structuredClone(t.tree)
 	}));
+}
+
+// ---- source tick pipeline (Phase 2) — the pure seams of the poll loop ---------------------------
+// The adapter (widgets/plugins/packages-source.ts) runs: sandbox `requests()` → host fetch (Rust
+// `package_fetch`) → sandbox `transform()` → hub. The validation between those hops is the riskiest
+// logic, so it lives HERE, pure and tested: nothing the sandbox returns is trusted.
+
+/** The hub/catalog id of a package sensor — namespaced so two packages can never collide and a
+ * package can never spoof a built-in (`cpu.total`) or another source (`ha.*`). */
+export function packageSensorId(pkgId: string, sensorId: string): string {
+	return `pkg.${pkgId}.${sensorId}`;
+}
+
+/** The consent key for a package's network allowlist: order-insensitive, so a reordered manifest
+ * doesn't re-prompt but ANY host change (add/remove/edit) invalidates the stored consent. */
+export function consentFingerprint(hosts: readonly string[]): string {
+	return [...hosts].sort().join(' ');
+}
+
+/** The first-enable confirmation text: one dialog that states every consent-worthy fact (flagged
+ * theme CSS and/or network polling) — the Plugins panel feeds it straight to window.confirm. */
+export function enableConsentMessage(parts: {
+	cssSummary?: string;
+	hosts?: string[];
+	pollSeconds?: number;
+}): string {
+	const lines: string[] = [];
+	if (parts.cssSummary) {
+		lines.push(
+			`This package's theme contains ${parts.cssSummary}. ` +
+				`Package theme CSS runs with full access to the studio.`
+		);
+	}
+	if (parts.hosts?.length) {
+		lines.push(
+			`This package polls the network every ${parts.pollSeconds ?? DEFAULT_POLL_SECONDS}s: ` +
+				`${parts.hosts.join(', ')}.`
+		);
+	}
+	lines.push(parts.cssSummary ? 'Enable anyway?' : 'Enable?');
+	return lines.join('\n');
+}
+
+/** Cap on URLs one `requests()` call may return — a package polls a couple of endpoints, not a list. */
+export const MAX_SOURCE_REQUESTS = 8;
+/** Cap on samples one `transform()` call may return. */
+export const MAX_SOURCE_SAMPLES = 64;
+/** Cap on one text sample's length (the hub stores these verbatim). */
+export const MAX_SAMPLE_TEXT = 1024;
+
+/** What `requests()` returned, validated: https string URLs only, capped at MAX_SOURCE_REQUESTS.
+ * Everything else lands in `dropped` (human-readable, for a console.warn). The HOST allowlist is
+ * deliberately not checked here — the Rust proxy re-reads the manifest and enforces it server-side. */
+export function validateSourceRequests(raw: unknown): { urls: string[]; dropped: string[] } {
+	if (!Array.isArray(raw)) return { urls: [], dropped: ['requests() did not return an array'] };
+	const urls: string[] = [];
+	const dropped: string[] = [];
+	for (const r of raw) {
+		if (urls.length >= MAX_SOURCE_REQUESTS) {
+			dropped.push(`over the ${MAX_SOURCE_REQUESTS}-request cap (${raw.length} requested)`);
+			break;
+		}
+		if (typeof r !== 'string' || !r.startsWith('https://')) {
+			dropped.push(`not an https URL: ${JSON.stringify(r)?.slice(0, 80)}`);
+			continue;
+		}
+		urls.push(r);
+	}
+	return { urls, dropped };
+}
+
+/** One validated `transform()` output sample (pre-namespacing — the adapter prefixes the id). */
+export type SourceSample = { sensor: string; value: number | string };
+
+/** What `transform()` returned, validated against the manifest's declared sensor ids: undeclared
+ * ids, non-finite numbers, oversized strings, and non-object entries are dropped with a reason;
+ * output is capped at MAX_SOURCE_SAMPLES. */
+export function validateSourceSamples(
+	declared: readonly string[],
+	raw: unknown
+): { samples: SourceSample[]; dropped: string[] } {
+	if (!Array.isArray(raw)) return { samples: [], dropped: ['transform() did not return an array'] };
+	const known = new Set(declared);
+	const samples: SourceSample[] = [];
+	const dropped: string[] = [];
+	for (const item of raw) {
+		if (samples.length >= MAX_SOURCE_SAMPLES) {
+			dropped.push(`over the ${MAX_SOURCE_SAMPLES}-sample cap (${raw.length} returned)`);
+			break;
+		}
+		if (typeof item !== 'object' || item === null) {
+			dropped.push('sample is not an object');
+			continue;
+		}
+		const o = item as Record<string, unknown>;
+		if (typeof o.sensor !== 'string') {
+			dropped.push('sample has no "sensor" string');
+			continue;
+		}
+		if (!known.has(o.sensor)) {
+			dropped.push(`undeclared sensor "${o.sensor}"`);
+			continue;
+		}
+		if (typeof o.value === 'number' && Number.isFinite(o.value)) {
+			samples.push({ sensor: o.sensor, value: o.value });
+		} else if (typeof o.value === 'string' && o.value.length <= MAX_SAMPLE_TEXT) {
+			samples.push({ sensor: o.sensor, value: o.value });
+		} else {
+			dropped.push(
+				`"${o.sensor}": value must be a finite number or a string ≤ ${MAX_SAMPLE_TEXT} chars`
+			);
+		}
+	}
+	return { samples, dropped };
 }

--- a/client/src/lib/devMock.ts
+++ b/client/src/lib/devMock.ts
@@ -35,8 +35,9 @@ export function installDevMock(opts: { layout?: string } = {}): void {
 				return null;
 			case COMMANDS.installPluginPackage:
 			case COMMANDS.checkPluginPackageUpdate:
+			case COMMANDS.packageFetch:
 				// No network in the mock — throw so the panel surfaces an honest failure (mirrors
-				// llmSynthesize) instead of pretending an install/check succeeded.
+				// llmSynthesize) instead of pretending an install/check/fetch succeeded.
 				throw new Error('no network in dev mock');
 			case COMMANDS.removePluginPackage:
 				return undefined;

--- a/client/src/lib/formula/engine.ts
+++ b/client/src/lib/formula/engine.ts
@@ -8,7 +8,8 @@
 import {
 	newQuickJSWASMModuleFromVariant,
 	type QuickJSContext,
-	type QuickJSRuntime
+	type QuickJSRuntime,
+	type QuickJSWASMModule
 } from 'quickjs-emscripten-core';
 // One pinned variant with the WASM embedded (base64) in the JS — a single payload, no runtime .wasm
 // fetch (robust under Tauri's CSP/asset protocol) instead of the umbrella package's 4 wasm flavors.
@@ -34,6 +35,18 @@ let ctx: QuickJSContext | null = null;
 let readyPromise: Promise<void> | null = null;
 const readyListeners = new Set<() => void>();
 
+// The WASM module itself is loaded once per window and shared: the formula engine's singleton
+// context AND every package-source sandbox (packageSandbox.ts) get their own runtime from it.
+let modulePromise: Promise<QuickJSWASMModule> | null = null;
+
+/** The (cached) QuickJS-WASM module load. Rejects on a genuine load failure — callers decide
+ *  whether that's fatal (a package source reports an error status; the formula engine just stays
+ *  not-ready). */
+export function loadQuickJSModule(): Promise<QuickJSWASMModule> {
+	if (!modulePromise) modulePromise = newQuickJSWASMModuleFromVariant(quickjsVariant);
+	return modulePromise;
+}
+
 function defineHostFns(c: QuickJSContext): void {
 	const reg = (name: string, fn: (...args: number[]) => string) => {
 		const handle = c.newFunction(name, (...args) =>
@@ -53,7 +66,7 @@ function defineHostFns(c: QuickJSContext): void {
  *  cached. Resolves once the sandbox is ready; never rejects (a failed init just leaves it not-ready). */
 export function initFormulaEngine(): Promise<void> {
 	if (!readyPromise) {
-		readyPromise = newQuickJSWASMModuleFromVariant(quickjsVariant)
+		readyPromise = loadQuickJSModule()
 			.then((QuickJS) => {
 				runtime = QuickJS.newRuntime();
 				// Bound an adversarial / imported-sack formula's RESOURCES as tightly as its CPU: the

--- a/client/src/lib/formula/packageSandbox.ts
+++ b/client/src/lib/formula/packageSandbox.ts
@@ -1,0 +1,129 @@
+// The QuickJS sandbox for third-party package sensor sources (Phase 2). Each enabled package with
+// a `source` gets its OWN runtime + context (isolated from the formula engine and from other
+// packages) built from the shared WASM module (engine.ts loadQuickJSModule). The sandbox has ZERO
+// capabilities — no host functions, no fetch, no Tauri, no DOM, no timers; the host performs the
+// network I/O between the script's two PURE calls:
+//
+//   module.exports = {
+//     requests(): string[]                                      // https URLs to fetch this tick
+//     transform(responses: {url,status,body}[]): {sensor,value}[]  // samples to ingest
+//   }
+//
+// Data crosses the boundary as JSON in both directions (same pattern as engine.ts evalExpr), and
+// every call runs under an interrupt deadline + the runtime's memory/stack caps, so a hostile
+// script can burn ~100ms of CPU per tick and nothing else.
+import type { QuickJSContext, QuickJSRuntime } from 'quickjs-emscripten-core';
+import { loadQuickJSModule } from './engine';
+
+// Per-call CPU budget. Wider than the formula engine's 50ms (a transform may JSON.parse a
+// few-hundred-KiB body) but still interactive-frame-class.
+const CALL_DEADLINE_MS = 100;
+const MEMORY_LIMIT = 16 * 1024 * 1024;
+const STACK_LIMIT = 512 * 1024;
+
+/** One response as the sandbox's `transform` sees it. Failed fetches arrive as status 0. */
+export type SandboxResponse = { url: string; status: number; body: string };
+
+export type SandboxResult = { ok: true; value: unknown } | { ok: false; error: string };
+
+export type PackageSandbox = {
+	/** Call the script's `requests()`; the value is the JSON round-trip of its return. */
+	requests(): SandboxResult;
+	/** Call the script's `transform(responses)`. */
+	transform(responses: SandboxResponse[]): SandboxResult;
+	dispose(): void;
+};
+
+export type CreateSandboxResult =
+	| { ok: true; sandbox: PackageSandbox }
+	| { ok: false; error: string };
+
+/**
+ * Compile `script` (a CommonJS-style source.js that assigns `module.exports`) into a fresh,
+ * isolated sandbox. Fail-soft: any load/compile/shape problem returns `{ ok: false, error }` and
+ * leaks nothing. The caller owns `dispose()`.
+ */
+export async function createPackageSandbox(script: string): Promise<CreateSandboxResult> {
+	let runtime: QuickJSRuntime;
+	try {
+		const mod = await loadQuickJSModule();
+		runtime = mod.newRuntime();
+	} catch (err) {
+		return { ok: false, error: `sandbox init failed: ${String(err)}` };
+	}
+	runtime.setMemoryLimit(MEMORY_LIMIT);
+	runtime.setMaxStackSize(STACK_LIMIT);
+	const ctx: QuickJSContext = runtime.newContext();
+
+	// Evaluate `code` (which must produce a JSON string) under the deadline; never throws.
+	const evalJson = (code: string): SandboxResult => {
+		const deadline = Date.now() + CALL_DEADLINE_MS;
+		runtime.setInterruptHandler(() => Date.now() > deadline);
+		try {
+			const out = ctx.evalCode(code);
+			if (out.error) {
+				const err = ctx.dump(out.error) as { message?: string } | string | null;
+				out.error.dispose();
+				const msg = typeof err === 'object' && err !== null ? err.message ?? 'error' : err;
+				return { ok: false, error: String(msg) };
+			}
+			const v = ctx.dump(out.value);
+			out.value.dispose();
+			if (typeof v !== 'string') return { ok: false, error: 'returned no JSON-serializable value' };
+			try {
+				return { ok: true, value: JSON.parse(v) as unknown };
+			} catch {
+				return { ok: false, error: 'returned malformed JSON' };
+			}
+		} catch (err) {
+			return { ok: false, error: String(err) };
+		} finally {
+			runtime.setInterruptHandler(() => false);
+		}
+	};
+
+	// Compile once: run the script in a CommonJS-shaped wrapper, stash module.exports on the
+	// context's global, and verify it exposes the two functions. The script never re-evaluates —
+	// later ticks only call __src.requests/__src.transform.
+	const compiled = evalJson(
+		`JSON.stringify((function () {
+			var module = { exports: {} }; var exports = module.exports;
+			${script}
+			;globalThis.__src = module.exports;
+			return typeof __src.requests === 'function' && typeof __src.transform === 'function';
+		})())`
+	);
+	if (!compiled.ok || compiled.value !== true) {
+		ctx.dispose();
+		runtime.dispose();
+		return {
+			ok: false,
+			error: compiled.ok
+				? 'source.js must assign module.exports = { requests, transform } (both functions)'
+				: compiled.error
+		};
+	}
+
+	let disposed = false;
+	return {
+		ok: true,
+		sandbox: {
+			requests: () =>
+				disposed
+					? { ok: false, error: 'sandbox disposed' }
+					: evalJson('JSON.stringify(__src.requests())'),
+			transform: (responses) =>
+				disposed
+					? { ok: false, error: 'sandbox disposed' }
+					: // Responses are injected as DATA: JSON.stringify output is a valid JS literal, so
+					  // a hostile body can't escape into code.
+					  evalJson(`JSON.stringify(__src.transform(${JSON.stringify(responses)}))`),
+			dispose: () => {
+				if (disposed) return;
+				disposed = true;
+				ctx.dispose();
+				runtime.dispose();
+			}
+		}
+	};
+}

--- a/client/src/lib/widgets/Canvas.tsx
+++ b/client/src/lib/widgets/Canvas.tsx
@@ -902,8 +902,8 @@ export default function Canvas({ studio = false }: Props) {
 	// package's theme CSS for its instantiated widgets too), and re-scan when the Plugins section
 	// opens so a freshly dropped folder shows up without a restart.
 	useEffect(() => {
-		void initPackages();
-	}, []);
+		void initPackages(hub);
+	}, [hub]);
 	useEffect(() => {
 		if (studio && navSection === 'plugins') void refreshPackages();
 	}, [studio, navSection]);

--- a/client/src/lib/widgets/PluginsPanel.tsx
+++ b/client/src/lib/widgets/PluginsPanel.tsx
@@ -35,6 +35,7 @@ function packageSubtext(row: PackageRow): string {
 	const parts: string[] = [];
 	if (row.templates) parts.push(`${row.templates} template${row.templates === 1 ? '' : 's'}`);
 	if (row.themeName) parts.push(`theme “${row.themeName}”`);
+	if (row.sensors) parts.push(`${row.sensors} sensor${row.sensors === 1 ? '' : 's'}`);
 	return parts.length ? parts.join(' · ') : 'empty';
 }
 
@@ -88,11 +89,10 @@ function PackageItem({ row, enabled }: { row: PackageRow; enabled: boolean }) {
 					disabled={!!row.error}
 					aria-label={`Enable ${row.name}`}
 					onChange={(e) =>
-						void togglePackage(row.id, e.currentTarget.checked, (summary) =>
-							window.confirm(
-								`This package's theme contains ${summary}. Package theme CSS runs with full ` +
-									`access to the studio. Enable anyway?`
-							)
+						// togglePackage composes the full first-enable consent message (flagged theme
+						// CSS and/or network hosts, one dialog) — the panel just asks it.
+						void togglePackage(row.id, e.currentTarget.checked, (message) =>
+							window.confirm(message)
 						)
 					}
 				/>
@@ -101,6 +101,9 @@ function PackageItem({ row, enabled }: { row: PackageRow; enabled: boolean }) {
 				{warn && <span className="pl-dot pl-dot--warn" aria-label="Package warning" />}
 			</label>
 			<span className="pkg-sub dim">{packageSubtext(row)}</span>
+			{row.hosts.length > 0 && (
+				<span className="pkg-sub pkg-net dim">network: {row.hosts.join(', ')}</span>
+			)}
 			{row.installedFrom && <span className="pkg-sub pkg-src dim">from {row.installedFrom}</span>}
 			<div className="pkg-actions">
 				{row.installedFrom && (

--- a/client/src/lib/widgets/plugins/packages-commands.ts
+++ b/client/src/lib/widgets/plugins/packages-commands.ts
@@ -53,3 +53,13 @@ export async function checkPluginPackageUpdate(id: string): Promise<PackageUpdat
 export async function removePluginPackage(id: string): Promise<void> {
 	await invoke(COMMANDS.removePluginPackage, { id });
 }
+
+/** What `package_fetch` hands back — the exact shape the sandbox's `transform` receives. */
+export type PackageFetchResponse = { url: string; status: number; body: string };
+
+/** Host-side fetch for a package source: the backend re-reads `plugins/<id>/plugin.json` and
+ * enforces its `source.hosts` allowlist server-side (https only, no redirects, GET, 10s timeout,
+ * 256 KiB cap). Throws the backend's reason — the poll loop maps failures to status 0. */
+export async function packageFetch(id: string, url: string): Promise<PackageFetchResponse> {
+	return await invoke<PackageFetchResponse>(COMMANDS.packageFetch, { id, url });
+}

--- a/client/src/lib/widgets/plugins/packages-source.test.ts
+++ b/client/src/lib/widgets/plugins/packages-source.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// End-to-end tick pipeline against the REAL QuickJS sandbox (the engine's WASM harness runs fine
+// under vitest — see formula/engine.test.ts); only the Tauri command module is stubbed.
+const assets = new Map<string, string>();
+const fetches: { id: string; url: string }[] = [];
+let fetchImpl: (id: string, url: string) => Promise<{ url: string; status: number; body: string }>;
+
+vi.mock('./packages-commands', () => ({
+	readPluginPackageAsset: (id: string, name: string) => Promise.resolve(assets.get(name) ?? null),
+	packageFetch: (id: string, url: string) => {
+		fetches.push({ id, url });
+		return fetchImpl(id, url);
+	}
+}));
+
+import type { PluginPackageManifest } from '../../core/pluginPackage';
+import { createTelemetryHub } from '../../core/telemetry';
+import { startPackageSource } from './packages-source';
+
+const manifest = (over: Partial<PluginPackageManifest> = {}): PluginPackageManifest => ({
+	manifestVersion: 1,
+	id: 'wx',
+	name: 'Weather',
+	version: '1.0.0',
+	templates: [],
+	source: { file: 'source.js', pollSeconds: 60, hosts: ['api.example.com'] },
+	sensors: [
+		{ id: 'temp', label: 'Temperature', unit: '°C' },
+		{ id: 'summary', label: 'Summary' }
+	],
+	...over
+});
+
+const SOURCE_JS = `
+module.exports = {
+	requests: function () {
+		return ['https://api.example.com/now'];
+	},
+	transform: function (responses) {
+		var r = responses[0];
+		if (!r || r.status !== 200) return [{ sensor: 'summary', value: 'offline' }];
+		var data = JSON.parse(r.body);
+		return [
+			{ sensor: 'temp', value: data.t },
+			{ sensor: 'summary', value: data.text },
+			{ sensor: 'undeclared', value: 1 }
+		];
+	}
+};
+`;
+
+// Wait until `pred` holds (the first tick runs async behind startPackageSource).
+async function until(pred: () => boolean): Promise<void> {
+	for (let i = 0; i < 300 && !pred(); i++) await new Promise((r) => setTimeout(r, 10));
+	expect(pred()).toBe(true);
+}
+
+const textOf = (hub: ReturnType<typeof createTelemetryHub>, id: string): string | null => {
+	const v = hub.sensor(id).getSnapshot().value;
+	return v?.kind === 'text' ? v.value : null;
+};
+
+describe('startPackageSource', () => {
+	let stop: (() => void) | null = null;
+	beforeEach(() => {
+		assets.clear();
+		fetches.length = 0;
+		assets.set('source.js', SOURCE_JS);
+		fetchImpl = (id, url) =>
+			Promise.resolve({ url, status: 200, body: JSON.stringify({ t: 21.5, text: 'sunny' }) });
+	});
+	afterEach(() => {
+		stop?.();
+		stop = null;
+	});
+
+	it('runs requests → fetch → transform → hub with namespaced ids and an ok status', async () => {
+		const hub = createTelemetryHub();
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+		stop = await startPackageSource(manifest(), hub);
+		await until(() => textOf(hub, 'pkg.wx.status') === 'ok');
+		expect(fetches).toEqual([{ id: 'wx', url: 'https://api.example.com/now' }]);
+		expect(hub.sensor('pkg.wx.temp').getSnapshot().value).toEqual({
+			kind: 'scalar',
+			value: 21.5
+		});
+		expect(hub.sensor('pkg.wx.summary').getSnapshot().value).toEqual({
+			kind: 'text',
+			value: 'sunny'
+		});
+		// The undeclared sensor never reaches the hub — it is dropped with a warning.
+		expect(hub.sensorIds()).not.toContain('pkg.wx.undeclared');
+		expect(warn.mock.calls.some((c) => String(c[1]).includes('undeclared'))).toBe(true);
+		warn.mockRestore();
+	});
+
+	it('maps a failed fetch to { status: 0 } so transform decides what a miss means', async () => {
+		fetchImpl = () => Promise.reject(new Error('host not in allowlist'));
+		const hub = createTelemetryHub();
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+		stop = await startPackageSource(manifest(), hub);
+		await until(() => textOf(hub, 'pkg.wx.status') === 'ok');
+		expect(textOf(hub, 'pkg.wx.summary')).toBe('offline');
+		warn.mockRestore();
+	});
+
+	it('reports a missing or non-exporting source.js as an error status without throwing', async () => {
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+		const hub = createTelemetryHub();
+		assets.delete('source.js');
+		stop = await startPackageSource(manifest(), hub);
+		expect(textOf(hub, 'pkg.wx.status')).toContain('error:');
+		stop();
+
+		assets.set('source.js', 'module.exports = { requests: 1 };');
+		stop = await startPackageSource(manifest(), hub);
+		expect(textOf(hub, 'pkg.wx.status')).toContain('error:');
+		expect(textOf(hub, 'pkg.wx.status')).toContain('module.exports');
+		warn.mockRestore();
+	});
+
+	it('reports a runaway transform as an error status (deadline trips, loop survives)', async () => {
+		assets.set(
+			'source.js',
+			`module.exports = {
+				requests: function () { return []; },
+				transform: function () { while (true) {} }
+			};`
+		);
+		const hub = createTelemetryHub();
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+		stop = await startPackageSource(manifest(), hub);
+		await until(() => (textOf(hub, 'pkg.wx.status') ?? '').startsWith('error: transform()'));
+		warn.mockRestore();
+	});
+
+	it('stop() halts the loop and disposes the sandbox', async () => {
+		const hub = createTelemetryHub();
+		stop = await startPackageSource(manifest(), hub);
+		await until(() => textOf(hub, 'pkg.wx.status') === 'ok');
+		stop();
+		stop = null;
+		const seen = fetches.length;
+		await new Promise((r) => setTimeout(r, 50));
+		expect(fetches.length).toBe(seen); // no further ticks
+	});
+});

--- a/client/src/lib/widgets/plugins/packages-source.ts
+++ b/client/src/lib/widgets/plugins/packages-source.ts
@@ -1,0 +1,112 @@
+// The per-package poll loop for sandboxed sensor sources (Phase 2, adapter ring). One loop per
+// enabled package with a manifest `source`, owned by packages.ts applyPackage. Each tick:
+//
+//   sandbox requests() ──▶ host fetch (Rust package_fetch, allowlist enforced server-side)
+//        ──▶ sandbox transform(responses) ──▶ validate/cap/namespace (core seams) ──▶ hub
+//
+// Errors NEVER escape the loop: every failure path lands in a console.warn plus the package's
+// implicit `pkg.<id>.status` text sensor ('ok' / 'error: …'), which the Plugins row and any text
+// widget can watch like the first-party plugin status sensors.
+import {
+	packageSensorId,
+	validateSourceRequests,
+	validateSourceSamples,
+	type PluginPackageManifest
+} from '../../core/pluginPackage';
+import type { SensorSample, TelemetryHub } from '../../core/telemetry';
+import { createPackageSandbox, type SandboxResponse } from '../../formula/packageSandbox';
+import { packageFetch, readPluginPackageAsset } from './packages-commands';
+
+/** source.js size cap — a poll script is a screenful, not a bundle. */
+const MAX_SCRIPT_BYTES = 64 * 1024;
+
+/**
+ * Start one package's source: load + compile source.js once, tick immediately, then every
+ * `pollSeconds`. Always resolves to a stop function (a broken script just reports an error status
+ * and the stop is a no-op beyond the status guard) — the caller doesn't branch on failure.
+ */
+export async function startPackageSource(
+	manifest: PluginPackageManifest,
+	hub: TelemetryHub
+): Promise<() => void> {
+	const src = manifest.source;
+	if (!src) return () => undefined;
+	const id = manifest.id;
+	const statusSensor = packageSensorId(id, 'status');
+	let stopped = false;
+	const status = (text: string): void => {
+		if (stopped) return;
+		hub.ingest({ sensor: statusSensor, ts_ms: Date.now(), value: { kind: 'text', value: text } });
+	};
+	const fail = (reason: string): (() => void) => {
+		console.warn(`[pkg ${id}] source not started: ${reason}`);
+		status(`error: ${reason}`);
+		return () => {
+			stopped = true;
+		};
+	};
+
+	const script = await readPluginPackageAsset(id, src.file);
+	if (script == null) return fail(`${src.file} is missing`);
+	if (script.length > MAX_SCRIPT_BYTES) return fail(`${src.file} exceeds 64 KiB`);
+	const made = await createPackageSandbox(script);
+	if (!made.ok) return fail(made.error);
+	const sandbox = made.sandbox;
+	const declared = manifest.sensors.map((s) => s.id);
+
+	const tick = async (): Promise<void> => {
+		if (stopped) return;
+		try {
+			const req = sandbox.requests();
+			if (!req.ok) {
+				status(`error: requests() failed: ${req.error}`);
+				return;
+			}
+			const { urls, dropped: droppedUrls } = validateSourceRequests(req.value);
+			if (droppedUrls.length) console.warn(`[pkg ${id}] dropped requests:`, droppedUrls);
+			// Failures become { status: 0, body: '' } — transform sees every URL it asked for, in
+			// order, and decides what a miss means.
+			const responses: SandboxResponse[] = await Promise.all(
+				urls.map(async (url) => {
+					try {
+						return await packageFetch(id, url);
+					} catch (err) {
+						console.warn(`[pkg ${id}] fetch failed`, url, err);
+						return { url, status: 0, body: '' };
+					}
+				})
+			);
+			if (stopped) return; // stop() during the fetches — the sandbox is already disposed
+			const out = sandbox.transform(responses);
+			if (!out.ok) {
+				status(`error: transform() failed: ${out.error}`);
+				return;
+			}
+			const { samples, dropped } = validateSourceSamples(declared, out.value);
+			if (dropped.length) console.warn(`[pkg ${id}] dropped samples:`, dropped);
+			const ts = Date.now();
+			const batch: SensorSample[] = samples.map((s) => ({
+				sensor: packageSensorId(id, s.sensor),
+				ts_ms: ts,
+				value:
+					typeof s.value === 'number'
+						? { kind: 'scalar', value: s.value }
+						: { kind: 'text', value: s.value }
+			}));
+			hub.ingestBatch(batch);
+			status('ok');
+		} catch (err) {
+			// Belt-and-braces: nothing above should throw, but the loop must outlive a surprise.
+			console.warn(`[pkg ${id}] tick failed`, err);
+			status(`error: ${String(err)}`);
+		}
+	};
+
+	void tick();
+	const timer = setInterval(() => void tick(), src.pollSeconds * 1000);
+	return () => {
+		stopped = true;
+		clearInterval(timer);
+		sandbox.dispose();
+	};
+}

--- a/client/src/lib/widgets/plugins/packages.ts
+++ b/client/src/lib/widgets/plugins/packages.ts
@@ -2,15 +2,21 @@
 // core/pluginPackage.ts; the raw file I/O in packages-commands.ts). Canvas calls `initPackages()`
 // once per window (both roles): discover `plugins/<id>/plugin.json`, parse every manifest
 // (failures become warn rows in the Plugins panel, like pluginLoadErrors), and apply the ENABLED
-// ones — register their templates as a named group in the Add palette / widget designer, and
-// inject their theme CSS (scanned by core/cssThreats; injected only with the user's stored
-// consent). Packages are OPT-IN: the enabled list is an explicit localStorage allowlist that
-// starts empty, so a freshly dropped folder registers nothing until the user flips its toggle.
+// ones — register their templates as a named group in the Add palette / widget designer, inject
+// their theme CSS (scanned by core/cssThreats; injected only with the user's stored consent), and
+// run their sandboxed sensor source (Phase 2 — QuickJS poll loop in packages-source.ts, started
+// only with stored network consent for the manifest's exact hosts list). Packages are OPT-IN: the
+// enabled list is an explicit localStorage allowlist that starts empty, so a freshly dropped
+// folder registers nothing until the user flips its toggle.
 
 import { createStore } from '../../../stores/createStore';
 import { createPersistedStore } from '../../../stores/persist';
 import { scanCssThreats, threatSummary } from '../../core/cssThreats';
+import { registerSource, unregisterSource, type SensorCatalogEntry } from '../../core/plugin';
 import {
+	consentFingerprint,
+	enableConsentMessage,
+	packageSensorId,
 	packageTemplates,
 	parseInstallSidecar,
 	parsePluginPackage,
@@ -20,6 +26,7 @@ import {
 	type PluginPackageManifest
 } from '../../core/pluginPackage';
 import { registerTemplates, unregisterTemplates } from '../../core/templates';
+import type { TelemetryHub } from '../../core/telemetry';
 import {
 	checkPluginPackageUpdate,
 	installPluginPackage,
@@ -27,6 +34,7 @@ import {
 	readPluginPackageAsset,
 	removePluginPackage
 } from './packages-commands';
+import { startPackageSource } from './packages-source';
 
 // One discovered package directory: either a parsed manifest (+ drop warnings) or a parse error.
 type Discovered = {
@@ -50,6 +58,10 @@ export type PackageRow = {
 	warnings: string[];
 	templates: number;
 	themeName: string | null;
+	/** Declared source sensors (0 when the package has no source). */
+	sensors: number;
+	/** The source's network allowlist ([] when no source) — shown as a dim "network:" line. */
+	hosts: string[];
 	/** The install source (`owner/repo` or a URL) when installed via `installPackage`; null for a
 	 * hand-dropped folder (no update-check affordance — there's nowhere to check against). */
 	installedFrom: string | null;
@@ -73,6 +85,21 @@ const trustedCssPackages = createPersistedStore<string[]>(
 	parseIds
 );
 
+const parseConsentMap = (raw: unknown): Record<string, string> => {
+	if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) return {};
+	const out: Record<string, string> = {};
+	for (const [k, v] of Object.entries(raw)) if (typeof v === 'string') out[k] = v;
+	return out;
+};
+
+// Network consent per package id, keyed by the hosts FINGERPRINT (sorted hosts string) the user
+// saw in the first-enable confirm. A manifest update that changes the hosts list mismatches the
+// stored fingerprint, so the source stays stopped until the new hosts are re-confirmed.
+const netConsentPackages = createPersistedStore<Record<string, string>>(
+	'widgetsack.packages.netConsent',
+	parseConsentMap
+);
+
 /** The discovered package rows, for the Plugins panel (subscribe via useStore). */
 export const packagesStore = createStore<PackageRow[]>([]);
 
@@ -88,6 +115,8 @@ function rowOf(d: Discovered): PackageRow {
 		warnings: d.warnings.slice(),
 		templates: d.manifest?.templates.length ?? 0,
 		themeName: d.manifest?.theme?.name ?? null,
+		sensors: d.manifest?.source ? d.manifest.sensors.length : 0,
+		hosts: d.manifest?.source?.hosts.slice() ?? [],
 		installedFrom: d.install?.source ?? null,
 		...(d.install ? { installedVersion: d.install.version } : {})
 	};
@@ -119,10 +148,48 @@ async function injectPackageTheme(d: Discovered): Promise<void> {
 	document.head.appendChild(el);
 }
 
+// ---- sandboxed sensor sources (Phase 2) ----------------------------------------------------------
+// The poll loop itself lives in packages-source.ts; this module owns WHEN it runs: started by
+// applyPackage when a package is enabled AND its hosts fingerprint matches the stored network
+// consent, stopped on disable/remove/refresh. The hub arrives from Canvas via initPackages — the
+// loop ingests into THIS window's hub, exactly like the first-party sources.
+
+let hubRef: TelemetryHub | null = null;
+
+// One running poll loop's stop function per package id.
+const runningSources = new Map<string, () => void>();
+
+function stopPackageSource(id: string): void {
+	runningSources.get(id)?.();
+	runningSources.delete(id);
+}
+
+function netConsented(d: Discovered): boolean {
+	const hosts = d.manifest?.source?.hosts;
+	if (!hosts) return false;
+	return netConsentPackages.getSnapshot()[d.id] === consentFingerprint(hosts);
+}
+
+// The sensor-catalog entries a package's source contributes: its declared sensors (namespaced,
+// with the manifest's label/unit) plus the implicit status sensor. Registered as a no-op-start
+// SensorSource purely so sourceCatalogEntries() — which reads the registry live — surfaces them
+// in the Inspector dropdown / Sensors browser; the poll loop's lifecycle is owned HERE (start on
+// enable+consent, stop on disable), not by the one-shot startAllSources at Canvas init.
+function packageCatalog(m: PluginPackageManifest): SensorCatalogEntry[] {
+	const entries: SensorCatalogEntry[] = m.sensors.map((s) => ({
+		id: packageSensorId(m.id, s.id),
+		...(s.label !== undefined ? { label: s.label } : {}),
+		...(s.unit !== undefined ? { unit: s.unit } : {})
+	}));
+	entries.push({ id: packageSensorId(m.id, 'status'), label: `${m.name} status` });
+	return entries;
+}
+
 // ---- registration ------------------------------------------------------------------------------
 
 // Apply one package's enabled state: register/unregister its template group (keyed by the
-// package's display name — that's the heading the palette shows) and add/remove its theme style.
+// package's display name — that's the heading the palette shows), add/remove its theme style,
+// and start/stop its sandboxed source (+ catalog entries).
 async function applyPackage(d: Discovered, enabled: boolean): Promise<void> {
 	if (!d.manifest) return; // unparsed packages register nothing
 	if (enabled) {
@@ -130,9 +197,25 @@ async function applyPackage(d: Discovered, enabled: boolean): Promise<void> {
 			registerTemplates(d.manifest.name, packageTemplates(d.manifest));
 		}
 		await injectPackageTheme(d);
+		if (d.manifest.source) {
+			const m = d.manifest;
+			registerSource({
+				id: `pkg:${d.id}`,
+				start: async () => () => undefined, // lifecycle owned here, not by startAllSources
+				catalogEntries: () => packageCatalog(m)
+			});
+			stopPackageSource(d.id); // refresh re-applies — never stack two loops
+			// Consent-gated: a hosts list the user never confirmed (fresh enable race, manifest
+			// edited on disk, update that changed hosts) keeps the loop OFF, fail-closed.
+			if (hubRef && netConsented(d)) {
+				runningSources.set(d.id, await startPackageSource(m, hubRef));
+			}
+		}
 	} else {
 		unregisterTemplates(d.manifest.name);
 		removePackageTheme(d.id);
+		unregisterSource(`pkg:${d.id}`);
+		stopPackageSource(d.id);
 	}
 }
 
@@ -174,34 +257,53 @@ export async function refreshPackages(): Promise<void> {
 
 let initialized = false;
 
-/** One-shot init per window (Canvas mount, both roles — idempotent like registerBuiltinPlugins). */
-export async function initPackages(): Promise<void> {
+/** One-shot init per window (Canvas mount, both roles — idempotent like registerBuiltinPlugins).
+ * `hub` is this window's telemetry hub — package sources ingest into it (overlays poll too, so an
+ * overlay-only widget bound to a package sensor works without the studio open). */
+export async function initPackages(hub: TelemetryHub): Promise<void> {
 	if (initialized) return;
 	initialized = true;
+	hubRef = hub;
 	await refreshPackages();
 }
 
 /**
  * Flip one package's enabled state, LIVE (templates appear in / vanish from the palette without
- * a reload; the theme style tag follows). On the FIRST enable of a package whose theme CSS scans
- * with threats, `confirmCssThreats` is asked with a human summary (the Plugins panel passes a
- * window.confirm mirroring the sack-import wording); declining aborts the enable. Consent is
- * stored, so subsequent boots inject without asking again. Other windows (overlays) pick the
- * change up on their next reload — the allowlist is shared localStorage.
+ * a reload; the theme style tag follows; a source's poll loop starts/stops). On the FIRST enable
+ * of a package whose theme CSS scans with threats AND/OR which declares a network source,
+ * `confirmEnable` is asked ONCE with a combined message stating both facts (the Plugins panel
+ * passes window.confirm); declining aborts the enable. Both consents are stored — CSS by package
+ * id, network by hosts FINGERPRINT (so changed hosts re-prompt) — and subsequent boots apply
+ * without asking again. Other windows (overlays) pick the change up on their next reload — the
+ * allowlist is shared localStorage.
  */
 export async function togglePackage(
 	id: string,
 	enabled: boolean,
-	confirmCssThreats: (summary: string) => boolean = () => true
+	confirmEnable: (message: string) => boolean = () => true
 ): Promise<void> {
 	const d = discovered.get(id);
 	if (!d?.manifest) return; // unknown / unparsed → not toggleable
-	if (enabled && d.manifest.theme && !trustedCssPackages.getSnapshot().includes(id)) {
-		const css = await readPluginPackageAsset(id, d.manifest.theme.file);
-		const threats = css ? scanCssThreats(css) : [];
-		if (threats.length) {
-			if (!confirmCssThreats(threatSummary(threats))) return;
-			trustedCssPackages.update((ids) => [...ids, id]);
+	if (enabled) {
+		let cssSummary: string | null = null;
+		if (d.manifest.theme && !trustedCssPackages.getSnapshot().includes(id)) {
+			const css = await readPluginPackageAsset(id, d.manifest.theme.file);
+			const threats = css ? scanCssThreats(css) : [];
+			if (threats.length) cssSummary = threatSummary(threats);
+		}
+		const source = d.manifest.source;
+		const fingerprint = source ? consentFingerprint(source.hosts) : null;
+		const needsNet = fingerprint !== null && netConsentPackages.getSnapshot()[id] !== fingerprint;
+		if (cssSummary !== null || needsNet) {
+			const message = enableConsentMessage({
+				...(cssSummary !== null ? { cssSummary } : {}),
+				...(needsNet && source ? { hosts: source.hosts, pollSeconds: source.pollSeconds } : {})
+			});
+			if (!confirmEnable(message)) return;
+			if (cssSummary !== null) trustedCssPackages.update((ids) => [...ids, id]);
+			if (needsNet && fingerprint !== null) {
+				netConsentPackages.update((m) => ({ ...m, [id]: fingerprint }));
+			}
 		}
 	}
 	enabledPackages.update((ids) => {
@@ -271,6 +373,17 @@ export async function updatePackage(id: string): Promise<PackageOpResult> {
 		return { ok: false, error: String(err) };
 	}
 	await refreshPackages();
+	// If the update CHANGED the hosts list (or dropped the source), the stored network consent is
+	// stale — drop it so the new hosts must be re-confirmed (toggle off/on). The fingerprint check
+	// in applyPackage already kept the new source from starting during the refresh above.
+	const next = discovered.get(id);
+	const nextFp = next?.manifest?.source ? consentFingerprint(next.manifest.source.hosts) : null;
+	netConsentPackages.update((m) => {
+		if (m[id] === undefined || m[id] === nextFp) return m;
+		const rest = { ...m };
+		delete rest[id];
+		return rest;
+	});
 	return { ok: true };
 }
 
@@ -284,6 +397,12 @@ export async function removePackage(id: string): Promise<PackageOpResult> {
 	if (d) await applyPackage(d, false);
 	enabledPackages.update((ids) => ids.filter((x) => x !== id));
 	trustedCssPackages.update((ids) => ids.filter((x) => x !== id));
+	netConsentPackages.update((m) => {
+		if (m[id] === undefined) return m;
+		const rest = { ...m };
+		delete rest[id];
+		return rest;
+	});
 	try {
 		await removePluginPackage(id);
 	} catch (err) {
@@ -297,9 +416,13 @@ export async function removePackage(id: string): Promise<PackageOpResult> {
 /** TEST-ONLY: drop all module state so each test starts from a clean registry. */
 export function resetPackagesForTest(): void {
 	for (const d of discovered.values()) void applyPackage(d, false);
+	for (const stop of runningSources.values()) stop();
+	runningSources.clear();
 	discovered.clear();
 	publishRows();
 	enabledPackages.set([]);
 	trustedCssPackages.set([]);
+	netConsentPackages.set({});
+	hubRef = null;
 	initialized = false;
 }

--- a/docs/third-party-plugins.md
+++ b/docs/third-party-plugins.md
@@ -1,10 +1,10 @@
 # Third-party plugin packages
 
 A **plugin package** is a folder you drop into the app-config `plugins/` directory that adds
-templates (ready-made widget clusters) and optionally a theme — **declarative data only, no
-code**. Packages show up in the studio's **Plugins** section under *Packages*, where each one is
-enabled per-machine (everything starts **disabled** — installing a folder runs nothing until you
-flip its toggle).
+templates (ready-made widget clusters), optionally a theme, and optionally a **sandboxed sensor
+source** — a small `source.js` that polls an HTTP API and feeds custom sensors. Packages show up
+in the studio's **Plugins** section under *Packages*, where each one is enabled per-machine
+(everything starts **disabled** — installing a folder runs nothing until you flip its toggle).
 
 ```
 %APPDATA%\com.widgetsack.app\plugins\
@@ -12,11 +12,13 @@ flip its toggle).
   my-pack\                        ← a package is a DIRECTORY
     plugin.json                   ← the manifest (required)
     sky.css                       ← assets the manifest declares (optional)
+    source.js                     ← sandboxed sensor source (optional, Phase 2)
 ```
 
-> Phase 1 is data-only on purpose: a package cannot run JavaScript or render its own components.
-> A planned Phase 2 adds sandboxed sensor sources (QuickJS, capability-gated network access). The
-> one sharp edge today is **theme CSS** — see Security below.
+> Templates and themes are declarative data; a package cannot render its own components. The
+> only code surface is `source.js`, and it runs in a QuickJS sandbox with **zero capabilities**
+> (no network, no DOM, no Tauri — the host does the fetching against a consented allowlist; see
+> *Sandboxed sensor sources* below). The other sharp edge is **theme CSS** — see Security.
 
 ## plugin.json
 
@@ -75,7 +77,16 @@ flip its toggle).
 			}
 		}
 	],
-	"theme": { "name": "Sky", "file": "sky.css" }
+	"theme": { "name": "Sky", "file": "sky.css" },
+	"source": {
+		"file": "source.js",
+		"pollSeconds": 600,
+		"hosts": ["api.open-meteo.com"]
+	},
+	"sensors": [
+		{ "id": "temp", "label": "Temperature", "unit": "°C" },
+		{ "id": "humidity", "label": "Humidity", "unit": "%" }
+	]
 }
 ```
 
@@ -100,6 +111,70 @@ Field rules:
   subdirectories). The CSS is injected globally while the package is enabled — set `--np-*` /
   `--ui-*` tokens or target the stable widget hooks, exactly like a user theme
   ([theming reference](theming.md)).
+- **`source`** (optional) declares a sandboxed sensor source:
+  - `file` must be a plain `<name>.js` filename inside the package folder.
+  - `pollSeconds` is the tick cadence, clamped to **15–3600** (default 60).
+  - `hosts` is a **non-empty** list of bare lowercase hostnames the source may fetch from —
+    no scheme, port, path, or wildcard, and no IP literals. Exact match only: a subdomain must
+    be listed explicitly (`api.example.com` does not cover `cdn.api.example.com`).
+- **`sensors`** declares the sensor ids the source may emit (`id` uses the same token alphabet
+  as package ids; `label`/`unit` are optional display metadata for the sensor picker). Samples
+  for undeclared ids are dropped.
+- A malformed `source` or `sensors` block is **dropped with a warning** (shown on the package's
+  row) — templates and theme still load; the poll loop just never starts.
+
+## Sandboxed sensor sources (`source.js`)
+
+`source.js` is CommonJS-shaped: assign `module.exports` an object with two **pure, synchronous**
+functions. There is no `fetch`, no `setTimeout`, no host API of any kind inside the sandbox — the
+host performs the network I/O *between* your two calls:
+
+1. each tick the host calls `requests()` → you return the full https URLs to fetch (max **8**);
+2. the host fetches each through the backend proxy (which enforces `hosts`);
+3. the host calls `transform(responses)` → you return samples to ingest (max **64**).
+
+A complete worked weather source against [open-meteo](https://open-meteo.com) (pairs with the
+manifest above):
+
+```js
+// source.js — runs sandboxed: no network/DOM/Tauri access; just compute.
+module.exports = {
+	requests: function () {
+		return [
+			'https://api.open-meteo.com/v1/forecast?latitude=1.35&longitude=103.82' +
+				'&current=temperature_2m,relative_humidity_2m'
+		];
+	},
+	transform: function (responses) {
+		var r = responses[0]; // { url, status, body } — a failed fetch arrives as status 0
+		if (!r || r.status !== 200) return [];
+		var data = JSON.parse(r.body);
+		return [
+			{ sensor: 'temp', value: data.current.temperature_2m },
+			{ sensor: 'humidity', value: data.current.relative_humidity_2m }
+		];
+	}
+};
+```
+
+Contract details:
+
+- `requests(): string[]` — https URLs only, capped at 8 per tick. Anything else is dropped with
+  a console warning. The **host** allowlist is enforced in the Rust proxy, not here.
+- `transform(responses): { sensor, value }[]` — `responses` mirrors the request list in order as
+  `{ url, status, body }` (status `0` = the fetch failed or was refused). Each returned `sensor`
+  must be a declared `sensors[].id`; `value` must be a **finite number** or a **string ≤ 1 KiB**.
+  Undeclared ids, non-finite numbers, and oversized strings are dropped (warned), and the batch
+  is capped at 64 samples.
+- Each call runs under a ~100 ms CPU deadline and a 16 MiB memory cap; `source.js` itself is
+  capped at 64 KiB. A runaway/oversized script degrades to an error status, never a hang.
+- **Sensor namespace:** a declared id `temp` in package `my-pack` surfaces in the sensor picker
+  and formulas as `pkg.my-pack.temp`. The source also implicitly publishes
+  `pkg.<id>.status` — a text sensor set to `ok` or `error: …` every tick, handy for a Text
+  widget or for debugging a package.
+- Sources poll **per window** into that window's telemetry hub, so an overlay-only widget bound
+  to a package sensor works without the studio open. Keep `pollSeconds` honest — 60 s+ for
+  anything rate-limited.
 
 ## How templates surface
 
@@ -118,7 +193,22 @@ keeps your `params` as instance params).
   scanned (remote `url()`/`@import`, viewport overlays — the same scan sack imports get) and a
   flagged theme asks for explicit confirmation on first enable. Don't enable packages from
   sources you don't trust.
-- **No code:** there is no JavaScript surface in a Phase 1 package at all.
+- **The sandbox has zero capabilities.** `source.js` runs in a QuickJS-in-WASM interpreter with
+  no host bindings whatsoever — it cannot fetch, touch the DOM, call Tauri, read files, or keep
+  time beyond `Date`. The worst a hostile script can do is burn its ~100 ms CPU budget per tick.
+- **The host does the fetching, against a Rust-enforced allowlist.** Every URL the source asks
+  for goes through the backend's `package_fetch`, which **re-reads the manifest on disk** and
+  checks the URL's host against `source.hosts` server-side — a compromised webview can't widen
+  the list. https only, GET only, **redirects disabled** (a listed host can't bounce the request
+  somewhere else), 10 s timeout, 256 KiB response cap. IP literals, explicit ports, and embedded
+  credentials are rejected.
+- **Network access is consented per hosts-list.** The first-enable confirm names every host
+  (e.g. *"This package polls the network every 60s: api.open-meteo.com."* — combined with the
+  theme-CSS warning when both apply, one dialog). Consent is stored against the exact hosts
+  fingerprint: if an update changes the list, the source stays stopped until you re-confirm by
+  toggling the package off and on.
+- **Sensors are namespaced.** A package can only ever write `pkg.<its-id>.*` — it cannot spoof
+  `cpu.total`, `ha.*`, or another package's sensors, and only ids it declared up front.
 
 ## Installing from a link
 
@@ -132,8 +222,9 @@ forms:
 | `https://github.com/owner/repo/tree/<ref>`    | the manifest on that branch/tag (the ref is pinned for updates)   |
 | any `https://…/plugin.json` URL               | that exact manifest (self-hosted packages)                        |
 
-The backend downloads the manifest plus every asset it declares (`theme.file` — fetched from the
-same directory), then writes `plugins/<id>/` exactly as if you had dropped the folder by hand.
+The backend downloads the manifest plus every asset it declares (`theme.file` and `source.file`
+— fetched from the same directory), then writes `plugins/<id>/` exactly as if you had dropped the
+folder by hand.
 Provenance is recorded in a sidecar, `plugins/<id>/.install.json`:
 
 ```json
@@ -149,18 +240,21 @@ the manifest from the recorded source and compares version strings — any diffe
 manifest). Nothing is checked or fetched in the background, ever.
 
 *Remove* deletes the package folder (it works for local packages too), unregisters its templates
-and theme live, and clears its enable flag **and** any stored theme-CSS consent — a re-installed
-package starts from zero trust.
+and theme live, stops its source, and clears its enable flag **and** any stored theme-CSS /
+network consent — a re-installed package starts from zero trust. An *Update* that changes the
+`source.hosts` list also drops the stored network consent: the new hosts stay unfetched until
+you toggle the package off and on and confirm them.
 
 Security of remote installs:
 
 - **https only** — `http://` sources are rejected; the GitHub shorthand forms always resolve to
   `raw.githubusercontent.com` over https.
 - **Size caps** — the manifest and each asset are capped at 256 KiB (10 s timeout); only
-  `.css`/`.json` filenames that pass the same allowlist as local packages are fetched/written.
+  `.css`/`.json`/`.js` filenames that pass the same allowlist as local packages are
+  fetched/written.
 - **Installs land disabled** — a fetched package goes through exactly the same opt-in toggle,
-  structural validation, CSS threat scan, and first-enable consent as a hand-dropped folder. The
-  link is a delivery mechanism, not a trust grant.
+  structural validation, CSS threat scan, and first-enable consent (including the network-hosts
+  confirm) as a hand-dropped folder. The link is a delivery mechanism, not a trust grant.
 
 ## Updating / removing
 

--- a/widgetsack/src/command.rs
+++ b/widgetsack/src/command.rs
@@ -545,13 +545,16 @@ fn plugins_dir(app: &tauri::AppHandle) -> Result<PathBuf, String> {
     Ok(dir.join("plugins"))
 }
 
-/// A package asset filename is a single path component: `<valid_name stem>.<css|json>`. Splitting
-/// at the LAST dot and running the stem through `valid_name` rejects separators, `..`, extra dots
+/// A package asset filename is a single path component: `<valid_name stem>.<css|json|js>` (`.js`
+/// is a Phase 2 sandboxed source script — it is only ever TEXT to the backend). Splitting at the
+/// LAST dot and running the stem through `valid_name` rejects separators, `..`, extra dots
 /// (so no `x.css.tmp` smuggling), and oversized names by construction.
 fn valid_asset_name(name: &str) -> bool {
     match name.rsplit_once('.') {
         Some((stem, ext)) => {
-            (ext.eq_ignore_ascii_case("css") || ext.eq_ignore_ascii_case("json"))
+            (ext.eq_ignore_ascii_case("css")
+                || ext.eq_ignore_ascii_case("json")
+                || ext.eq_ignore_ascii_case("js"))
                 && valid_name(stem)
         }
         None => false,
@@ -834,15 +837,18 @@ pub async fn install_plugin_package(
     if version.is_empty() {
         return Err("manifest has no \"version\"".to_string());
     }
-    // Declared assets: `theme.file` is the only asset slot in manifestVersion 1. Fetch before
-    // writing anything.
+    // Declared assets: `theme.file` (Phase 1) and `source.file` (Phase 2 sandbox script) are the
+    // only asset slots in manifestVersion 1. Fetch before writing anything.
     let mut assets: Vec<(String, String)> = Vec::new();
-    if let Some(file) = json.pointer("/theme/file").and_then(|v| v.as_str()) {
-        if !valid_asset_name(file) {
-            return Err(format!("declared asset \"{file}\" has an unsafe filename"));
+    for pointer in ["/theme/file", "/source/file"] {
+        if let Some(file) = json.pointer(pointer).and_then(|v| v.as_str()) {
+            if !valid_asset_name(file) {
+                return Err(format!("declared asset \"{file}\" has an unsafe filename"));
+            }
+            let body =
+                fetch_text_capped(&client, &asset_url_for(&resolved.manifest_url, file)).await?;
+            assets.push((file.to_string(), body));
         }
-        let body = fetch_text_capped(&client, &asset_url_for(&resolved.manifest_url, file)).await?;
-        assets.push((file.to_string(), body));
     }
     let dir = plugins_dir(&app)?.join(&id);
     fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
@@ -932,6 +938,101 @@ pub fn remove_plugin_package(app: tauri::AppHandle, id: String) -> Result<(), St
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
         Err(err) => Err(err.to_string()),
     }
+}
+
+// ---- plugin packages: sandboxed source network proxy (Phase 2) ----------------------------------
+// A package's `source.js` runs in a QuickJS sandbox with ZERO capabilities; the frontend asks this
+// command to perform each fetch between the sandbox's two pure calls. The hosts allowlist is
+// re-read from the manifest ON DISK per request (server-side enforcement — a compromised webview
+// can't widen it), https only, GET only, redirects DISABLED (so the response host can never drift
+// off-allowlist), 10s timeout, 256 KiB body cap.
+
+/// PURE SEAM: is `url` an https URL whose host is a DOMAIN matching one of `hosts` exactly?
+/// Subdomains must be listed explicitly; IP literals, explicit ports, embedded credentials, and
+/// non-https schemes all fail. Comparison is ASCII-case-insensitive (URL hosts parse lowercased,
+/// but the manifest on disk is untrusted text).
+fn host_allowed(url: &str, hosts: &[String]) -> bool {
+    let Ok(u) = reqwest::Url::parse(url) else {
+        return false;
+    };
+    if u.scheme() != "https" || u.port().is_some() {
+        return false;
+    }
+    if !u.username().is_empty() || u.password().is_some() {
+        return false;
+    }
+    match u.domain() {
+        Some(d) => hosts.iter().any(|h| h.eq_ignore_ascii_case(d)),
+        None => false, // IP literal (or no host at all)
+    }
+}
+
+#[derive(Serialize)]
+pub struct PackageFetchResponse {
+    pub url: String,
+    pub status: u16,
+    pub body: String,
+}
+
+/// GET `url` on behalf of package `id`'s sandboxed source. Non-2xx responses are returned (with
+/// their status) rather than erroring — the sandbox's `transform` decides what a miss means; only
+/// transport/validation failures are `Err`.
+#[tauri::command]
+pub async fn package_fetch(
+    app: tauri::AppHandle,
+    id: String,
+    url: String,
+) -> Result<PackageFetchResponse, String> {
+    if !valid_name(&id) {
+        return Err("invalid package id".to_string());
+    }
+    let raw = fs::read_to_string(plugins_dir(&app)?.join(&id).join("plugin.json"))
+        .map_err(|_| "package manifest not found".to_string())?;
+    let json: serde_json::Value = serde_json::from_str(&raw)
+        .map_err(|_| "package manifest is not valid JSON".to_string())?;
+    let hosts: Vec<String> = json
+        .pointer("/source/hosts")
+        .and_then(|v| v.as_array())
+        .map(|a| {
+            a.iter()
+                .filter_map(|x| x.as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default();
+    if hosts.is_empty() {
+        return Err("package declares no source hosts".to_string());
+    }
+    if !host_allowed(&url, &hosts) {
+        return Err(format!("url is not in the package's host allowlist: {url}"));
+    }
+    let client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .map_err(|e| e.to_string())?;
+    let resp = client
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| format!("GET {url} failed: {e}"))?;
+    let status = resp.status().as_u16();
+    if let Some(len) = resp.content_length()
+        && len > FETCH_CAP as u64
+    {
+        return Err(format!("{url} is too large ({len} bytes; cap {FETCH_CAP})"));
+    }
+    use futures_util::StreamExt;
+    let mut buf: Vec<u8> = Vec::new();
+    let mut stream = resp.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let bytes = chunk.map_err(|e| format!("GET {url} failed mid-body: {e}"))?;
+        if buf.len() + bytes.len() > FETCH_CAP {
+            return Err(format!("{url} exceeded the {FETCH_CAP}-byte download cap"));
+        }
+        buf.extend_from_slice(&bytes);
+    }
+    let body = String::from_utf8(buf).map_err(|_| format!("{url} body is not valid UTF-8"))?;
+    Ok(PackageFetchResponse { url, status, body })
 }
 
 /// Seed a couple of example themes on first run so the picker has something to show
@@ -1143,10 +1244,12 @@ mod tests {
     }
 
     #[test]
-    fn valid_asset_name_requires_css_or_json_and_no_traversal() {
+    fn valid_asset_name_requires_css_json_or_js_and_no_traversal() {
         assert!(super::valid_asset_name("theme.css"));
         assert!(super::valid_asset_name("extra.JSON")); // case-insensitive ext
         assert!(super::valid_asset_name("My Theme 2.css")); // spaces ok (valid_name stem)
+        assert!(super::valid_asset_name("source.js")); // Phase 2 sandbox script
+        assert!(super::valid_asset_name("Source.JS")); // case-insensitive ext
         assert!(!super::valid_asset_name("theme.css.tmp")); // wrong ext (last dot wins)
         assert!(!super::valid_asset_name("evil.tmp.css")); // stem contains a dot
         assert!(!super::valid_asset_name("../theme.css")); // traversal
@@ -1154,9 +1257,42 @@ mod tests {
         assert!(!super::valid_asset_name("a/b.css")); // separator
         assert!(!super::valid_asset_name("a\\b.css")); // separator
         assert!(!super::valid_asset_name("theme.exe")); // disallowed ext
+        assert!(!super::valid_asset_name("source.mjs")); // js only, not mjs/cjs
         assert!(!super::valid_asset_name("noext")); // no extension
         assert!(!super::valid_asset_name(".css")); // empty stem
         assert!(!super::valid_asset_name("")); // empty
+    }
+
+    #[test]
+    fn host_allowed_matches_exact_https_domains_only() {
+        let hosts = vec!["api.open-meteo.com".to_string(), "example.org".to_string()];
+        assert!(super::host_allowed(
+            "https://api.open-meteo.com/v1/forecast?latitude=1.35",
+            &hosts
+        ));
+        // URL hosts parse case-folded; a SHOUTING url still matches.
+        assert!(super::host_allowed("https://API.OPEN-METEO.COM/v1", &hosts));
+        // An explicit default port is elided by the parser → still allowed.
+        assert!(super::host_allowed("https://example.org:443/", &hosts));
+        // Subdomains are NOT implied — they must be listed.
+        assert!(!super::host_allowed("https://sub.example.org/", &hosts));
+        assert!(!super::host_allowed("https://example.org.evil.com/", &hosts));
+        // https only, no explicit ports, no credentials, no IP literals.
+        assert!(!super::host_allowed("http://api.open-meteo.com/", &hosts));
+        assert!(!super::host_allowed("https://api.open-meteo.com:8443/", &hosts));
+        assert!(!super::host_allowed("https://user@example.org/", &hosts));
+        assert!(!super::host_allowed(
+            "https://93.184.216.34/",
+            &["93.184.216.34".to_string()]
+        ));
+        // Host case-insensitivity also covers an uppercased (hand-edited) manifest entry.
+        assert!(super::host_allowed(
+            "https://example.org/",
+            &["EXAMPLE.ORG".to_string()]
+        ));
+        assert!(!super::host_allowed("https://evil.com/?q=example.org", &hosts));
+        assert!(!super::host_allowed("not a url", &hosts));
+        assert!(!super::host_allowed("https://example.org/", &[]));
     }
 
     #[test]

--- a/widgetsack/src/main.rs
+++ b/widgetsack/src/main.rs
@@ -164,6 +164,7 @@ async fn main() -> Result<(), ()> {
             command::install_plugin_package,
             command::check_plugin_package_update,
             command::remove_plugin_package,
+            command::package_fetch,
             command::list_layouts,
             command::read_layout,
             command::save_layout_as,


### PR DESCRIPTION
Completes the plugin-package trilogy. Packages may ship `source.js`, run in a per-package QuickJS-WASM runtime with **zero capabilities**: two pure functions — `requests()` → https URLs, `transform(responses)` → samples under `pkg.<id>.*` — with the trusted host doing the fetch in between.

- **Rust-enforced host allowlist**: `package_fetch` re-reads the manifest server-side; exact https domains only, redirects disabled, timeout + body caps (pure `host_allowed` seam, tested).
- **Sandbox budgets**: 100 ms interrupt deadline per call, memory/stack caps, 64 KiB script, request/sample/value caps, declared sensor ids only; per-tick `pkg.<id>.status` sensor; errors never escape the loop.
- **Consent names the network** (one dialog with the css facts + hosts/cadence); consent is hosts-fingerprinted — an update that changes hosts stops the source until re-confirmed.
- Declared sensors appear in the sensor browser (live catalog source + new `unregisterSource`); remote install now fetches `source.file`; worked open-meteo example in the authoring guide.

Verified: 1,137 unit (incl. 5 end-to-end sandbox tests on real QuickJS) · 32 e2e · build · check:docs · cargo test (118) · clippy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)