### PR TITLE
fix(ai-provider): stop chat hanging, fix model refresh + refine settings (0.0.38)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5130,7 +5130,7 @@ dependencies = [
 
 [[package]]
 name = "widgetsack"
-version = "0.0.37"
+version = "0.0.38"
 dependencies = [
  "fontdb",
  "futures-util",

--- a/client/src/lib/llm/useLlmChat.test.ts
+++ b/client/src/lib/llm/useLlmChat.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+// llm_stream rejects (the real-world "AI provider not configured" / backend error case). The hook
+// must NOT leave the opened assistant turn streaming forever — it should surface the error.
+vi.mock('../widgets/plugins/llm-commands', () => ({
+	llmStream: vi.fn(() => Promise.reject('AI provider not configured')),
+	llmCancel: vi.fn()
+}));
+// No Tauri in the test: the delta source is a no-op unlisten.
+vi.mock('./source', () => ({ startLlmSource: () => Promise.resolve(() => undefined) }));
+
+import { useLlmChat } from './useLlmChat';
+import { resetChat } from '../../stores/llmStore';
+
+beforeEach(() => resetChat());
+afterEach(() => vi.clearAllMocks());
+
+describe('useLlmChat', () => {
+	it('terminates the streaming turn with the error when llm_stream rejects (no eternal "…")', async () => {
+		const { result } = renderHook(() => useLlmChat());
+
+		await act(async () => {
+			await result.current.send('hello');
+		});
+
+		await waitFor(() => {
+			const assistant = result.current.chat.turns.find((t) => t.role === 'assistant');
+			expect(assistant).toBeTruthy();
+			expect(assistant?.streaming).toBe(false);
+			expect(assistant?.error).toContain('AI provider not configured');
+		});
+	});
+});

--- a/client/src/lib/llm/useLlmChat.ts
+++ b/client/src/lib/llm/useLlmChat.ts
@@ -4,7 +4,7 @@
 // Pure transcript logic lives in core/llm.ts; the Tauri calls go through llm-commands.ts.
 import { useCallback, useEffect } from 'react';
 import { pushUser, startTurn, toMessages, type ChatState } from '../core/llm';
-import { llmStore, resetChat, useChat } from '../../stores/llmStore';
+import { handleDelta, llmStore, resetChat, useChat } from '../../stores/llmStore';
 import { llmCancel, llmStream } from '../widgets/plugins/llm-commands';
 import { startLlmSource } from './source';
 
@@ -47,7 +47,15 @@ export function useLlmChat(): LlmChat {
 		llmStore.update((s) => startTurn(pushUser(s, `u-${seq}`, trimmed), requestId));
 		// Send the full prior transcript (the empty assistant turn is filtered out by toMessages).
 		const messages = toMessages(llmStore.getSnapshot());
-		await llmStream(requestId, messages);
+		try {
+			await llmStream(requestId, messages);
+		} catch (err) {
+			// `llm_stream` rejected before any `llm_delta` frame could arrive — e.g. the provider isn't
+			// configured/saved (load_llm_config -> None) or a backend error. The streaming turn we just
+			// opened would otherwise hang on "…" forever, so terminate it with the error: the same
+			// error path a server-side failure takes (applyDelta), making the cause visible.
+			handleDelta({ requestId, token: '', done: true, error: String(err) });
+		}
 		return requestId;
 	}, []);
 

--- a/client/src/lib/widgets/NavRail.css
+++ b/client/src/lib/widgets/NavRail.css
@@ -1541,6 +1541,40 @@
 	color: var(--ui-danger-fg);
 }
 
+/* AI-provider settings: per-provider auth chips (the active one outlined) + the unsaved-changes cue. */
+.canvas .plugins-panel .has-authrow {
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--space-2);
+	margin: 0 0 var(--space-4);
+}
+
+.canvas .plugins-panel .has-chip {
+	font-size: var(--text-md);
+	color: var(--ui-fg-dim);
+	background: var(--ui-raised);
+	border: 1px solid var(--ui-border);
+	border-radius: var(--radius-control);
+	padding: var(--space-1) var(--space-2);
+	white-space: nowrap;
+}
+
+.canvas .plugins-panel .has-chip.ok {
+	color: var(--ui-success-fg);
+}
+
+.canvas .plugins-panel .has-chip.active {
+	border-color: rgb(var(--ui-accent-rgb));
+	color: var(--ui-accent-fg);
+}
+
+/* Pushed to the right of the action row (and the status line); a calm warn tone, not an error. */
+.canvas .plugins-panel .has-unsaved {
+	margin-left: auto;
+	color: var(--ui-warn-fg);
+	font-size: var(--text-md);
+}
+
 /* HA entity browser: search + refresh bar, count, and the expose/copy entity rows. */
 .canvas .plugins-panel .has-browser-bar {
 	display: flex;

--- a/client/src/lib/widgets/plugins/LlmSettings.tsx
+++ b/client/src/lib/widgets/plugins/LlmSettings.tsx
@@ -37,6 +37,9 @@ import { sttAvailable, startRecording, type Recorder } from '../../stt';
 import type { LlmModel, LlmStatus } from './llm-types';
 
 type TestState = { kind: 'idle' } | { kind: 'ok'; msg: string } | { kind: 'err'; msg: string };
+// The model-picker's own status, kept SEPARATE from `test` so refresh feedback shows next to the
+// ↻ Models button (not buried under the Test/Save line at the bottom of the form).
+type ModelsState = TestState | { kind: 'loading' };
 
 export default function LlmSettings() {
 	const hub = useTelemetryHub();
@@ -57,8 +60,10 @@ export default function LlmSettings() {
 	const [agentControl, setAgentControl] = useState(false); // global
 	const [saving, setSaving] = useState(false);
 	const [saved, setSaved] = useState(false);
+	const [dirty, setDirty] = useState(false); // form differs from the saved plugins/llm.json
 	const [test, setTest] = useState<TestState>({ kind: 'idle' });
 	const [models, setModels] = useState<LlmModel[]>([]);
+	const [modelsState, setModelsState] = useState<ModelsState>({ kind: 'idle' });
 
 	// Auto-dismiss the "Saved ✓" tick like a toast (it otherwise lingers until the next edit).
 	useEffect(() => {
@@ -85,6 +90,7 @@ export default function LlmSettings() {
 		setTtsVoice(p?.ttsVoice ?? '');
 		setApiKey('');
 		setModels([]);
+		setModelsState({ kind: 'idle' });
 	};
 
 	useEffect(() => {
@@ -106,7 +112,12 @@ export default function LlmSettings() {
 		};
 	}, []);
 
-	const dirtied = () => setSaved(false);
+	// Any field edit marks the form dirty (and clears the Saved tick) so an "Unsaved — click Save" cue can
+	// nudge the user to persist — the #1 confusion was Test working while Chat/widgets need a saved config.
+	const dirtied = () => {
+		setSaved(false);
+		setDirty(true);
+	};
 	const onPickProvider = (id: string) => {
 		setProvider(id);
 		loadProvider(id, status);
@@ -114,6 +125,13 @@ export default function LlmSettings() {
 	};
 
 	const canSubmit = !saving && (!needsKey || hasKey || apiKey.trim().length > 0);
+	// Listing models needs auth, so disable refresh until a key is usable (saved or just typed).
+	const canListModels = !needsKey || hasKey || apiKey.trim().length > 0;
+	// The Chat tester + assistant call the SAVED active provider (the backend reads plugins/llm.json), so
+	// readiness tracks the saved file, NOT the in-progress form — surfacing this kills the "I added a key
+	// but chat hangs" trap (Test works unsaved; Chat needs a Save).
+	const activeReady = !!status?.configured;
+	const activeLabel = status?.active ? providerMeta(status.active).label : undefined;
 
 	// Build the typeahead options for a free-text Select: the live list (when loaded) else the samples.
 	const modelOptions = models.length
@@ -147,6 +165,7 @@ export default function LlmSettings() {
 			setStatus(next);
 			ingestLlmStatus(hub, next); // keep the Plugins-list dot live without a restart
 			setSaved(true);
+			setDirty(false);
 		} catch (err) {
 			setTest({ kind: 'err', msg: `Save failed: ${String(err)}` });
 		} finally {
@@ -162,6 +181,7 @@ export default function LlmSettings() {
 		try {
 			await saveLlmConfig(configBody({ agentControl: next }));
 			await (next ? controlStart() : controlStop());
+			setDirty(false); // configBody persisted every field, so the form now matches disk
 		} catch (err) {
 			setTest({ kind: 'err', msg: `Agent control: ${String(err)}` });
 		}
@@ -177,11 +197,21 @@ export default function LlmSettings() {
 		}
 	};
 
+	// List the provider's models for the CURRENT form (provider/url/key/insecure), so refresh works for
+	// a just-switched or not-yet-saved provider. Shows in-flight + result feedback next to the button —
+	// the prior version gave none, so an empty list or a buried error read as "nothing happens".
 	const onLoadModels = async () => {
+		setModelsState({ kind: 'loading' });
 		try {
-			setModels(await llmListModels());
+			const list = await llmListModels({ provider, baseUrl: baseUrl.trim(), apiKey, insecure });
+			setModels(list);
+			setModelsState(
+				list.length
+					? { kind: 'ok', msg: `Loaded ${list.length} model${list.length === 1 ? '' : 's'}` }
+					: { kind: 'err', msg: `${meta.label} returned no models (type the id manually)` }
+			);
 		} catch (err) {
-			setTest({ kind: 'err', msg: `Could not list models: ${String(err)}` });
+			setModelsState({ kind: 'err', msg: `Could not list models: ${String(err)}` });
 		}
 	};
 
@@ -212,14 +242,15 @@ export default function LlmSettings() {
 					))}
 				</select>
 			</label>
-			{/* Per-provider auth at a glance, so the multi-provider state is visible. */}
-			<div className="has-help">
-				Authenticated:{' '}
-				{PROVIDERS.map((p, i) => {
+			{/* Per-provider auth at a glance (the active one outlined), so the multi-provider state is visible. */}
+			<div className="has-authrow" aria-label="Provider authentication">
+				{PROVIDERS.map((p) => {
 					const keyed = !p.needsKey || !!status?.providers[p.id]?.hasKey;
 					return (
-						<span key={p.id}>
-							{i > 0 ? ' · ' : ''}
+						<span
+							key={p.id}
+							className={`has-chip${keyed ? ' ok' : ''}${p.id === provider ? ' active' : ''}`}
+						>
 							{p.label.split(' ')[0]} {keyed ? '✓' : '—'}
 						</span>
 					);
@@ -227,6 +258,7 @@ export default function LlmSettings() {
 			</div>
 			<div className="has-help">{meta.help}</div>
 
+			<div className="rp-hd">Connection</div>
 			<label className="has-field">
 				Base URL
 				<input
@@ -272,10 +304,21 @@ export default function LlmSettings() {
 						}}
 					/>
 				</label>
-				<button type="button" onClick={onLoadModels} title="List the provider's models">
-					↻ Models
+				<button
+					type="button"
+					onClick={onLoadModels}
+					disabled={modelsState.kind === 'loading' || !canListModels}
+					aria-busy={modelsState.kind === 'loading'}
+					title={canListModels ? "List the provider's models" : 'Enter an API key first'}
+				>
+					{modelsState.kind === 'loading' ? 'Loading…' : '↻ Models'}
 				</button>
 			</div>
+			{modelsState.kind === 'ok' && <div className="has-test ok">{modelsState.msg}</div>}
+			{modelsState.kind === 'err' && <div className="has-test err">⚠ {modelsState.msg}</div>}
+			<small className="has-help">
+				Blank uses the provider default; ↻ Models lists what your key can access.
+			</small>
 
 			{meta.supportsAudio && (
 				<>
@@ -403,12 +446,17 @@ export default function LlmSettings() {
 					Test
 				</button>
 				{saved && <span className="has-ok">Saved ✓</span>}
+				{!saved && dirty && <span className="has-unsaved">● Unsaved — click Save</span>}
 			</div>
-			{test.kind === 'ok' && <div className="has-ok">{test.msg}</div>}
-			{test.kind === 'err' && <div className="has-warn">⚠ {test.msg}</div>}
+			<small className="has-help">
+				<strong>Test</strong> checks the key without saving. <strong>Save</strong> persists it so
+				Chat, the assistant &amp; widgets can use the provider.
+			</small>
+			{test.kind === 'ok' && <div className="has-test ok">{test.msg}</div>}
+			{test.kind === 'err' && <div className="has-test err">⚠ {test.msg}</div>}
 
 			<LayoutAssistant sensorIds={() => hub.sensorIds()} />
-			<ChatTester />
+			<ChatTester ready={activeReady} activeLabel={activeLabel} />
 		</div>
 	);
 }
@@ -551,7 +599,7 @@ function LayoutAssistant({ sensorIds }: { sensorIds: () => string[] }) {
 
 // --- a quick streaming chat tester -----------------------------------------------------------
 
-function ChatTester() {
+function ChatTester({ ready, activeLabel }: { ready: boolean; activeLabel?: string }) {
 	const { chat, send, reset } = useLlmChat();
 	const [input, setInput] = useState('');
 	const logRef = useRef<HTMLDivElement>(null);
@@ -570,50 +618,64 @@ function ChatTester() {
 	return (
 		<>
 			<div className="rp-hd">Chat</div>
-			<div className="has-help">A quick test of the configured provider (streamed).</div>
-			{chat.turns.length > 0 && (
-				<div className="has-entities" ref={logRef} style={{ maxHeight: 180, overflowY: 'auto' }}>
-					{chat.turns.map((t) => (
-						<div key={t.id} className="has-entity" style={{ display: 'block' }}>
-							<span className="has-state-dim">{t.role === 'user' ? 'you' : 'ai'}</span>{' '}
-							<span>{t.error ? `⚠ ${t.error}` : t.content || (t.streaming ? '…' : '')}</span>
-							{t.role === 'assistant' && t.content && !t.streaming && ttsAvailable() && (
-								<button
-									type="button"
-									className="has-copy"
-									title="Read aloud"
-									aria-label="Read aloud"
-									onClick={() => void speakSmart(t.content)}
-								>
-									🔊
-								</button>
-							)}
-						</div>
-					))}
-				</div>
-			)}
-			<div className="has-browser-bar">
-				<label className="has-field" style={{ flex: 3 }}>
-					<input
-						type="text"
-						autoComplete="off"
-						placeholder="Ask anything…"
-						value={input}
-						onChange={(e) => setInput(e.currentTarget.value)}
-						onKeyDown={(e) => {
-							if (e.key === 'Enter') onSend();
-						}}
-					/>
-				</label>
-				<button type="button" className="has-primary" onClick={onSend} disabled={!input.trim()}>
-					Send
-				</button>
-				{chat.turns.length > 0 && (
-					<button type="button" onClick={reset} title="Clear the transcript">
-						Clear
-					</button>
-				)}
+			<div className="has-help">
+				A quick streamed test of the saved provider{activeLabel ? ` (${activeLabel})` : ''}.
 			</div>
+			{!ready ? (
+				// The chat calls the SAVED active provider — make the "you must Save first" requirement
+				// explicit instead of letting a send fail with an error turn.
+				<div className="has-warn">Save a configured provider above to start chatting.</div>
+			) : (
+				<>
+					{chat.turns.length > 0 && (
+						<div
+							className="has-entities"
+							ref={logRef}
+							style={{ maxHeight: 180, overflowY: 'auto' }}
+						>
+							{chat.turns.map((t) => (
+								<div key={t.id} className="has-entity" style={{ display: 'block' }}>
+									<span className="has-state-dim">{t.role === 'user' ? 'you' : 'ai'}</span>{' '}
+									<span>{t.error ? `⚠ ${t.error}` : t.content || (t.streaming ? '…' : '')}</span>
+									{t.role === 'assistant' && t.content && !t.streaming && ttsAvailable() && (
+										<button
+											type="button"
+											className="has-copy"
+											title="Read aloud"
+											aria-label="Read aloud"
+											onClick={() => void speakSmart(t.content)}
+										>
+											🔊
+										</button>
+									)}
+								</div>
+							))}
+						</div>
+					)}
+					<div className="has-browser-bar">
+						<label className="has-field" style={{ flex: 3 }}>
+							<input
+								type="text"
+								autoComplete="off"
+								placeholder="Ask anything…"
+								value={input}
+								onChange={(e) => setInput(e.currentTarget.value)}
+								onKeyDown={(e) => {
+									if (e.key === 'Enter') onSend();
+								}}
+							/>
+						</label>
+						<button type="button" className="has-primary" onClick={onSend} disabled={!input.trim()}>
+							Send
+						</button>
+						{chat.turns.length > 0 && (
+							<button type="button" onClick={reset} title="Clear the transcript">
+								Clear
+							</button>
+						)}
+					</div>
+				</>
+			)}
 		</>
 	);
 }

--- a/client/src/lib/widgets/plugins/llm-commands.ts
+++ b/client/src/lib/widgets/plugins/llm-commands.ts
@@ -57,8 +57,21 @@ export const llmComplete = (
 		maxTokens: opts?.maxTokens ?? null
 	});
 
-/** The configured provider's available models (best-effort; may be empty). */
-export const llmListModels = (): Promise<LlmModel[]> => invoke<LlmModel[]>(COMMANDS.llmListModels);
+/** The provider's available models (best-effort; may be empty). Pass the settings form's current
+ * (possibly unsaved) provider/url/key/insecure so the picker can refresh before Save; with nothing
+ * passed the backend uses the saved active config. A blank apiKey reuses the saved key. */
+export const llmListModels = (params?: {
+	provider?: string;
+	baseUrl?: string;
+	apiKey?: string;
+	insecure?: boolean;
+}): Promise<LlmModel[]> =>
+	invoke<LlmModel[]>(COMMANDS.llmListModels, {
+		provider: params?.provider ?? null,
+		baseUrl: params?.baseUrl ?? null,
+		apiKey: params?.apiKey ?? null,
+		insecure: params?.insecure ?? null
+	});
 
 /** Synthesize speech for `text` via the active provider's TTS endpoint (OpenAI-compatible only). Returns
  * the audio bytes + mime; rejects when the provider has no TTS endpoint or no key (caller falls back to

--- a/widgetsack/Cargo.toml
+++ b/widgetsack/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "widgetsack"
 # Keep in lockstep with tauri.conf.json's version (the bundle/updater source of truth).
-version = "0.0.37"
+version = "0.0.38"
 description = "widgetsack desktop widget platform"
 authors = ["you"]
 license = "MIT OR Apache-2.0"

--- a/widgetsack/src/llm.rs
+++ b/widgetsack/src/llm.rs
@@ -872,15 +872,33 @@ pub async fn llm_complete<R: Runtime>(
     chat_once(&cfg, &messages).await
 }
 
-/// The configured provider's available models (for the settings model picker). Best-effort: returns an
-/// empty list if the provider doesn't expose a catalog or the call fails.
+/// The available models for the settings model picker. Best-effort: an empty list when the provider
+/// has no catalog endpoint, an error string when the call fails. Accepts the settings form's
+/// (possibly UNSAVED) provider / url / key / insecure so the picker can refresh BEFORE Save — mirrors
+/// `llm_test_connection`. With no provider it falls back to the saved active config; a blank key
+/// resolves to that provider's saved one (the UI holds the key write-only).
 #[tauri::command]
-pub async fn llm_list_models<R: Runtime>(app: AppHandle<R>) -> Result<Vec<LlmModel>, String> {
-    let cfg = load_llm_config(&app)?.ok_or("AI provider not configured")?;
-    let base = effective_base(&cfg);
-    let url = models_endpoint(&cfg.provider, &base);
-    let client = llm_http_client(cfg.insecure)?;
-    let resp = apply_auth(client.get(&url), &cfg.provider, &cfg.api_key)
+pub async fn llm_list_models<R: Runtime>(
+    app: AppHandle<R>,
+    provider: Option<String>,
+    base_url: Option<String>,
+    api_key: Option<String>,
+    insecure: Option<bool>,
+) -> Result<Vec<LlmModel>, String> {
+    let (provider, base, key, insecure) = match provider.filter(|p| !p.is_empty()) {
+        Some(p) => {
+            let key = resolve_key(&app, &p, api_key.unwrap_or_default())?;
+            let base = effective_base_of(&p, &base_url.unwrap_or_default());
+            (p, base, key, insecure.unwrap_or(false))
+        }
+        None => {
+            let cfg = load_llm_config(&app)?.ok_or("AI provider not configured")?;
+            (cfg.provider.clone(), effective_base(&cfg), cfg.api_key, cfg.insecure)
+        }
+    };
+    let url = models_endpoint(&provider, &base);
+    let client = llm_http_client(insecure)?;
+    let resp = apply_auth(client.get(&url), &provider, &key)
         .send()
         .await
         .map_err(|e| e.to_string())?;
@@ -888,7 +906,7 @@ pub async fn llm_list_models<R: Runtime>(app: AppHandle<R>) -> Result<Vec<LlmMod
         return Err(format!("could not list models: HTTP {}", resp.status()));
     }
     let v: Value = resp.json().await.map_err(|e| e.to_string())?;
-    Ok(parse_models(&cfg.provider, &v))
+    Ok(parse_models(&provider, &v))
 }
 
 /// Transcribe recorded audio (speech-to-text). The webview captures the mic (getUserMedia/MediaRecorder)

--- a/widgetsack/tauri.conf.json
+++ b/widgetsack/tauri.conf.json
@@ -49,7 +49,7 @@
     "createUpdaterArtifacts": false
   },
   "productName": "widgetsack",
-  "version": "0.0.37",
+  "version": "0.0.38",
   "identifier": "io.github.gyng",
   "plugins": {},
   "app": {


### PR DESCRIPTION
## Problem
With a key entered, **Chat \"hello\" stuck on \"…\" forever**, and the model picker **\"couldn't refresh / change model, no feedback\"**.

Root cause: `llm_stream` and `llm_list_models` read a **saved** `plugins/llm.json`, but the UI let you **Test** a key without **Saving** it. So Chat/refresh rejected with *\"AI provider not configured\"* — and the rejection was **swallowed** (`void send()` → eternal \"…\") or **buried** at the bottom of the form (models). The key + endpoint were never the issue (verified: `GET /v1/models` → 200).

## Fixes
- **`useLlmChat`** — if `llm_stream` rejects, terminate the open streaming turn with the error (same path a server-side failure takes) instead of hanging on \"…\". New regression test `useLlmChat.test.ts`.
- **`llm_list_models`** — now takes the settings form's (possibly **unsaved**) provider/url/key/insecure, like `llm_test_connection`, so **↻ Models works before Save**; a blank key reuses the saved one; falls back to the saved active config when nothing is passed.
- **Refresh feedback** — in-flight state + *\"Loaded N models\"* / *\"no models\"* / error, inline next to the button.

## Settings refinement (all four requested areas)
- **Flow clarity** — *\"Unsaved — click Save\"* cue; a Test-vs-Save helper line; the **Chat tester is gated** until a provider is saved & configured (names the active provider).
- **Grouping** — `Provider` / `Connection` / `Speech` / `Advanced` section headers; the *Authenticated* line is now provider **chips** with the active one outlined.
- **Model picker** — ↻ Models disabled until a key is usable (*\"Enter an API key first\"*); default-model hint.
- **Status/errors** — results use the dedicated `has-test` styling; refresh feedback sits by its button.

## Verification
- Client: `check` ✓ · `lint` ✓ (0 warnings) · `test:unit` ✓ **1304** · `build` ✓
- Backend (Windows): `cargo test` ✓ **176** · `cargo clippy --all-targets` ✓ clean

Version bump 0.0.37 → **0.0.38**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)