### PR TITLE
docs(examples): reference plugin package, CI-pinned against the real pipeline

### DIFF
--- a/client/src/lib/widgets/plugins/samplePack.test.ts
+++ b/client/src/lib/widgets/plugins/samplePack.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// The repo's reference package (examples/packages/sample-pack) — parsed, scanned, and RUN here so
+// the sample the docs point at can never drift from the real schema or the sandbox contract.
+// vite's import.meta.url shim isn't a file URL under the test transform and the process cwd
+// varies by invocation (client/ vs repo root), so walk up from cwd to find the repo root.
+const REL = 'examples/packages/sample-pack';
+function sampleDir(): string {
+	let d = process.cwd();
+	for (let i = 0; i < 6; i++) {
+		if (existsSync(resolve(d, REL, 'plugin.json'))) return resolve(d, REL);
+		d = resolve(d, '..');
+	}
+	throw new Error(`examples/packages/sample-pack not found above ${process.cwd()}`);
+}
+const dir = sampleDir();
+const read = (name: string): string => readFileSync(resolve(dir, name), 'utf8');
+
+// Stub only the Tauri command module; the QuickJS sandbox is the real one.
+const fetches: { id: string; url: string }[] = [];
+vi.mock('./packages-commands', () => ({
+	readPluginPackageAsset: (_id: string, name: string) => Promise.resolve(read(name)),
+	packageFetch: (id: string, url: string) => {
+		fetches.push({ id, url });
+		return Promise.resolve({
+			url,
+			status: 200,
+			body: JSON.stringify({ current: { temperature_2m: 31.4, wind_speed_10m: 9.7 } })
+		});
+	}
+}));
+
+import { parsePluginPackage } from '../../core/pluginPackage';
+import { scanCssThreats } from '../../core/cssThreats';
+import { createTelemetryHub } from '../../core/telemetry';
+import { startPackageSource } from './packages-source';
+
+async function until(pred: () => boolean): Promise<void> {
+	for (let i = 0; i < 300 && !pred(); i++) await new Promise((r) => setTimeout(r, 10));
+	expect(pred()).toBe(true);
+}
+
+afterEach(() => {
+	fetches.length = 0;
+});
+
+describe('examples/packages/sample-pack', () => {
+	it('parses clean: both templates, theme, source, and sensors survive validation', () => {
+		const r = parsePluginPackage('sample-pack', read('plugin.json'));
+		expect(r.ok).toBe(true);
+		if (!r.ok) return;
+		expect(r.pkg.warnings).toEqual([]);
+		expect(r.pkg.manifest.templates.map((t) => t.id)).toEqual(['clock', 'weather']);
+		expect(r.pkg.manifest.theme?.file).toBe('sample.css');
+		expect(r.pkg.manifest.source?.hosts).toEqual(['api.open-meteo.com']);
+		expect(r.pkg.manifest.sensors.map((s) => s.id)).toEqual(['temp', 'wind']);
+	});
+
+	it('ships a threat-free theme (no consent dialog needed)', () => {
+		expect(scanCssThreats(read('sample.css'))).toEqual([]);
+	});
+
+	it('source.js runs in the real sandbox: fetches only the declared host, ingests temp + wind', async () => {
+		const r = parsePluginPackage('sample-pack', read('plugin.json'));
+		expect(r.ok).toBe(true);
+		if (!r.ok) return;
+		const hub = createTelemetryHub();
+		const stop = await startPackageSource(r.pkg.manifest, hub);
+		try {
+			await until(() => hub.sensor('pkg.sample-pack.temp').getSnapshot().value !== null);
+			expect(fetches).toHaveLength(1);
+			expect(new URL(fetches[0].url).hostname).toBe('api.open-meteo.com');
+			const scalar = (id: string) => {
+				const v = hub.sensor(id).getSnapshot().value;
+				return v?.kind === 'scalar' ? v.value : null;
+			};
+			expect(scalar('pkg.sample-pack.temp')).toBe(31.4);
+			expect(scalar('pkg.sample-pack.wind')).toBe(9.7);
+			const status = hub.sensor('pkg.sample-pack.status').getSnapshot().value;
+			expect(status?.kind === 'text' && status.value).toBe('ok');
+		} finally {
+			stop();
+		}
+	});
+});

--- a/docs/third-party-plugins.md
+++ b/docs/third-party-plugins.md
@@ -20,6 +20,21 @@ in the studio's **Plugins** section under *Packages*, where each one is enabled 
 > (no network, no DOM, no Tauri — the host does the fetching against a consented allowlist; see
 > *Sandboxed sensor sources* below). The other sharp edge is **theme CSS** — see Security.
 
+## Try the sample
+
+A complete reference package — a parameterized clock template, a weather card driven by a
+sandboxed [open-meteo](https://open-meteo.com) source, and a small theme — lives in this repo at
+[`examples/packages/sample-pack`](../examples/packages/sample-pack). CI parses it, scans its
+theme, and runs its `source.js` in the real sandbox on every build, so it can't drift from the
+schema. Two ways to install it:
+
+- **Copy**: drop the `sample-pack` folder into the app-config `plugins/` directory and reopen
+  the studio's Plugins section.
+- **Remote** (exercises the URL installer): *Plugins → Packages → Install from URL…* with
+  `https://raw.githubusercontent.com/gyng/widgetsack/main/examples/packages/sample-pack/plugin.json`
+
+Either way it lands disabled; enabling asks for consent to poll `api.open-meteo.com`.
+
 ## plugin.json
 
 ```json

--- a/examples/packages/sample-pack/plugin.json
+++ b/examples/packages/sample-pack/plugin.json
@@ -1,0 +1,99 @@
+{
+	"manifestVersion": 1,
+	"id": "sample-pack",
+	"name": "Sample pack",
+	"version": "1.0.0",
+	"description": "The reference plugin package: a parameterized clock, a weather card fed by a sandboxed open-meteo source, and a small accent theme.",
+	"author": "widgetsack",
+	"homepage": "https://github.com/gyng/widgetsack",
+	"templates": [
+		{
+			"id": "clock",
+			"name": "Sample clock",
+			"description": "Time over date, with a 12/24-hour insert-time option.",
+			"size": { "w": 200, "h": 64 },
+			"params": [
+				{
+					"key": "time",
+					"label": "Time format",
+					"default": "HH:mm",
+					"targets": ["children.0.unit.config.format"],
+					"choices": [
+						{ "value": "HH:mm", "label": "24-hour" },
+						{ "value": "h:mm A", "label": "12-hour" }
+					]
+				}
+			],
+			"tree": {
+				"id": "sp-clock",
+				"kind": "col",
+				"align": "stretch",
+				"gap": 2,
+				"children": [
+					{
+						"id": "sp-time",
+						"unit": {
+							"id": "sp-time",
+							"type": "clock",
+							"rect": { "x": 0, "y": 0, "w": 200, "h": 36 },
+							"config": { "format": "HH:mm" }
+						}
+					},
+					{
+						"id": "sp-date",
+						"unit": {
+							"id": "sp-date",
+							"type": "clock",
+							"rect": { "x": 0, "y": 0, "w": 200, "h": 20 },
+							"config": { "format": "ddd D MMM" }
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "weather",
+			"name": "Weather card",
+			"description": "Temperature gauge + wind readout bound to this package's own sandboxed open-meteo source.",
+			"size": { "w": 180, "h": 130 },
+			"tree": {
+				"id": "sp-wx",
+				"kind": "col",
+				"align": "stretch",
+				"gap": 4,
+				"children": [
+					{
+						"id": "sp-wx-temp",
+						"unit": {
+							"id": "sp-wx-temp",
+							"type": "gauge",
+							"sensor": "pkg.sample-pack.temp",
+							"rect": { "x": 0, "y": 0, "w": 96, "h": 96 },
+							"config": { "label": "TEMP", "unit": "°C", "min": -10, "max": 45 }
+						}
+					},
+					{
+						"id": "sp-wx-wind",
+						"unit": {
+							"id": "sp-wx-wind",
+							"type": "text",
+							"sensor": "pkg.sample-pack.wind",
+							"rect": { "x": 0, "y": 0, "w": 180, "h": 18 },
+							"config": { "label": "💨 ", "format": "integer" }
+						}
+					}
+				]
+			}
+		}
+	],
+	"theme": { "name": "Sample amber", "file": "sample.css" },
+	"source": {
+		"file": "source.js",
+		"pollSeconds": 900,
+		"hosts": ["api.open-meteo.com"]
+	},
+	"sensors": [
+		{ "id": "temp", "label": "Temperature", "unit": "°C" },
+		{ "id": "wind", "label": "Wind speed", "unit": "km/h" }
+	]
+}

--- a/examples/packages/sample-pack/sample.css
+++ b/examples/packages/sample-pack/sample.css
@@ -1,0 +1,7 @@
+/* Sample package theme: a warm amber accent for widgets, nothing else. Theme CSS is plain token
+   overrides at :root (docs/theming.md) — it is scanned on enable, so keep remote fetches and
+   imports out of package themes (the scanner reads comments too). */
+:root {
+	--np-accent: rgb(255, 176, 92);
+	--np-label: rgb(240, 222, 200);
+}

--- a/examples/packages/sample-pack/source.js
+++ b/examples/packages/sample-pack/source.js
@@ -1,0 +1,24 @@
+// Sample sandboxed source: current weather from open-meteo (no API key required).
+//
+// The contract (docs/third-party-plugins.md): assign `module.exports = { requests, transform }`.
+// Both functions are PURE — this script runs in a QuickJS sandbox with no host access at all; the
+// app fetches the URLs `requests()` returns (https-only, against the manifest's `hosts`
+// allowlist) and hands the responses to `transform()`, which returns samples for the sensor ids
+// declared in plugin.json. Edit the latitude/longitude for your location.
+module.exports = {
+	requests: function () {
+		return [
+			'https://api.open-meteo.com/v1/forecast?latitude=1.35&longitude=103.82&current=temperature_2m,wind_speed_10m'
+		];
+	},
+	transform: function (responses) {
+		var r = responses[0];
+		if (!r || r.status !== 200) return [];
+		var current = JSON.parse(r.body).current;
+		if (!current) return [];
+		return [
+			{ sensor: 'temp', value: current.temperature_2m },
+			{ sensor: 'wind', value: current.wind_speed_10m }
+		];
+	}
+};


### PR DESCRIPTION
A complete sample package at `examples/packages/sample-pack` exercising all three phases: parameterized clock template, a weather card bound to the package''s own `pkg.sample-pack.*` sensors, an amber theme, and a sandboxed open-meteo `source.js` (keyless API).

- Linked from the authoring guide with both install paths — copy into `plugins/`, or **Install from URL…** with the raw GitHub link (testing the remote installer against this very repo once merged).
- **CI-pinned**: `samplePack.test.ts` parses the real manifest (zero warnings), scans the real theme, and runs the real `source.js` in the real QuickJS sandbox — asserting fetched host, ingested samples, and the status sensor. The sample can''t rot.

Verified: 1,140 unit · tsc · lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)