### PR TITLE
feat(settings): app update check in About + SLSA build provenance (0.0.42)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,8 @@ jobs:
   build-tauri:
     permissions:
       contents: write
+      id-token: write # mint the OIDC token actions/attest-build-provenance signs the provenance with
+      attestations: write # write the provenance attestation to the repo
     strategy:
       fail-fast: false
       matrix:
@@ -77,3 +79,12 @@ jobs:
             echo "Upload attempt $attempt failed; retrying in 20s…"; sleep 20
           done
           echo "::error::release upload failed after 5 attempts"; exit 1
+      - name: Attest build provenance
+        # SLSA provenance for the exact installer we just published — proves it was built by THIS
+        # workflow from THIS commit (no reproducible build needed). Verify a downloaded asset with:
+        #   gh attest verify widgetsack_<ver>_x64-setup.exe --repo gyng/widgetsack
+        # Release events only: dispatch builds aren't published, so there's nothing to attest.
+        if: github.event_name == 'release'
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: "target/release/bundle/nsis/*-setup.exe"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5130,7 +5130,7 @@ dependencies = [
 
 [[package]]
 name = "widgetsack"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "fontdb",
  "futures-util",

--- a/client/src/lib/bridge/contract.ts
+++ b/client/src/lib/bridge/contract.ts
@@ -88,6 +88,8 @@ export const COMMANDS = {
 	setSubsystemProfiling: 'set_subsystem_profiling',
 	subsystemTimings: 'subsystem_timings',
 	getLogs: 'get_logs',
+	// app update check — GitHub latest release vs the running version (command.rs)
+	checkAppUpdate: 'check_app_update',
 	// fonts (command.rs)
 	systemFonts: 'system_fonts',
 	// sensors / telemetry demand-gating (sensors.rs)

--- a/client/src/lib/devMock.ts
+++ b/client/src/lib/devMock.ts
@@ -76,6 +76,15 @@ export function installDevMock(opts: { layout?: string } = {}): void {
 			case COMMANDS.autostartSet:
 				return false;
 
+			// --- app update check: pretend we're current ---
+			case COMMANDS.checkAppUpdate:
+				return {
+					current: '0.0.0',
+					latest: '0.0.0',
+					url: 'https://github.com/gyng/widgetsack/releases',
+					update_available: false
+				};
+
 			// --- Home Assistant proxy: not configured, no entities. Catalogs MUST be [] (not null) —
 			// ha-source caches the result and later .map()s it; a null would throw on the next read. ---
 			case COMMANDS.haConnect:

--- a/client/src/lib/overlay.ts
+++ b/client/src/lib/overlay.ts
@@ -578,6 +578,28 @@ export async function openDevtools(): Promise<void> {
 	}
 }
 
+// --- app update check ---
+// Manual check (About panel): the backend (command.rs check_app_update) asks GitHub for the latest
+// published release and compares it to the running version — the app ships no auto-updater.
+
+export type AppUpdate = {
+	current: string;
+	latest: string;
+	url: string;
+	updateAvailable: boolean;
+};
+
+/** Check GitHub for a newer release. Throws on network/parse failure (the caller surfaces it). */
+export async function checkAppUpdate(): Promise<AppUpdate> {
+	const r = await invoke<{
+		current: string;
+		latest: string;
+		url: string;
+		update_available: boolean;
+	}>(COMMANDS.checkAppUpdate);
+	return { current: r.current, latest: r.latest, url: r.url, updateAvailable: r.update_available };
+}
+
 // --- launch at login ---
 // Backed by tauri-plugin-autostart, but routed through our own commands (autostart.rs) so a durable
 // preference is persisted alongside the OS Run key — the Run key alone doesn't survive a manual

--- a/client/src/lib/widgets/StudioSettingsPanel.tsx
+++ b/client/src/lib/widgets/StudioSettingsPanel.tsx
@@ -3,13 +3,65 @@
 // the prefs/handlers it surfaces stay owned by Canvas and arrive as grouped props; the only module
 // calls it makes itself are the stateless overlay helpers (devtools / rescue / clipboard). Lazy-
 // loaded like the other studio panels (Canvas's lazy() block), so the overlay never fetches it.
+import { useState } from 'react';
 import type { Rect } from '../core/layout';
 import type { ControlOverrides, Trigger } from '../core/controls';
 import type { OverlayLayer, OverlayPrefs } from './canvas/overlayPrefs';
-import { copyToClipboard, openDevtools, rescueWindows } from '../overlay';
+import { checkAppUpdate, copyToClipboard, openDevtools, rescueWindows } from '../overlay';
 import ControlsPanel from './ControlsPanel';
 import DiagnosticsPanel from './DiagnosticsPanel';
 import mascotUrl from '../../assets/mascot.png';
+
+// About → "Check for updates": asks the backend (GitHub latest release vs the running version) on
+// demand and reports the result inline. Local state only — closing the panel resets it, which is
+// fine for a manual check (mirrors the per-package update check in PluginsPanel).
+type AppUpdateState =
+	| { kind: 'idle' }
+	| { kind: 'busy' }
+	| { kind: 'current'; current: string }
+	| { kind: 'update'; latest: string; url: string }
+	| { kind: 'error'; message: string };
+
+function AppUpdateCheck() {
+	const [state, setState] = useState<AppUpdateState>({ kind: 'idle' });
+	const onCheck = async () => {
+		setState({ kind: 'busy' });
+		try {
+			const r = await checkAppUpdate();
+			setState(
+				r.updateAvailable
+					? { kind: 'update', latest: r.latest, url: r.url }
+					: { kind: 'current', current: r.current }
+			);
+		} catch (err) {
+			setState({ kind: 'error', message: err instanceof Error ? err.message : String(err) });
+		}
+	};
+	return (
+		<>
+			<div className="rp-hd">Updates</div>
+			<button type="button" disabled={state.kind === 'busy'} onClick={() => void onCheck()}>
+				{state.kind === 'busy' ? 'Checking…' : '⟳ Check for updates'}
+			</button>
+			{state.kind === 'current' && (
+				<div className="pl-desc">You’re up to date (v{state.current}).</div>
+			)}
+			{state.kind === 'update' && (
+				<div className="rp-row">
+					<span>v{state.latest} available</span>
+					<button type="button" onClick={() => void copyToClipboard(state.url)}>
+						copy link
+					</button>
+				</div>
+			)}
+			{state.kind === 'error' && (
+				<div className="pl-desc" title={state.message}>
+					Update check failed: {state.message}
+				</div>
+			)}
+		</>
+	);
+}
 
 // Settings subsections — a side list (mirrors the Plugins list+detail split) so the pane shows one
 // focused topic at a time (progressive disclosure / chunking) instead of one long scroll, and each
@@ -289,13 +341,14 @@ export default function StudioSettingsPanel({
 								<span className="dim">MIT OR Apache-2.0</span>
 							</div>
 						</div>
+						<AppUpdateCheck />
 						<div className="rp-hd">Source</div>
 						<div className="rp-row">
-							<span className="set-repo">github.com/gyng/nowplaying-widget</span>
+							<span className="set-repo">github.com/gyng/widgetsack</span>
 							<button
 								type="button"
 								onClick={() => {
-									void copyToClipboard('https://github.com/gyng/nowplaying-widget');
+									void copyToClipboard('https://github.com/gyng/widgetsack');
 								}}
 							>
 								copy

--- a/widgetsack/Cargo.toml
+++ b/widgetsack/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "widgetsack"
 # Keep in lockstep with tauri.conf.json's version (the bundle/updater source of truth).
-version = "0.0.41"
+version = "0.0.42"
 description = "widgetsack desktop widget platform"
 authors = ["you"]
 license = "MIT OR Apache-2.0"

--- a/widgetsack/src/command.rs
+++ b/widgetsack/src/command.rs
@@ -804,6 +804,79 @@ async fn fetch_text_capped(client: &reqwest::Client, url: &str) -> Result<String
     String::from_utf8(buf).map_err(|_| format!("{url} is not valid UTF-8"))
 }
 
+/// GitHub releases API for the app's own repo — the manual "check for updates" source (the app
+/// ships no auto-updater, so this just tells the user a newer release exists).
+const GITHUB_LATEST_RELEASE_API: &str =
+    "https://api.github.com/repos/gyng/widgetsack/releases/latest";
+const RELEASES_PAGE: &str = "https://github.com/gyng/widgetsack/releases";
+
+#[derive(Serialize)]
+pub struct AppUpdate {
+    pub current: String,
+    pub latest: String,
+    pub url: String,
+    pub update_available: bool,
+}
+
+/// Parse an `X.Y.Z` version into a comparable tuple, tolerating a leading `v` and a `-pre`/`+build`
+/// suffix; any missing or non-numeric part is 0 so a malformed tag never falsely reports an update.
+fn parse_version(v: &str) -> (u32, u32, u32) {
+    let core = v.trim().trim_start_matches('v');
+    let core = core.split(['-', '+']).next().unwrap_or(core);
+    let mut parts = core.split('.').map(|p| p.parse::<u32>().unwrap_or(0));
+    (
+        parts.next().unwrap_or(0),
+        parts.next().unwrap_or(0),
+        parts.next().unwrap_or(0),
+    )
+}
+
+/// Whether `latest` is a newer version than `current` (numeric X.Y.Z compare). Pure seam.
+fn version_is_newer(latest: &str, current: &str) -> bool {
+    parse_version(latest) > parse_version(current)
+}
+
+/// Ask GitHub for the latest published release of the app and compare it to the running version.
+/// Manual (driven by the About panel button); best-effort — any network/parse failure is returned
+/// as an `Err` the UI shows verbatim. The GitHub REST API requires a User-Agent.
+#[tauri::command]
+pub async fn check_app_update(app: tauri::AppHandle) -> Result<AppUpdate, String> {
+    let current = app.package_info().version.to_string();
+    let client = install_http_client()?;
+    let resp = client
+        .get(GITHUB_LATEST_RELEASE_API)
+        .header(reqwest::header::USER_AGENT, "widgetsack")
+        .header(reqwest::header::ACCEPT, "application/vnd.github+json")
+        .send()
+        .await
+        .map_err(|e| format!("update check failed: {e}"))?;
+    if !resp.status().is_success() {
+        return Err(format!("update check failed: HTTP {}", resp.status()));
+    }
+    let json: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| format!("update check failed: {e}"))?;
+    let latest = json
+        .get("tag_name")
+        .and_then(|v| v.as_str())
+        .ok_or("update check failed: no tag_name in latest release")?
+        .trim_start_matches('v')
+        .to_string();
+    let url = json
+        .get("html_url")
+        .and_then(|v| v.as_str())
+        .unwrap_or(RELEASES_PAGE)
+        .to_string();
+    let update_available = version_is_newer(&latest, &current);
+    Ok(AppUpdate {
+        current,
+        latest,
+        url,
+        update_available,
+    })
+}
+
 #[derive(Serialize)]
 pub struct InstalledPackage {
     pub id: String,
@@ -1223,7 +1296,23 @@ pub fn watch_controls(app: tauri::AppHandle) -> Result<(), String> {
 
 #[cfg(test)]
 mod tests {
-    use super::valid_name;
+    use super::{valid_name, version_is_newer};
+
+    #[test]
+    fn version_is_newer_compares_numerically() {
+        assert!(version_is_newer("0.0.42", "0.0.41"));
+        assert!(version_is_newer("0.1.0", "0.0.41")); // 0.1.0 > 0.0.41, not string compare
+        assert!(version_is_newer("1.0.0", "0.9.9"));
+        assert!(!version_is_newer("0.0.41", "0.0.41")); // equal → no update
+        assert!(!version_is_newer("0.0.40", "0.0.41")); // older
+    }
+
+    #[test]
+    fn version_is_newer_tolerates_v_prefix_and_suffixes() {
+        assert!(version_is_newer("v0.0.42", "0.0.41"));
+        assert!(!version_is_newer("0.0.41-rc1", "0.0.41")); // pre-release suffix stripped → equal
+        assert!(!version_is_newer("garbage", "0.0.1")); // unparseable → (0,0,0), no false update
+    }
 
     #[test]
     fn valid_name_accepts_plain_tokens() {

--- a/widgetsack/src/main.rs
+++ b/widgetsack/src/main.rs
@@ -234,6 +234,7 @@ async fn main() -> Result<(), ()> {
             command::rescue_windows,
             command::reload_window,
             command::log_diag,
+            command::check_app_update,
             command::system_fonts,
             display::list_display_names,
             clickthrough::set_interactive_rects,

--- a/widgetsack/tauri.conf.json
+++ b/widgetsack/tauri.conf.json
@@ -50,7 +50,7 @@
     "createUpdaterArtifacts": false
   },
   "productName": "widgetsack",
-  "version": "0.0.41",
+  "version": "0.0.42",
   "identifier": "io.github.gyng",
   "plugins": {},
   "app": {


### PR DESCRIPTION
## App update check (About)
A **"⟳ Check for updates"** button in Settings → About. The backend (`check_app_update`) queries GitHub for the latest release and compares it to the running version (the app has no auto-updater), reporting **up to date (vX)** / **vX available** (+ copy-link) / the error, inline. Pure `version_is_newer` seam is unit-tested. Also fixed the stale `nowplaying-widget` → `widgetsack` Source link.

The per-package **"Check updates"** button for third-party plugins already existed, so that wasn't duplicated.

## Build provenance (CI)
`actions/attest-build-provenance@v4` attests the published installer on each release (SLSA provenance, public Sigstore/Rekor). Verify any downloaded asset with:
```
gh attest verify widgetsack_<ver>_x64-setup.exe --repo gyng/widgetsack
```
Independent of code signing — proves *where the binary came from*, doesn't touch SmartScreen.

## Verification
- client check / lint / test:unit (1305) / build ✅
- cargo clippy clean ✅; `version_is_newer` tests 2/2 ✅
- validated against the real GitHub API (shape matches; app at current version → "up to date")
- attestation: YAML valid, `@v4` + `subject-path` confirmed; runs on next release (can't exercise locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)