### PR TITLE
chore(release): bump version to 0.0.28

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5130,7 +5130,7 @@ dependencies = [
 
 [[package]]
 name = "widgetsack"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "fontdb",
  "futures-util",

--- a/widgetsack/Cargo.toml
+++ b/widgetsack/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "widgetsack"
 # Keep in lockstep with tauri.conf.json's version (the bundle/updater source of truth).
-version = "0.0.27"
+version = "0.0.28"
 description = "widgetsack desktop widget platform"
 authors = ["you"]
 license = "MIT OR Apache-2.0"

--- a/widgetsack/tauri.conf.json
+++ b/widgetsack/tauri.conf.json
@@ -49,7 +49,7 @@
     "createUpdaterArtifacts": false
   },
   "productName": "widgetsack",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "identifier": "io.github.gyng",
   "plugins": {},
   "app": {


### PR DESCRIPTION
Version bump for v0.0.28. Release highlights since v0.0.27:

- **Plugin packages** — the new extensibility surface: declarative template/theme bundles (#22), install from a GitHub link with manual update checks (#23), sandboxed zero-capability sensor sources with Rust-enforced host allowlists (#24), and a CI-pinned reference package (#25)
- **Gauge styles** — circle, linear, pips, needle + arc sweep (#19, closes #17)
- **Installer** — silent upgrades (no more running-app modal), mascot branding, root Start Menu shortcut (fixes the "app missing after install" report)
- **Fixes/polish** — sorted monitor dropdown, Outline hover layout-shift, widget-designer empty-state coverage, transparent-icon branding, 900px demo + showcase studio screenshots, Monitor/Display naming, themeable density docs, sack content summaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)