### PR TITLE
v0.0.36: auto-theme action in the theme picker too

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5130,7 +5130,7 @@ dependencies = [
 
 [[package]]
 name = "widgetsack"
-version = "0.0.35"
+version = "0.0.36"
 dependencies = [
  "fontdb",
  "futures-util",

--- a/client/src/lib/widgets/BackgroundPanel.tsx
+++ b/client/src/lib/widgets/BackgroundPanel.tsx
@@ -3,12 +3,9 @@
 // Purely a panel: the spec + handlers live in Canvas (canvas/useBackground) and arrive as props;
 // the only module call it makes itself is the stateless open-folder helper. Lazy-loaded like the
 // other studio panels (Canvas's lazy() block), so the overlay never fetches it.
-import { useState } from 'react';
 import { BACKGROUND_FITS, BACKGROUND_KINDS, isMediaKind } from '../core/background';
 import type { BackgroundKind, BackgroundSpec } from '../core/layoutTree';
-import type { Tokens } from '../core/tokens';
-import { deriveTokens } from '../core/palette';
-import { sampleImagePixels } from './canvas/wallpaperSampler';
+import type { AutoTheme } from './canvas/useAutoTheme';
 import { openWallpapersDir } from '../overlay';
 
 type Props = {
@@ -18,9 +15,9 @@ type Props = {
 	patchBg: (patch: Partial<BackgroundSpec>) => void;
 	setBgKind: (kind: BackgroundKind) => void;
 	clearBg: () => void;
-	// Wallpaper auto-theme (issue #15): resolve the current image to a URL, apply the derived tokens.
-	resolveWallpaper?: (name: string) => string;
-	onAutoTheme?: (tokens: Tokens) => void;
+	// Wallpaper auto-theme (issue #15) — the shared action (also offered in the Themes section) +
+	// a "reset colours" callback (clears the token overrides).
+	autoTheme?: AutoTheme;
 	onClearTokens?: () => void;
 };
 
@@ -31,31 +28,9 @@ export default function BackgroundPanel({
 	patchBg,
 	setBgKind,
 	clearBg,
-	resolveWallpaper,
-	onAutoTheme,
+	autoTheme,
 	onClearTokens
 }: Props) {
-	const [busy, setBusy] = useState(false);
-	const [status, setStatus] = useState<'idle' | 'done' | 'fail'>('idle');
-
-	const autoTheme = async (): Promise<void> => {
-		if (!bg?.src || !resolveWallpaper || !onAutoTheme) return;
-		setBusy(true);
-		setStatus('idle');
-		try {
-			const pixels = await sampleImagePixels(resolveWallpaper(bg.src));
-			const tokens = deriveTokens(pixels);
-			if (Object.keys(tokens).length === 0) {
-				setStatus('fail');
-				return;
-			}
-			onAutoTheme(tokens);
-			setStatus('done');
-		} finally {
-			setBusy(false);
-		}
-	};
-
 	return (
 		<div className="rail-panel bg-panel">
 			<div className="rp-hd">Background</div>
@@ -162,7 +137,7 @@ export default function BackgroundPanel({
 				</label>
 			)}
 
-			{bg?.kind === 'image' && bg.src && resolveWallpaper && onAutoTheme && (
+			{bg?.kind === 'image' && bg.src && autoTheme && (
 				<>
 					<div className="bg-files-hd">
 						<span className="rp-sub">Auto theme</span>
@@ -172,8 +147,13 @@ export default function BackgroundPanel({
 						with text that flips light/dark to stay legible over it.
 					</div>
 					<div className="bg-files-ops">
-						<button type="button" onClick={autoTheme} disabled={busy} aria-busy={busy}>
-							{busy ? 'Reading…' : '🎨 From wallpaper'}
+						<button
+							type="button"
+							onClick={() => void autoTheme.run()}
+							disabled={autoTheme.busy}
+							aria-busy={autoTheme.busy}
+						>
+							{autoTheme.busy ? 'Reading…' : '🎨 From wallpaper'}
 						</button>
 						{onClearTokens && (
 							<button
@@ -181,15 +161,19 @@ export default function BackgroundPanel({
 								title="Clear the auto / manual colour overrides"
 								onClick={() => {
 									onClearTokens();
-									setStatus('idle');
+									autoTheme.resetStatus();
 								}}
 							>
 								Reset colours
 							</button>
 						)}
 					</div>
-					{status === 'done' && <div className="rp-stub">Applied — the widgets recolour live.</div>}
-					{status === 'fail' && <div className="rp-stub">Couldn’t read the image’s colours.</div>}
+					{autoTheme.status === 'done' && (
+						<div className="rp-stub">Applied — the widgets recolour live.</div>
+					)}
+					{autoTheme.status === 'fail' && (
+						<div className="rp-stub">Couldn’t read the image’s colours.</div>
+					)}
 				</>
 			)}
 

--- a/client/src/lib/widgets/Canvas.tsx
+++ b/client/src/lib/widgets/Canvas.tsx
@@ -139,6 +139,7 @@ import { useThemes } from './canvas/useThemes';
 import { sackSummary, useSacks } from './canvas/useSacks';
 import { useSavedLayouts } from './canvas/useSavedLayouts';
 import { useBackground } from './canvas/useBackground';
+import { useAutoTheme } from './canvas/useAutoTheme';
 import { useDefEditor } from './canvas/useDefEditor';
 import { useSplitters } from './canvas/useSplitters';
 import { useStudioInit } from './canvas/useStudioInit';
@@ -628,6 +629,13 @@ export default function Canvas({ studio = false }: Props) {
 	// full-bleed in top-overlay mode would cover the user's apps); the studio always previews it.
 	const { bg, resolveWallpaper, wallpaperFiles, refreshWallpapers, patchBg, setBgKind, clearBg } =
 		useBackground({ studio, navSection, monitor, handleOp });
+	// Wallpaper auto-theme (issue #15) — shared by the Background panel + the Themes section's token
+	// overrides. Applies the derived map above any active theme via the setTokens op.
+	const autoTheme = useAutoTheme({
+		bg,
+		resolveWallpaper,
+		applyTokens: (tokens) => handleOp({ op: 'setTokens', tokens })
+	});
 	const showBackground = studio || overlayPrefs.overlayLayer !== 'top';
 
 	// --- selection-derived state ---
@@ -2839,6 +2847,31 @@ export default function Canvas({ studio = false }: Props) {
 										    the Inspector for per-widget tweaks). These override on top of the selected theme,
 										    persist across theme switches, and win until cleared. */}
 										<div className="rp-hd">Tokens (override this theme)</div>
+										{/* Auto theme from the wallpaper (issue #15): fills these overrides with a readable
+										    palette derived from the current image wallpaper. Same action as the Background
+										    panel's button; shown here because it WRITES these token overrides. */}
+										{autoTheme.canAuto ? (
+											<div className="theme-auto">
+												<button
+													type="button"
+													onClick={() => void autoTheme.run()}
+													disabled={autoTheme.busy}
+													aria-busy={autoTheme.busy}
+													title="Derive a readable accent + text colours from your wallpaper"
+												>
+													{autoTheme.busy ? 'Reading…' : '🎨 From wallpaper'}
+												</button>
+												{autoTheme.status === 'done' && <span className="rp-id">applied ✓</span>}
+												{autoTheme.status === 'fail' && (
+													<span className="rp-id">couldn’t read the image</span>
+												)}
+											</div>
+										) : (
+											<div className="rp-stub">
+												Tip: set an <strong>image</strong> Background to auto-derive colours from
+												your wallpaper.
+											</div>
+										)}
 										<TokenFields
 											values={tokenOverrides}
 											onSet={(key, value) => handleOp({ op: 'setToken', key, value })}
@@ -2855,8 +2888,7 @@ export default function Canvas({ studio = false }: Props) {
 										patchBg={patchBg}
 										setBgKind={setBgKind}
 										clearBg={clearBg}
-										resolveWallpaper={resolveWallpaper}
-										onAutoTheme={(tokens) => handleOp({ op: 'setTokens', tokens })}
+										autoTheme={autoTheme}
 										onClearTokens={() => handleOp({ op: 'clearTokens' })}
 									/>
 								)}

--- a/client/src/lib/widgets/NavRail.css
+++ b/client/src/lib/widgets/NavRail.css
@@ -1677,3 +1677,11 @@
 .canvas .plugins-panel .has-copy:hover {
 	color: rgb(var(--ui-accent-rgb));
 }
+
+/* Auto-theme-from-wallpaper action in the Themes section (sits above the token-override fields). */
+.theme-auto {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin-bottom: 8px;
+}

--- a/client/src/lib/widgets/canvas/useAutoTheme.ts
+++ b/client/src/lib/widgets/canvas/useAutoTheme.ts
@@ -1,0 +1,53 @@
+// Shared "auto theme from wallpaper" action (issue #15) — used by BOTH the Background panel and the
+// Themes section so there's one implementation. Samples the current IMAGE wallpaper, derives a
+// readable Tokens override (core/palette.ts), and applies it via the caller's apply callback (which
+// dispatches the setTokens editor op). `canAuto` is false unless there's an image wallpaper to read.
+import { useCallback, useState } from 'react';
+import type { BackgroundSpec } from '../../core/layoutTree';
+import type { Tokens } from '../../core/tokens';
+import { deriveTokens } from '../../core/palette';
+import { sampleImagePixels } from './wallpaperSampler';
+
+export type AutoThemeStatus = 'idle' | 'done' | 'fail';
+
+export type AutoTheme = {
+	/** True when there's an image wallpaper with a file to derive from. */
+	canAuto: boolean;
+	busy: boolean;
+	status: AutoThemeStatus;
+	/** Sample the wallpaper → derive → apply. No-op when `canAuto` is false. */
+	run: () => Promise<void>;
+	resetStatus: () => void;
+};
+
+export function useAutoTheme(opts: {
+	bg: BackgroundSpec | undefined;
+	resolveWallpaper: (name: string) => string;
+	applyTokens: (tokens: Tokens) => void;
+}): AutoTheme {
+	const { bg, resolveWallpaper, applyTokens } = opts;
+	const [busy, setBusy] = useState(false);
+	const [status, setStatus] = useState<AutoThemeStatus>('idle');
+	const canAuto = Boolean(bg && bg.kind === 'image' && bg.src);
+
+	const run = useCallback(async (): Promise<void> => {
+		if (!bg || bg.kind !== 'image' || !bg.src) return;
+		setBusy(true);
+		setStatus('idle');
+		try {
+			const pixels = await sampleImagePixels(resolveWallpaper(bg.src));
+			const tokens = deriveTokens(pixels);
+			if (Object.keys(tokens).length === 0) {
+				setStatus('fail');
+				return;
+			}
+			applyTokens(tokens);
+			setStatus('done');
+		} finally {
+			setBusy(false);
+		}
+	}, [bg, resolveWallpaper, applyTokens]);
+
+	const resetStatus = useCallback(() => setStatus('idle'), []);
+	return { canAuto, busy, status, run, resetStatus };
+}

--- a/widgetsack/Cargo.toml
+++ b/widgetsack/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "widgetsack"
 # Keep in lockstep with tauri.conf.json's version (the bundle/updater source of truth).
-version = "0.0.35"
+version = "0.0.36"
 description = "widgetsack desktop widget platform"
 authors = ["you"]
 license = "MIT OR Apache-2.0"

--- a/widgetsack/tauri.conf.json
+++ b/widgetsack/tauri.conf.json
@@ -49,7 +49,7 @@
     "createUpdaterArtifacts": false
   },
   "productName": "widgetsack",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "identifier": "io.github.gyng",
   "plugins": {},
   "app": {


### PR DESCRIPTION
Follow-up to #15: the **"🎨 From wallpaper"** auto-theme action now also appears in the **Themes** section, directly above the "Tokens (override this theme)" fields — which is what it fills.

- Extracted the sample → derive → apply orchestration into a shared **`useAutoTheme`** hook, so the Background panel and the Themes section share **one** implementation (no duplication). `BackgroundPanel` now consumes it via props.
- In the Themes section: the button shows when an image wallpaper is set; otherwise a tip points at the Background section.

Bumps to 0.0.36.

**Note:** local Playwright e2e couldn't run (a wedged dev-server port on the dev box); verified locally with tsc + lint + 1303 unit tests + build. No new boot/Tauri command was added (just a conditional button reusing the existing action), so boots-clean is unaffected — CI runs the full e2e here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)