### PR TITLE
fix(ai-provider): clickable model picker, non-blank default, gpt-5 token param (0.0.39)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5130,7 +5130,7 @@ dependencies = [
 
 [[package]]
 name = "widgetsack"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "fontdb",
  "futures-util",

--- a/client/src/lib/widgets/Select.test.tsx
+++ b/client/src/lib/widgets/Select.test.tsx
@@ -51,6 +51,14 @@ describe('Select (combobox variant: typeahead)', () => {
 		expect(onChange).toHaveBeenCalledWith('s.7');
 	});
 
+	it('opens the menu on a plain click of the input (not just the ▾ caret)', () => {
+		const onChange = vi.fn();
+		render(<Select value="" options={SENSORS} onChange={onChange} searchable />);
+		fireEvent.click(screen.getByRole('combobox')); // click the field itself
+		fireEvent.click(screen.getByText('Sensor 5')); // the list is open → pick from it
+		expect(onChange).toHaveBeenCalledWith('s.5');
+	});
+
 	it('accepts a typed custom value when allowCustom (commits live, like the sensor field)', () => {
 		const onChange = vi.fn();
 		render(<Select value="" options={SENSORS} onChange={onChange} allowCustom />);

--- a/client/src/lib/widgets/Select.tsx
+++ b/client/src/lib/widgets/Select.tsx
@@ -188,7 +188,8 @@ function SelectCombobox({
 		getMenuProps,
 		getInputProps,
 		getToggleButtonProps,
-		getItemProps
+		getItemProps,
+		openMenu
 	} = useCombobox<SelectOption>({
 		items,
 		inputValue,
@@ -237,6 +238,10 @@ function SelectCombobox({
 					placeholder={placeholder}
 					title={title}
 					{...getInputProps({ disabled, 'aria-label': ariaLabel })}
+					// Open the list on a plain click of the field (not just the ▾ caret) — clicking a combobox
+					// to see its options is what users expect ("I can't click to choose"). Attached after the
+					// prop-getter spread so it isn't dropped; useCombobox sets no onClick of its own to compose.
+					onClick={() => openMenu()}
 				/>
 				<button
 					type="button"

--- a/client/src/lib/widgets/plugins/LlmSettings.tsx
+++ b/client/src/lib/widgets/plugins/LlmSettings.tsx
@@ -83,11 +83,14 @@ export default function LlmSettings() {
 		const m = providerMeta(id);
 		const p = st?.providers[id];
 		setBaseUrl(p?.baseUrl ?? m.defaultBaseUrl);
-		setModel(p?.model ?? '');
+		// Default each model field to the provider's first sample (which mirrors the backend
+		// default_model / whisper-1 / tts-1 / alloy) instead of blank, so there's always a selected item
+		// to start from rather than an empty box.
+		setModel(p?.model || m.sampleModels[0] || '');
 		setInsecure(p?.insecure ?? false);
-		setSttModel(p?.sttModel ?? '');
-		setTtsModel(p?.ttsModel ?? '');
-		setTtsVoice(p?.ttsVoice ?? '');
+		setSttModel(p?.sttModel || m.sampleSttModels[0] || '');
+		setTtsModel(p?.ttsModel || m.sampleTtsModels[0] || '');
+		setTtsVoice(p?.ttsVoice || m.sampleVoices[0] || '');
 		setApiKey('');
 		setModels([]);
 		setModelsState({ kind: 'idle' });

--- a/widgetsack/Cargo.toml
+++ b/widgetsack/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "widgetsack"
 # Keep in lockstep with tauri.conf.json's version (the bundle/updater source of truth).
-version = "0.0.38"
+version = "0.0.39"
 description = "widgetsack desktop widget platform"
 authors = ["you"]
 license = "MIT OR Apache-2.0"

--- a/widgetsack/src/llm.rs
+++ b/widgetsack/src/llm.rs
@@ -489,14 +489,32 @@ fn build_chat_body(
             "stream": stream,
             "options": { "temperature": temperature, "num_predict": max_tokens },
         }),
-        _ => json!({
-            "model": model,
-            "messages": messages_json(provider, messages),
-            "stream": stream,
-            "temperature": temperature,
-            "max_tokens": max_tokens,
-        }),
+        _ => {
+            let mut body = json!({
+                "model": model,
+                "messages": messages_json(provider, messages),
+                "stream": stream,
+            });
+            if uses_completion_tokens(model) {
+                // Next-gen / reasoning OpenAI models (gpt-5*, o-series) REJECT the legacy `max_tokens`
+                // ("use max_completion_tokens instead") and also reject a non-default `temperature`, so
+                // send the new field and omit temperature — otherwise every request 400s.
+                body["max_completion_tokens"] = json!(max_tokens);
+            } else {
+                body["temperature"] = json!(temperature);
+                body["max_tokens"] = json!(max_tokens);
+            }
+            body
+        }
     }
+}
+
+/// Whether an OpenAI-style model needs `max_completion_tokens` (and no custom temperature) instead of
+/// the legacy `max_tokens`. True for the reasoning o-series (o1/o3/o4…) and the gpt-5 family; older
+/// models (gpt-4o…) and most OpenAI-compatible servers still take `max_tokens`.
+fn uses_completion_tokens(model: &str) -> bool {
+    let m = model.trim();
+    m.starts_with("gpt-5") || m.starts_with("o1") || m.starts_with("o3") || m.starts_with("o4")
 }
 
 /// Extract the assistant's reply text from a non-streamed response body, per provider.
@@ -1285,6 +1303,34 @@ mod tests {
         assert_eq!(m[0].id, "gpt-4o");
         let oll = serde_json::json!({ "models": [ { "name": "llama3.2" } ] });
         assert_eq!(parse_models("ollama", &oll)[0].id, "llama3.2");
+    }
+
+    #[test]
+    fn uses_completion_tokens_matches_next_gen_families() {
+        for m in ["gpt-5", "gpt-5-nano", "gpt-5.1", "o1", "o1-mini", "o3-mini", "o4-mini"] {
+            assert!(uses_completion_tokens(m), "{m} should use max_completion_tokens");
+        }
+        for m in ["gpt-4o", "gpt-4o-mini", "gpt-4-turbo", "llama3.2", ""] {
+            assert!(!uses_completion_tokens(m), "{m} should keep max_tokens");
+        }
+    }
+
+    #[test]
+    fn openai_body_picks_the_right_token_param_per_model() {
+        let msgs = vec![ChatMessage {
+            role: "user".into(),
+            content: "hi".into(),
+        }];
+        // Legacy model: temperature + max_tokens, no max_completion_tokens.
+        let legacy = build_chat_body("openai", "gpt-4o-mini", &msgs, 0.5, 100, false);
+        assert_eq!(legacy["max_tokens"], 100);
+        assert_eq!(legacy["temperature"], 0.5);
+        assert!(legacy.get("max_completion_tokens").is_none());
+        // Next-gen model: max_completion_tokens, and NO max_tokens / NO temperature (both 400 there).
+        let next = build_chat_body("openai", "gpt-5-nano", &msgs, 0.5, 100, false);
+        assert_eq!(next["max_completion_tokens"], 100);
+        assert!(next.get("max_tokens").is_none());
+        assert!(next.get("temperature").is_none());
     }
 
     #[test]

--- a/widgetsack/tauri.conf.json
+++ b/widgetsack/tauri.conf.json
@@ -49,7 +49,7 @@
     "createUpdaterArtifacts": false
   },
   "productName": "widgetsack",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "identifier": "io.github.gyng",
   "plugins": {},
   "app": {


### PR DESCRIPTION
Three model-selection fixes in the AI provider settings.

## 1. Click to choose
The shared `Select` combobox only opened its list via the tiny ▾ caret (or by typing) — clicking the field did nothing. It now **opens on a plain click of the input**, so the model / STT / TTS / voice pickers (and every studio combobox) are pickable by clicking. Regression test added.

## 2. Non-blank default
Each model field now defaults to the provider's **first sample** instead of an empty box — and that sample mirrors the backend exactly: `gpt-4o-mini` (OpenAI), `claude-sonnet-4-5` (Anthropic), `llama3.2` (Ollama), plus `whisper-1` / `tts-1` / `alloy` for speech.

## 3. gpt-5 / o-series chat error
Newer OpenAI models reject `max_tokens` (*"unsupported params max_tokens, use max_completion_tokens instead"*) and a custom `temperature`. `build_chat_body` now sends **`max_completion_tokens`** and omits temperature for `gpt-5*` / `o1` / `o3` / `o4`, while older models (`gpt-4o…`) and OpenAI-compatible servers keep `max_tokens`. Fixes chat erroring on `gpt-5-nano`. Per-model Rust tests added.

## Verification
- Client: `check` ✓ · `lint` ✓ (0 warnings) · `test:unit` ✓ **1305** · `build` ✓
- Backend (Windows): `cargo test` ✓ · `cargo clippy --all-targets` ✓ clean

Version bump 0.0.38 → **0.0.39**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)