### PR TITLE
fix(overlay): secondary overlays reveal themselves; bump to 0.0.29

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5130,7 +5130,7 @@ dependencies = [
 
 [[package]]
 name = "widgetsack"
-version = "0.0.28"
+version = "0.0.29"
 dependencies = [
  "fontdb",
  "futures-util",

--- a/README.md
+++ b/README.md
@@ -94,6 +94,42 @@ show (reachable in edit mode; "All media" lists the current sources).
 
 Toggle autostart in settings, or add `widgetsack.exe` to Startup apps in Task Manager.
 
+## Plugins
+
+widgetsack has two plugin layers, both managed from the studio's **Plugins** section:
+
+- **Built-in integrations** — Home Assistant, MQTT, stock quotes, and the AI provider are
+  first-party plugins configured in the studio. Tokens and API keys stay in the Rust backend;
+  the webview never holds them.
+- **Third-party plugin packages** — drop-in community bundles that add **templates**
+  (ready-made widget clusters with insert-time options), optionally a **theme**, and optionally
+  a **sandboxed sensor source**: a small `source.js` that polls an HTTP API and feeds custom
+  sensors you can bind to any meter or formula as `pkg.<id>.*`.
+
+Install a package by dropping its folder into the app-config `plugins/` directory, or via
+**Plugins → Packages → Install from URL…** — paste `owner/repo`, a GitHub link, or any https
+`plugin.json` URL. Update checks are manual (per-package *Check updates*); nothing is fetched in
+the background.
+
+Packages are opt-in and sandboxed by design:
+
+- **Nothing runs on install.** Every package lands disabled; enabling it is a per-machine
+  allowlist, and re-installing starts from zero trust.
+- **Templates and themes are declarative data** — a package can't ship its own components. The
+  only code surface is `source.js`, which runs in a QuickJS-in-WASM sandbox with zero
+  capabilities: no network, no DOM, no Tauri, a ~100 ms CPU budget per tick.
+- **The host does the fetching** against a Rust-enforced https allowlist of exact hostnames the
+  manifest declares — consented by name on first enable, re-confirmed if an update changes the
+  list.
+- **Theme CSS is the trust boundary:** it's scanned (remote `url()`/`@import`, viewport
+  overlays), and a flagged theme asks for explicit confirmation. Don't enable packages from
+  sources you don't trust.
+
+To write one, see the [authoring guide](docs/third-party-plugins.md) and the reference
+[sample pack](examples/packages/sample-pack) — a parameterized clock template, a weather card
+driven by a sandboxed [open-meteo](https://open-meteo.com) source, and a small theme, CI-tested
+against the real pipeline on every build.
+
 ## TODO
 
 - Desktop-pinned widget layer (behind windows, à la wallpaper engines)

--- a/client/src/lib/monitorKey.test.ts
+++ b/client/src/lib/monitorKey.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { monitorByKey, monitorDeviceKey } from './monitorKey';
+
+describe('monitorDeviceKey', () => {
+	it('strips the GDI prefix to the bare device tag', () => {
+		expect(monitorDeviceKey('\\\\.\\DISPLAY3', 1)).toBe('DISPLAY3');
+	});
+
+	it('falls back to a position-independent m<i> when the platform gives no name', () => {
+		expect(monitorDeviceKey(null, 2)).toBe('m2');
+		expect(monitorDeviceKey('', 0)).toBe('m0');
+	});
+});
+
+describe('monitorByKey', () => {
+	const monitors = [
+		{ name: '\\\\.\\DISPLAY1' },
+		{ name: '\\\\.\\DISPLAY3' },
+		{ name: '\\\\.\\DISPLAY2' }
+	];
+
+	it('finds the monitor whose stable device key matches', () => {
+		expect(monitorByKey(monitors, 'DISPLAY3')).toBe(monitors[1]);
+	});
+
+	it('returns null when no current monitor matches the key', () => {
+		expect(monitorByKey(monitors, 'DISPLAY9')).toBeNull();
+	});
+
+	it('matches the m<i> fallback keys index-aware on platforms with no device names', () => {
+		const unnamed = [{ name: null }, { name: null }];
+		expect(monitorByKey(unnamed, 'm1')).toBe(unnamed[1]);
+		expect(monitorByKey(unnamed, 'm2')).toBeNull();
+	});
+});

--- a/client/src/lib/monitorKey.ts
+++ b/client/src/lib/monitorKey.ts
@@ -1,0 +1,23 @@
+// Pure monitor-key seam, kept out of overlay.ts (the Tauri adapter) so it's unit-testable without
+// a window — same split as monitorLabel.ts. The stable device key is what layouts, overlay window
+// labels (`overlay-<key>`), and the studio's monitor switcher all share.
+
+/** A monitor's STABLE layout key: the GDI device tag ('DISPLAY3'), not the `availableMonitors()`
+ * enumeration index — the index reshuffles across reboots/hot-plugs, which put a saved layout on
+ * the wrong physical monitor. Falls back to a position-independent `m<i>` when the platform gives
+ * no device name (plain browser / tests). The primary monitor's key stays 'default' (callers). */
+export function monitorDeviceKey(name: string | null | undefined, index: number): string {
+	const tag = (name ?? '').replace(/^[\\.?]+/, '').trim();
+	return tag || `m${index}`;
+}
+
+/** The monitor in `monitors` whose stable device key is `key`, or null when none matches (e.g. the
+ * monitor was unplugged). Index-aware so the `m<i>` fallback keys keep matching on platforms with
+ * no device names. */
+export function monitorByKey<T extends { name: string | null }>(
+	monitors: T[],
+	key: string
+): T | null {
+	const i = monitors.findIndex((m, idx) => monitorDeviceKey(m.name, idx) === key);
+	return i >= 0 ? monitors[i] : null;
+}

--- a/client/src/lib/overlay.ts
+++ b/client/src/lib/overlay.ts
@@ -18,6 +18,7 @@ import type { WindowDescriptor } from './core/windowMatch';
 import { monitorHasWidgets } from './core/layoutTree';
 import { builtinCss } from './core/builtinThemes';
 import { compareMonitorOptions, monitorOptionLabel } from './monitorLabel';
+import { monitorByKey, monitorDeviceKey } from './monitorKey';
 import { migrateMonitorKeys, parseLayoutAny } from './core/migration';
 import { readOverlayPrefs, type OverlayLayer } from './widgets/canvas/overlayPrefs';
 import type { OverlayPresentation } from './widgets/canvas/overlayPresentation';
@@ -65,14 +66,9 @@ export async function applyOverlayLayer(layer: OverlayLayer): Promise<void> {
 	emit(EVENTS.overlayLayerStatus, { layer, ok, detail, label: win.label }).catch(() => undefined);
 }
 
-/** A monitor's STABLE layout key: the GDI device tag ('DISPLAY3'), not the `availableMonitors()`
- * enumeration index — the index reshuffles across reboots/hot-plugs, which put a saved layout on
- * the wrong physical monitor. Falls back to a position-independent `m<i>` when the platform gives
- * no device name (plain browser / tests). The primary monitor's key stays 'default' (callers). */
-export function monitorDeviceKey(name: string | null | undefined, index: number): string {
-	const tag = (name ?? '').replace(/^[\\.?]+/, '').trim();
-	return tag || `m${index}`;
-}
+// The stable per-monitor layout key (monitorDeviceKey) and its reverse lookup (monitorByKey) live
+// in monitorKey.ts — a pure seam, unit-tested without a window.
+export { monitorDeviceKey };
 
 /** The set of saved-layout monitor keys that hold at least one widget (so an overlay there would
  * render something). Keys: 'default' (primary) or the device key, matching studioMonitorOptions.
@@ -240,6 +236,50 @@ export async function fillPrimaryMonitor(): Promise<void> {
 			console.warn('onScaleChanged registration failed', err);
 			scaleListenerWired = false; // allow a retry on a later fill
 		}
+	}
+}
+
+// Guard so repeat fillOwnMonitor() calls don't stack duplicate onScaleChanged listeners (one per
+// secondary-overlay webview, mirroring fillPrimaryMonitor's scaleListenerWired).
+let ownScaleListenerWired = false;
+
+/** Secondary overlay (?monitor=<key>) self-fit + reveal: position/size THIS window onto the monitor
+ * whose stable device key is `key`, re-assert borderless + click-through, then show. Runs in the
+ * overlay's OWN webview so it can't be orphaned: the spawn-side `tauri://created` setup in
+ * reconcileOverlays runs in the CREATING window's JS context, and when an empty-primary `main`
+ * destroys itself (renderer reclaim) right after reconciling, that context died before
+ * positioning/revealing the new overlay — leaving it permanently invisible (and `if (have) continue`
+ * never repaired it). Idempotent with the spawn-side setup when both run. Best-effort: failures are
+ * logged, never thrown. No-op when no current monitor matches `key` (a later reconcile closes the
+ * orphan). */
+export async function fillOwnMonitor(key: string): Promise<void> {
+	try {
+		const m = monitorByKey(await availableMonitors(), key);
+		if (!m) {
+			console.warn(`fillOwnMonitor: no monitor matches key '${key}'`);
+			return;
+		}
+		const win = getCurrentWindow();
+		await win.setPosition(new PhysicalPosition(m.position.x, m.position.y));
+		await win.setSize(new PhysicalSize(m.size.width, m.size.height));
+		// Same re-asserts as the spawn side: no border/title bar (the window-state plugin can restore
+		// a stale decorations:true) and click-through BEFORE the window is ever visible.
+		await win.setDecorations(false);
+		await win.setShadow(false);
+		await win.setIgnoreCursorEvents(true);
+		await win.show();
+		// show() raises the window; re-assert the chosen z-order layer AFTER it (see
+		// setMainWindowVisible). Safe to apply the full layer here, incl. the wallpaper SetParent,
+		// which must run from this overlay's own webview anyway.
+		await applyOverlayLayer(readOverlayPrefs().overlayLayer);
+		// #12: DPI/scale hot-plug — re-fit to our monitor when its scale factor changes (mirrors
+		// fillPrimaryMonitor; the device key stays stable across a scale change).
+		if (!ownScaleListenerWired) {
+			ownScaleListenerWired = true;
+			await win.onScaleChanged(() => void fillOwnMonitor(key));
+		}
+	} catch (err) {
+		console.warn('fillOwnMonitor failed', err);
 	}
 }
 
@@ -851,7 +891,10 @@ export async function reconcileOverlays(): Promise<void> {
 			// uses no OS file-drop, so Tauri's native handler is safe to disable here too.
 			dragDropEnabled: false
 		});
-		// Constructor sizes are logical; place precisely in physical px, then show.
+		// Constructor sizes are logical; place precisely in physical px, then show. BEST-EFFORT fast
+		// path only: this callback lives in the CREATING window's JS context and dies with it (an
+		// empty-primary `main` self-destructs right after reconciling). The overlay's own Canvas init
+		// re-runs the same setup via fillOwnMonitor (idempotent), so it reveals either way.
 		w.once('tauri://created', async () => {
 			try {
 				await w.setPosition(new PhysicalPosition(m.position.x, m.position.y));

--- a/client/src/lib/widgets/canvas/useStudioInit.test.ts
+++ b/client/src/lib/widgets/canvas/useStudioInit.test.ts
@@ -1,0 +1,83 @@
+// The init must make every window role reveal itself from its OWN webview: a secondary overlay
+// (?monitor=<key>) self-fits + shows via fillOwnMonitor — the spawn-side `tauri://created` setup
+// dies with its creator when an empty-primary `main` self-destructs (renderer reclaim), which left
+// secondaries permanently invisible. The primary keeps its fill/reconcile path.
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { TelemetryHub } from '../../core/telemetry';
+import type { StudioInitDeps } from './useStudioInit';
+import { useStudioInit } from './useStudioInit';
+
+const fillOwnMonitor = vi.fn((key: string) => Promise.resolve(void key));
+const fillPrimaryMonitor = vi.fn(() => Promise.resolve());
+const setMainWindowVisible = vi.fn((visible: boolean) => Promise.resolve(void visible));
+let monitorParamValue: string | null = null;
+
+vi.mock('../../overlay', () => ({
+	fillOwnMonitor: (key: string) => fillOwnMonitor(key),
+	fillPrimaryMonitor: () => fillPrimaryMonitor(),
+	setMainWindowVisible: (v: boolean) => setMainWindowVisible(v),
+	monitorParam: () => monitorParamValue,
+	listThemes: vi.fn(async () => []),
+	openStudio: vi.fn(() => Promise.resolve()),
+	studioMonitorOptions: vi.fn(async () => [])
+}));
+vi.mock('../../core/plugin', () => ({
+	startAllSources: vi.fn(async () => () => undefined)
+}));
+vi.mock('@tauri-apps/api/event', () => ({
+	listen: vi.fn(async () => () => undefined)
+}));
+
+function makeDeps(overrides: Partial<StudioInitDeps> = {}): StudioInitDeps {
+	return {
+		studio: false,
+		hub: {} as unknown as TelemetryHub,
+		updateWorkArea: vi.fn(() => Promise.resolve()),
+		reloadLayout: vi.fn(() => Promise.resolve()),
+		reloadControls: vi.fn(() => Promise.resolve()),
+		editMode: () => false,
+		syncRects: vi.fn(),
+		syncPrimaryOverlays: vi.fn(() => Promise.resolve()),
+		applyTheme: vi.fn(() => Promise.resolve()),
+		setThemeList: vi.fn(),
+		setEdit: vi.fn(),
+		setEditModeImmediate: vi.fn(),
+		setMonitorOptions: vi.fn(),
+		clearPreviewWrite: vi.fn(),
+		...overrides
+	};
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	monitorParamValue = null;
+});
+
+describe('useStudioInit window-role reveal', () => {
+	it('secondary overlay (?monitor=<key>): self-fits + reveals via fillOwnMonitor, not the primary path', async () => {
+		monitorParamValue = 'DISPLAY3';
+		const deps = makeDeps();
+		renderHook(() => useStudioInit(deps));
+		await waitFor(() => expect(fillOwnMonitor).toHaveBeenCalledWith('DISPLAY3'));
+		expect(fillPrimaryMonitor).not.toHaveBeenCalled();
+		expect(deps.syncPrimaryOverlays).not.toHaveBeenCalled();
+	});
+
+	it('primary main window: fills the primary monitor and reconciles overlays, no self-fit', async () => {
+		const deps = makeDeps();
+		renderHook(() => useStudioInit(deps));
+		await waitFor(() => expect(deps.syncPrimaryOverlays).toHaveBeenCalled());
+		expect(fillPrimaryMonitor).toHaveBeenCalled();
+		expect(fillOwnMonitor).not.toHaveBeenCalled();
+	});
+
+	it('studio: neither overlay reveal path runs', async () => {
+		const deps = makeDeps({ studio: true });
+		renderHook(() => useStudioInit(deps));
+		await waitFor(() => expect(deps.setMonitorOptions).toHaveBeenCalled());
+		expect(fillOwnMonitor).not.toHaveBeenCalled();
+		expect(fillPrimaryMonitor).not.toHaveBeenCalled();
+		expect(deps.syncPrimaryOverlays).not.toHaveBeenCalled();
+	});
+});

--- a/client/src/lib/widgets/canvas/useStudioInit.ts
+++ b/client/src/lib/widgets/canvas/useStudioInit.ts
@@ -9,6 +9,7 @@ import { EVENTS } from '../../bridge/contract';
 import { startAllSources } from '../../core/plugin';
 import type { TelemetryHub } from '../../core/telemetry';
 import {
+	fillOwnMonitor,
 	fillPrimaryMonitor,
 	listThemes,
 	monitorParam,
@@ -51,6 +52,14 @@ export function useStudioInit(deps: StudioInitDeps): void {
 
 		(async () => {
 			const dep = d.current;
+			// A secondary overlay (?monitor=<key>) fits + reveals ITSELF before anything else. The
+			// spawn-side `tauri://created` setup in reconcileOverlays runs in the creating window's JS
+			// context and dies with it when an empty-primary `main` self-destructs (renderer reclaim)
+			// right after spawning us — which left the overlay permanently invisible. Running first also
+			// means the work-area read below sees the window on its real monitor, not wherever the
+			// window-state plugin parked it.
+			const ownKey = dep.studio ? null : monitorParam();
+			if (ownKey) await fillOwnMonitor(ownKey);
 			await dep.updateWorkArea();
 			sourceStop = await startAllSources(dep.hub); // built-in `system` + any plugin sources
 			if (cancelled) {
@@ -142,11 +151,14 @@ export function useStudioInit(deps: StudioInitDeps): void {
 			}
 		})().catch((err) => {
 			// The primary main window is born hidden (config `visible:false`) and only revealed once
-			// init reaches `syncPrimaryOverlays`. If init throws before that, reveal it anyway so a
-			// failure can never strand the app permanently invisible (its old always-visible default).
+			// init reaches `syncPrimaryOverlays`; a secondary is born hidden and reveals itself via
+			// fillOwnMonitor. If init throws before the reveal, reveal anyway so a failure can never
+			// strand a window permanently invisible (the old always-visible default).
 			console.warn('overlay init failed', err);
-			if (!cancelled && !d.current.studio && !monitorParam()) {
-				void setMainWindowVisible(true).catch(() => undefined);
+			if (!cancelled && !d.current.studio) {
+				const key = monitorParam();
+				if (key) void fillOwnMonitor(key);
+				else void setMainWindowVisible(true).catch(() => undefined);
 			}
 		});
 

--- a/widgetsack/Cargo.toml
+++ b/widgetsack/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "widgetsack"
 # Keep in lockstep with tauri.conf.json's version (the bundle/updater source of truth).
-version = "0.0.28"
+version = "0.0.29"
 description = "widgetsack desktop widget platform"
 authors = ["you"]
 license = "MIT OR Apache-2.0"

--- a/widgetsack/tauri.conf.json
+++ b/widgetsack/tauri.conf.json
@@ -49,7 +49,7 @@
     "createUpdaterArtifacts": false
   },
   "productName": "widgetsack",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "identifier": "io.github.gyng",
   "plugins": {},
   "app": {


### PR DESCRIPTION
## The bug

With widgets only on a secondary monitor (primary layout empty), the overlay never appeared after launch — widgets showed in the studio but not on the monitor.

When the primary layout is empty, `main` destroys itself to reclaim its renderer (v0.0.25) right after `reconcileOverlays()` returns — but the spawned secondary overlay was positioned/shown only from a `tauri://created` callback living in `main`'s dying JS context. The overlay was left permanently invisible (born `visible:false`, default title, parked at stale window-state coordinates), and every later reconcile skipped it by label (`if (have) continue`), so it never repaired. Confirmed against a live instance: `overlay-DISPLAY3` existed as an invisible, unconfigured window off its monitor.

## The fix

Each secondary overlay (`?monitor=<key>`) now fits + reveals **itself** first thing in its own Canvas init (`fillOwnMonitor`): position/size onto its monitor, re-assert borderless + click-through, show, re-assert the z-order layer, and re-fit on scale change. The creator's lifetime no longer matters; the spawn-side `tauri://created` setup stays as an idempotent fast path. The init catch-path failsafe now also reveals secondaries, mirroring `main`.

- New pure seam `monitorKey.ts` (`monitorDeviceKey` moved out of overlay.ts + new `monitorByKey` reverse lookup), unit-tested.
- New `useStudioInit` hook test pinning the per-role reveal paths (secondary / primary / studio).
- `chore(release)` bump to 0.0.29 included so a release can be cut on merge.

## Verification

- `npm run check`, `npm run lint`, `npm run test:unit` (1148 passed), `npm run build` — all green locally.
- Rust side untouched (version bump only); relying on CI for `cargo test`/`clippy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)