### PR TITLE
fix(launch): open the studio when started from a shortcut + clean up legacy np (0.0.41)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5130,7 +5130,7 @@ dependencies = [
 
 [[package]]
 name = "widgetsack"
-version = "0.0.40"
+version = "0.0.41"
 dependencies = [
  "fontdb",
  "futures-util",

--- a/widgetsack/Cargo.toml
+++ b/widgetsack/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "widgetsack"
 # Keep in lockstep with tauri.conf.json's version (the bundle/updater source of truth).
-version = "0.0.40"
+version = "0.0.41"
 description = "widgetsack desktop widget platform"
 authors = ["you"]
 license = "MIT OR Apache-2.0"

--- a/widgetsack/src/main.rs
+++ b/widgetsack/src/main.rs
@@ -68,6 +68,16 @@ fn open_or_focus_studio(app: &tauri::AppHandle) {
         let _ = app.emit(bridge::OPEN_STUDIO_EVENT, ());
         return;
     }
+    build_studio_window(app);
+}
+
+/// Build the studio webview window directly (mirrors overlay.ts `openStudio`). Split out of
+/// `open_or_focus_studio` so the `--studio` startup launch can build it WITHOUT going through the
+/// main overlay's JS — at boot that webview hasn't registered the `open_studio` listener yet.
+fn build_studio_window(app: &tauri::AppHandle) {
+    if app.get_webview_window("studio").is_some() {
+        return;
+    }
     if let Err(err) =
         tauri::WebviewWindowBuilder::new(app, "studio", tauri::WebviewUrl::App("/".into()))
             .title("WidgetSack Studio")
@@ -81,6 +91,14 @@ fn open_or_focus_studio(app: &tauri::AppHandle) {
             .field("error", err)
             .emit();
     }
+}
+
+/// Whether this process was launched to open the designer. The Start Menu / desktop shortcuts and the
+/// installer's "Run WidgetSack" checkbox pass `--studio`, so starting the app manually shows the
+/// studio window instead of just the silent (and, on a fresh install, empty) overlay. Autostart at
+/// login passes no flag and stays silent.
+fn launched_with_studio_flag() -> bool {
+    std::env::args().any(|arg| arg == "--studio")
 }
 
 /// The window-state the app persists across runs: size / position / maximized / fullscreen, but NOT
@@ -287,6 +305,13 @@ async fn main() -> Result<(), ()> {
             // the OS Run key on every manual upgrade, so this is what makes the setting survive an
             // install (autostart.rs).
             autostart::reconcile(app.handle());
+
+            // `--studio` (shortcuts + installer "Run") opens the designer on a manual launch, so the
+            // app shows a window instead of just the silent overlay. Built directly here because the
+            // overlay webview isn't ready to receive `open_studio` yet at boot.
+            if launched_with_studio_flag() {
+                build_studio_window(app.handle());
+            }
 
             tauri::async_runtime::spawn(async move {
                 session_listener_windows_gsmtc(rx_session_manager, tx_gsmtc).await

--- a/widgetsack/tauri.conf.json
+++ b/widgetsack/tauri.conf.json
@@ -50,7 +50,7 @@
     "createUpdaterArtifacts": false
   },
   "productName": "widgetsack",
-  "version": "0.0.40",
+  "version": "0.0.41",
   "identifier": "io.github.gyng",
   "plugins": {},
   "app": {

--- a/widgetsack/windows/hooks.nsh
+++ b/widgetsack/windows/hooks.nsh
@@ -30,6 +30,18 @@
   ; so clear the leftover folder an upgrade would otherwise orphan. Runs AFTER the new
   ; shortcuts are created — the root-level widgetsack.lnk is untouched.
   RMDir /r "$SMPROGRAMS\widgetsack"
+
+  ; widgetsack evolved from the "np" (nowplaying-widget) app and kept its bundle identifier
+  ; (io.github.gyng). Windows de-dupes Start entries by AppUserModelID, so a leftover np.lnk from the
+  ; old app shadows widgetsack's shortcut — Start lists the app as "np" and searching "widgetsack"
+  ; finds nothing (the reported "doesn't show up in start"). Remove the legacy np shortcuts and its
+  ; autostart entries (the shared identifier would also collide with single-instance). np autostarts
+  ; via a Startup-folder shortcut (and possibly a Run key), so clear both. The old np install itself
+  ; is left alone — uninstall it via its own entry in Apps & features.
+  Delete "$SMPROGRAMS\np.lnk"
+  Delete "$DESKTOP\np.lnk"
+  Delete "$SMSTARTUP\np.lnk"
+  DeleteRegValue HKCU "Software\Microsoft\Windows\CurrentVersion\Run" "np"
 !macroend
 
 !macro NSIS_HOOK_PREUNINSTALL

--- a/widgetsack/windows/installer.nsi
+++ b/widgetsack/windows/installer.nsi
@@ -426,7 +426,9 @@ Var AppStartMenuFolder
 !insertmacro MUI_PAGE_FINISH
 
 Function RunMainBinary
-  nsis_tauri_utils::RunAsUser "$INSTDIR\${MAINBINARYNAME}.exe" ""
+  ; WIDGETSACK: --studio so the finish-page "Run WidgetSack" checkbox opens the designer rather than
+  ; launching a silent, empty overlay the user can't see.
+  nsis_tauri_utils::RunAsUser "$INSTDIR\${MAINBINARYNAME}.exe" "--studio"
 FunctionEnd
 
 ; WIDGETSACK launch-at-login checkbox. The finish page is an nsDialogs page, so we append a third
@@ -986,12 +988,14 @@ Function CreateOrUpdateStartMenuShortcut
     ${EndIf}
   ${EndIf}
 
+  ; WIDGETSACK: launch shortcuts with --studio so starting the app opens the designer (a fresh
+  ; launch is otherwise just a silent, empty overlay). Autostart at login passes no flag → silent.
   !if "${STARTMENUFOLDER}" != ""
     CreateDirectory "$SMPROGRAMS\$AppStartMenuFolder"
-    CreateShortcut "$SMPROGRAMS\$AppStartMenuFolder\${PRODUCTNAME}.lnk" "$INSTDIR\${MAINBINARYNAME}.exe"
+    CreateShortcut "$SMPROGRAMS\$AppStartMenuFolder\${PRODUCTNAME}.lnk" "$INSTDIR\${MAINBINARYNAME}.exe" "--studio"
     !insertmacro SetLnkAppUserModelId "$SMPROGRAMS\$AppStartMenuFolder\${PRODUCTNAME}.lnk"
   !else
-    CreateShortcut "$SMPROGRAMS\${PRODUCTNAME}.lnk" "$INSTDIR\${MAINBINARYNAME}.exe"
+    CreateShortcut "$SMPROGRAMS\${PRODUCTNAME}.lnk" "$INSTDIR\${MAINBINARYNAME}.exe" "--studio"
     !insertmacro SetLnkAppUserModelId "$SMPROGRAMS\${PRODUCTNAME}.lnk"
   !endif
 FunctionEnd
@@ -1015,6 +1019,7 @@ Function CreateOrUpdateDesktopShortcut
     ${EndIf}
   ${EndIf}
 
-  CreateShortcut "$DESKTOP\${PRODUCTNAME}.lnk" "$INSTDIR\${MAINBINARYNAME}.exe"
+  ; WIDGETSACK: --studio so the desktop shortcut opens the designer (see start-menu shortcut above).
+  CreateShortcut "$DESKTOP\${PRODUCTNAME}.lnk" "$INSTDIR\${MAINBINARYNAME}.exe" "--studio"
   !insertmacro SetLnkAppUserModelId "$DESKTOP\${PRODUCTNAME}.lnk"
 FunctionEnd


### PR DESCRIPTION
## Problem
Reported: "Run WidgetSack doesn't work after install" and "doesn't show up in Start".

Two root causes, found by inspecting an installed machine:
1. **Starting the app shows nothing.** A fresh launch is a transparent, click-through, taskbar-less overlay — empty on a new install — so there's no visible window and it looks like nothing happened (`RunAsUser` actually *does* launch it).
2. **Listed as "np", not "widgetsack".** The app evolved from `np` (nowplaying-widget) and kept the bundle identifier `io.github.gyng`. The old `np` app was still installed, and Windows de-dupes Start entries by AppUserModelID — so a leftover `np.lnk` shadowed `widgetsack.lnk` (Start showed "np"; searching "widgetsack" found nothing). Its **Startup-folder** `np.lnk` also autostarted the old app, colliding with widgetsack's single-instance guard.

## Fix
- **Launch → studio.** Shortcuts (Start Menu + desktop) and the installer's "Run WidgetSack" checkbox now pass `--studio`; the app builds the studio window at startup when launched with it (`build_studio_window` in `main.rs` setup). **Autostart at login passes no flag and stays a silent overlay.** Verified at runtime: `--studio` opens a `WidgetSack Studio` window; a bare launch does not.
- **Legacy np cleanup (installer hook).** On install, delete the legacy `np` Start / desktop / **Startup-folder** shortcuts and its Run-key entry, so the rename stops shadowing the Start entry and stops the old app autostarting. The old `np` install itself is left for the user to remove via Apps & features.

## Verification
- `cargo clippy` clean; `cargo tauri build` → `widgetsack_0.0.41_x64-setup.exe`; rendered installer confirmed to carry `--studio` on all shortcuts + the Run checkbox, and the build `!include`s the updated `hooks.nsh` np cleanup.
- Runtime: launched the built exe with `--studio` (studio window appears) and without (silent overlay, no studio).

🤖 Generated with [Claude Code](https://claude.com/claude-code)