### PR TITLE
refactor(settings): plugin settings UI refinement pass

### DIFF
--- a/client/src/lib/widgets/NavRail.css
+++ b/client/src/lib/widgets/NavRail.css
@@ -1460,6 +1460,71 @@
 	cursor: pointer;
 }
 
+/* TokenListField: a wrapping row of removable chips + an add-row (input + button). Used by the
+   stocks (tickers) and MQTT (topics) panels in place of a raw textarea. */
+.canvas .plugins-panel .has-tokens {
+	list-style: none;
+	margin: 0 0 var(--space-2);
+	padding: 0;
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--space-2);
+}
+
+.canvas .plugins-panel .has-token {
+	display: inline-flex;
+	align-items: center;
+	gap: var(--space-1);
+	max-width: 100%;
+	padding: var(--space-1) var(--space-1) var(--space-1) var(--space-2);
+	background: rgba(255, 255, 255, 0.03);
+	border: 1px solid var(--ui-border);
+	border-radius: var(--radius-control);
+	color: var(--ui-fg);
+	font-family: monospace;
+	font-size: var(--text-md);
+}
+
+.canvas .plugins-panel .has-token:hover {
+	border-color: var(--ui-border-strong);
+}
+
+.canvas .plugins-panel .has-token-text {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.canvas .plugins-panel .has-token-x {
+	flex: 0 0 auto;
+	margin: 0;
+	padding: 0 var(--space-1);
+	background: transparent;
+	border: none;
+	color: var(--ui-fg-dim);
+	font-size: var(--text-lg);
+	line-height: 1;
+	cursor: pointer;
+}
+
+.canvas .plugins-panel .has-token-x:hover {
+	color: var(--ui-danger-fg);
+}
+
+.canvas .plugins-panel .has-token-add {
+	display: flex;
+	gap: var(--space-2);
+}
+
+.canvas .plugins-panel .has-token-add input {
+	flex: 1;
+	min-width: 0;
+}
+
+.canvas .plugins-panel .has-token-add button {
+	flex: 0 0 auto;
+}
+
 .canvas .plugins-panel .has-warn {
 	color: var(--ui-warn-fg);
 	line-height: 1.5;

--- a/client/src/lib/widgets/NavRail.css
+++ b/client/src/lib/widgets/NavRail.css
@@ -1451,6 +1451,18 @@
 	border-color: rgb(var(--ui-accent-rgb));
 }
 
+/* Inline field validation: red border on the offending input + a small message under it (used by the
+   Weather / RSS / Agenda panels instead of a single hint next to Save). */
+.canvas .plugins-panel .has-field input[aria-invalid='true'] {
+	border-color: var(--ui-danger-fg);
+}
+
+.canvas .plugins-panel .has-field-err {
+	color: var(--ui-danger-fg);
+	font-size: var(--text-sm);
+	margin-top: var(--space-1);
+}
+
 .canvas .plugins-panel .has-check {
 	display: flex;
 	align-items: center;
@@ -1681,6 +1693,13 @@
 .canvas .plugins-panel .has-group-toggle {
 	margin-bottom: 0;
 	color: var(--ui-fg-dim);
+}
+
+/* Bulk expose/clear actions for the entity browser (act on the currently-shown, filter-aware set). */
+.canvas .plugins-panel .has-bulk {
+	display: flex;
+	gap: var(--space-2);
+	margin-bottom: var(--space-3);
 }
 
 /* Grouped (area > device > entity) browser. */

--- a/client/src/lib/widgets/plugins/AgendaSettings.tsx
+++ b/client/src/lib/widgets/plugins/AgendaSettings.tsx
@@ -88,11 +88,15 @@ export default function AgendaSettings() {
 					inputMode="url"
 					placeholder="https://calendar.google.com/…/basic.ics"
 					value={url}
+					aria-invalid={url !== '' && !valid}
 					onChange={(e) => {
 						setUrl(e.currentTarget.value);
 						dirtied();
 					}}
 				/>
+				{url !== '' && !valid && (
+					<small className="has-field-err">Enter an https:// or webcal:// calendar URL.</small>
+				)}
 			</label>
 			<label className="has-field">
 				Title (optional)
@@ -131,7 +135,6 @@ export default function AgendaSettings() {
 					{saving ? 'Saving…' : 'Save & fetch'}
 				</button>
 				{saved && <span className="has-ok">Saved ✓</span>}
-				{!valid && url !== '' && <span className="has-state-dim">enter an ICS / webcal URL</span>}
 			</div>
 
 			<div className="has-help">

--- a/client/src/lib/widgets/plugins/HaSettings.tsx
+++ b/client/src/lib/widgets/plugins/HaSettings.tsx
@@ -9,7 +9,7 @@ import { useTelemetryHub } from '../telemetryContext';
 import { useSensor } from '../useSensor';
 import { useStore } from '../../../stores/createStore';
 import { haStatusBadge } from '../../core/haStatus';
-import { isExposed, toggleExposed } from '../../core/haExposed';
+import { isExposed, normalizeExposed, toggleExposed } from '../../core/haExposed';
 import { buildRegistryTree, type HaRegistry, type LiveState } from '../../core/haRegistry';
 import { copyToClipboard } from '../../overlay';
 import {
@@ -149,6 +149,30 @@ export default function HaSettings() {
 			}))
 			.filter((a) => a.devices.length || a.looseEntities.length);
 	}, [tree, query]);
+
+	// The sensor ids currently SHOWN (flat list or grouped tree, after the search filter) — what the
+	// bulk expose/clear actions operate on, so they respect a filter ("expose every light.*").
+	const visibleSensorIds = useMemo(() => {
+		if (groupByArea) {
+			const ids: string[] = [];
+			for (const a of treeFiltered) {
+				for (const d of a.devices) for (const e of d.entities) ids.push(e.sensorId);
+				for (const e of a.looseEntities) ids.push(e.sensorId);
+			}
+			return ids;
+		}
+		return filtered.map((e) => `ha.${e.entity_id}`);
+	}, [groupByArea, treeFiltered, filtered]);
+	const visibleExposedCount = useMemo(
+		() => visibleSensorIds.reduce((n, id) => (exposed.includes(id) ? n + 1 : n), 0),
+		[visibleSensorIds, exposed]
+	);
+	const exposeAllVisible = () =>
+		haExposedStore.update((cur) => normalizeExposed([...cur, ...visibleSensorIds]));
+	const clearVisibleExposed = () => {
+		const vis = new Set(visibleSensorIds);
+		haExposedStore.update((cur) => cur.filter((id) => !vis.has(id)));
+	};
 
 	// One entity row, shared by the flat list and the grouped tree (expose toggle + copy id).
 	const entityRow = (
@@ -371,6 +395,29 @@ export default function HaSettings() {
 					Group by area
 				</label>
 			</div>
+
+			{entities.length > 0 && (
+				<div className="has-bulk">
+					<button
+						type="button"
+						onClick={exposeAllVisible}
+						disabled={
+							visibleSensorIds.length === 0 || visibleExposedCount === visibleSensorIds.length
+						}
+						title="Expose every entity currently shown (respects the filter)"
+					>
+						Expose all{query.trim() ? ' shown' : ''}
+					</button>
+					<button
+						type="button"
+						onClick={clearVisibleExposed}
+						disabled={visibleExposedCount === 0}
+						title="Un-expose every entity currently shown"
+					>
+						Clear{query.trim() ? ' shown' : ''}
+					</button>
+				</div>
+			)}
 
 			{groupByArea ? (
 				treeFiltered.length ? (

--- a/client/src/lib/widgets/plugins/LlmSettings.tsx
+++ b/client/src/lib/widgets/plugins/LlmSettings.tsx
@@ -218,6 +218,14 @@ export default function LlmSettings() {
 		}
 	};
 
+	// Auto-load the model list when the active provider changes (or its saved key becomes usable), so the
+	// dropdown populates without a manual "↻ Models" click. Keyed on `provider`/`hasKey` ONLY — a
+	// not-yet-saved key typed char-by-char must not fire a request per keystroke; use ↻ Models for that.
+	useEffect(() => {
+		if (canListModels) void onLoadModels();
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [provider, hasKey]);
+
 	return (
 		<div className="has">
 			<div className="has-statusline">

--- a/client/src/lib/widgets/plugins/MqttSettings.tsx
+++ b/client/src/lib/widgets/plugins/MqttSettings.tsx
@@ -11,7 +11,9 @@ import { copyToClipboard } from '../../overlay';
 import { mqttConfigStatus, mqttConnect, mqttDisconnect, saveMqttConfig } from './mqtt-commands';
 import { refreshMqttCatalog } from './mqtt-source';
 import type { MqttCatalogEntry } from './mqtt-types';
+import TokenListField from './TokenListField';
 
+// Split on newline only — MQTT topic names may legitimately contain commas (unlike stock tickers).
 const parseTopics = (text: string): string[] =>
 	text
 		.split('\n')
@@ -28,7 +30,7 @@ export default function MqttSettings() {
 	const [username, setUsername] = useState('');
 	const [password, setPassword] = useState('');
 	const [clientId, setClientId] = useState('');
-	const [topicsText, setTopicsText] = useState('');
+	const [topics, setTopics] = useState<string[]>([]);
 	const [tls, setTls] = useState(false);
 	const [insecure, setInsecure] = useState(false);
 	const [discovery, setDiscovery] = useState(false);
@@ -55,7 +57,7 @@ export default function MqttSettings() {
 				setHost(s.host);
 				setPort(s.port);
 				setUsername(s.username);
-				setTopicsText(s.topics.join('\n'));
+				setTopics(s.topics);
 				setTls(s.tls);
 				setInsecure(s.insecure);
 				setDiscovery(s.discovery);
@@ -84,7 +86,7 @@ export default function MqttSettings() {
 				username: username.trim(),
 				password,
 				clientId: clientId.trim(),
-				topics: parseTopics(topicsText),
+				topics,
 				tls,
 				insecure,
 				discovery
@@ -186,20 +188,22 @@ export default function MqttSettings() {
 				/>
 			</label>
 
-			<label className="has-field">
-				Topics (one per line, wildcards ok: <code>zigbee2mqtt/#</code>)
-				<textarea
-					className="has-search"
-					rows={3}
-					spellCheck={false}
-					placeholder={'zigbee2mqtt/#\ntasmota/+/SENSOR'}
-					value={topicsText}
-					onChange={(e) => {
-						setTopicsText(e.currentTarget.value);
-						dirtied();
-					}}
-				/>
-			</label>
+			<TokenListField
+				label={
+					<>
+						Topics (wildcards ok: <code>zigbee2mqtt/#</code>)
+					</>
+				}
+				values={topics}
+				onChange={(next) => {
+					setTopics(next);
+					dirtied();
+				}}
+				parse={parseTopics}
+				placeholder="zigbee2mqtt/# — Enter to add"
+				listLabel="Subscribed topics"
+				emptyHint="No topics yet — add one above (e.g. tasmota/+/SENSOR)."
+			/>
 
 			<label className="has-check">
 				<input

--- a/client/src/lib/widgets/plugins/RssSettings.tsx
+++ b/client/src/lib/widgets/plugins/RssSettings.tsx
@@ -91,11 +91,15 @@ export default function RssSettings() {
 					inputMode="url"
 					placeholder="https://example.com/feed.xml"
 					value={url}
+					aria-invalid={url !== '' && !valid}
 					onChange={(e) => {
 						setUrl(e.currentTarget.value);
 						dirtied();
 					}}
 				/>
+				{url !== '' && !valid && (
+					<small className="has-field-err">Enter a full http(s):// feed URL.</small>
+				)}
 			</label>
 			<label className="has-field">
 				Title (optional)
@@ -147,7 +151,6 @@ export default function RssSettings() {
 					{saving ? 'Saving…' : 'Save & fetch'}
 				</button>
 				{saved && <span className="has-ok">Saved ✓</span>}
-				{!valid && url !== '' && <span className="has-state-dim">enter a http(s) feed URL</span>}
 			</div>
 
 			<div className="has-help">

--- a/client/src/lib/widgets/plugins/StocksSettings.tsx
+++ b/client/src/lib/widgets/plugins/StocksSettings.tsx
@@ -16,13 +16,14 @@ import {
 } from './stocks-commands';
 import { refreshStocksCatalog, stocksSource } from './stocks-source';
 import { parseSymbols } from './stocks-symbols';
+import TokenListField from './TokenListField';
 
 export default function StocksSettings() {
 	const hub = useTelemetryHub();
 	const status = useSensor(hub, 'stocks.status');
 	const badge = haStatusBadge(status.value?.kind === 'text' ? status.value.value : null);
 
-	const [symbolsText, setSymbolsText] = useState('');
+	const [symbols, setSymbols] = useState<string[]>([]);
 	const [pollSeconds, setPollSeconds] = useState(60);
 	const [configured, setConfigured] = useState(false);
 	const [saving, setSaving] = useState(false);
@@ -42,7 +43,7 @@ export default function StocksSettings() {
 		stocksConfigStatus()
 			.then((s) => {
 				if (!alive) return;
-				setSymbolsText(s.symbols.join('\n'));
+				setSymbols(s.symbols);
 				setPollSeconds(s.pollSeconds);
 				setConfigured(s.configured);
 			})
@@ -52,7 +53,6 @@ export default function StocksSettings() {
 		};
 	}, []);
 
-	const symbols = parseSymbols(symbolsText);
 	const dirtied = () => setSaved(false);
 	const canSubmit = !saving;
 
@@ -95,20 +95,18 @@ export default function StocksSettings() {
 				<code>SPY</code>), crypto (<code>BTC-USD</code>), indices (<code>^GSPC</code>).
 			</div>
 
-			<label className="has-field">
-				Tickers (one per line, or comma-separated)
-				<textarea
-					className="has-search"
-					rows={4}
-					spellCheck={false}
-					placeholder={'AAPL\nMSFT\nBTC-USD'}
-					value={symbolsText}
-					onChange={(e) => {
-						setSymbolsText(e.currentTarget.value);
-						dirtied();
-					}}
-				/>
-			</label>
+			<TokenListField
+				label="Tickers"
+				values={symbols}
+				onChange={(next) => {
+					setSymbols(next);
+					dirtied();
+				}}
+				parse={parseSymbols}
+				placeholder="AAPL — Enter to add, or paste a comma/newline list"
+				listLabel="Tickers"
+				emptyHint="No tickers yet — type one above and press Enter."
+			/>
 
 			<label className="has-field">
 				Poll interval (seconds)
@@ -124,10 +122,6 @@ export default function StocksSettings() {
 					}}
 				/>
 			</label>
-
-			{symbolsText.trim() && symbols.length === 0 && (
-				<div className="has-warn">No valid symbols entered — nothing will be saved.</div>
-			)}
 
 			<div className="has-warn">
 				⚠ Yahoo&rsquo;s endpoint is unofficial and best-effort — it can rate-limit or change without

--- a/client/src/lib/widgets/plugins/TokenListField.test.tsx
+++ b/client/src/lib/widgets/plugins/TokenListField.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import TokenListField from './TokenListField';
+
+// Stocks-style parser: split on newline/comma, upper-case, trim, drop empties.
+const parse = (raw: string): string[] =>
+	raw
+		.split(/[\n,]/)
+		.map((s) => s.trim().toUpperCase())
+		.filter(Boolean);
+
+function setup(values: string[] = []) {
+	const onChange = vi.fn();
+	render(
+		<TokenListField
+			label="Tickers"
+			values={values}
+			onChange={onChange}
+			parse={parse}
+			addLabel="Add"
+		/>
+	);
+	const input = screen.getByLabelText('Add Tickers') as HTMLInputElement;
+	return { onChange, input };
+}
+
+describe('TokenListField', () => {
+	it('renders a removable chip per value', () => {
+		setup(['AAPL', 'MSFT']);
+		expect(screen.getByText('AAPL')).toBeTruthy();
+		expect(screen.getByText('MSFT')).toBeTruthy();
+		expect(screen.getByLabelText('Remove AAPL')).toBeTruthy();
+	});
+
+	it('adds a normalised token on Enter and clears the input', () => {
+		const { onChange, input } = setup(['AAPL']);
+		fireEvent.change(input, { target: { value: 'msft' } });
+		fireEvent.keyDown(input, { key: 'Enter' });
+		expect(onChange).toHaveBeenCalledWith(['AAPL', 'MSFT']);
+		expect(input.value).toBe('');
+	});
+
+	it('adds via the Add button', () => {
+		const { onChange, input } = setup([]);
+		fireEvent.change(input, { target: { value: 'tsla' } });
+		fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+		expect(onChange).toHaveBeenCalledWith(['TSLA']);
+	});
+
+	it('does not add a duplicate', () => {
+		const { onChange, input } = setup(['AAPL']);
+		fireEvent.change(input, { target: { value: 'aapl' } });
+		fireEvent.keyDown(input, { key: 'Enter' });
+		expect(onChange).not.toHaveBeenCalled();
+	});
+
+	it('removes a token', () => {
+		const { onChange } = setup(['AAPL', 'MSFT']);
+		fireEvent.click(screen.getByLabelText('Remove AAPL'));
+		expect(onChange).toHaveBeenCalledWith(['MSFT']);
+	});
+
+	it('fans a list paste out into multiple deduped chips', () => {
+		const { onChange, input } = setup(['AAPL']);
+		fireEvent.paste(input, { clipboardData: { getData: () => 'MSFT, AAPL, GOOG' } });
+		expect(onChange).toHaveBeenCalledWith(['AAPL', 'MSFT', 'GOOG']);
+	});
+
+	it('disables Add when the input parses to nothing', () => {
+		setup([]);
+		expect(screen.getByRole('button', { name: 'Add' })).toHaveProperty('disabled', true);
+	});
+
+	it('shows the empty hint when there are no values', () => {
+		const onChange = vi.fn();
+		render(
+			<TokenListField
+				label="Tickers"
+				values={[]}
+				onChange={onChange}
+				parse={parse}
+				emptyHint="No tickers yet."
+			/>
+		);
+		expect(screen.getByText('No tickers yet.')).toBeTruthy();
+	});
+});

--- a/client/src/lib/widgets/plugins/TokenListField.tsx
+++ b/client/src/lib/widgets/plugins/TokenListField.tsx
@@ -1,0 +1,111 @@
+// A reusable "add a token → removable chip" field for settings panels that collect a LIST of short
+// strings (stock tickers, MQTT topics, …) — a structured replacement for the raw textareas those
+// panels used, mirroring the editable-list affordance NowPlaying already has. Presentational: it owns
+// only the pending-input text; the committed list lives in the parent (controlled `values`/`onChange`).
+//
+// `parse` turns a raw entry (a typed token OR a pasted blob) into 0+ normalised tokens — each panel
+// passes its own splitter (stocks splits on newline/comma + upper-cases; MQTT splits on newline only,
+// since topics may contain commas). Adds dedupe against the existing list, so paste-a-list just works.
+import { useState } from 'react';
+
+type Props = {
+	label: React.ReactNode;
+	values: string[];
+	onChange: (next: string[]) => void;
+	/** Split + normalise a raw entry/paste into tokens (already trimmed/cased; may contain dupes). */
+	parse: (raw: string) => string[];
+	placeholder?: string;
+	addLabel?: string;
+	/** aria-label for the chip list (defaults to a string `label`). */
+	listLabel?: string;
+	/** Shown when the list is empty. */
+	emptyHint?: string;
+};
+
+export default function TokenListField({
+	label,
+	values,
+	onChange,
+	parse,
+	placeholder,
+	addLabel = 'Add',
+	listLabel,
+	emptyHint
+}: Props) {
+	const [pending, setPending] = useState('');
+
+	// Add every fresh token `raw` parses to (skipping ones already present), then clear the input.
+	const commit = (raw: string) => {
+		const tokens = parse(raw);
+		if (tokens.length === 0) return;
+		const next = values.slice();
+		for (const t of tokens) if (!next.includes(t)) next.push(t);
+		if (next.length !== values.length) onChange(next);
+		setPending('');
+	};
+
+	const remove = (token: string) => onChange(values.filter((v) => v !== token));
+
+	return (
+		<div className="has-field">
+			<span>{label}</span>
+			{values.length > 0 ? (
+				<ul
+					className="has-tokens"
+					aria-label={listLabel ?? (typeof label === 'string' ? label : undefined)}
+				>
+					{values.map((v) => (
+						<li key={v} className="has-token">
+							<span className="has-token-text" title={v}>
+								{v}
+							</span>
+							<button
+								type="button"
+								className="has-token-x"
+								title={`Remove ${v}`}
+								aria-label={`Remove ${v}`}
+								onClick={() => remove(v)}
+							>
+								×
+							</button>
+						</li>
+					))}
+				</ul>
+			) : (
+				emptyHint && <div className="has-help">{emptyHint}</div>
+			)}
+			<div className="has-token-add">
+				<input
+					type="text"
+					value={pending}
+					placeholder={placeholder}
+					spellCheck={false}
+					aria-label={typeof label === 'string' ? `Add ${label}` : 'Add item'}
+					onChange={(e) => setPending(e.currentTarget.value)}
+					onKeyDown={(e) => {
+						if (e.key === 'Enter') {
+							e.preventDefault();
+							commit(pending);
+						}
+					}}
+					onPaste={(e) => {
+						// Intercept a "list" paste (contains a separator) so it fans out into chips; a single
+						// token paste falls through to the input for the user to review and Add.
+						const text = e.clipboardData.getData('text');
+						if (/[\n,]/.test(text)) {
+							e.preventDefault();
+							commit(text);
+						}
+					}}
+				/>
+				<button
+					type="button"
+					onClick={() => commit(pending)}
+					disabled={parse(pending).length === 0}
+				>
+					{addLabel}
+				</button>
+			</div>
+		</div>
+	);
+}

--- a/client/src/lib/widgets/plugins/WeatherSettings.tsx
+++ b/client/src/lib/widgets/plugins/WeatherSettings.tsx
@@ -53,13 +53,9 @@ export default function WeatherSettings() {
 
 	const latN = parseFloat(lat);
 	const lonN = parseFloat(lon);
-	const valid =
-		Number.isFinite(latN) &&
-		Number.isFinite(lonN) &&
-		latN >= -90 &&
-		latN <= 90 &&
-		lonN >= -180 &&
-		lonN <= 180;
+	const latValid = Number.isFinite(latN) && latN >= -90 && latN <= 90;
+	const lonValid = Number.isFinite(lonN) && lonN >= -180 && lonN <= 180;
+	const valid = latValid && lonValid;
 
 	const dirtied = () => setSaved(false);
 
@@ -106,11 +102,15 @@ export default function WeatherSettings() {
 					inputMode="decimal"
 					placeholder="51.5072"
 					value={lat}
+					aria-invalid={lat !== '' && !latValid}
 					onChange={(e) => {
 						setLat(e.currentTarget.value);
 						dirtied();
 					}}
 				/>
+				{lat !== '' && !latValid && (
+					<small className="has-field-err">Must be a number between −90 and 90.</small>
+				)}
 			</label>
 			<label className="has-field">
 				Longitude
@@ -119,11 +119,15 @@ export default function WeatherSettings() {
 					inputMode="decimal"
 					placeholder="-0.1276"
 					value={lon}
+					aria-invalid={lon !== '' && !lonValid}
 					onChange={(e) => {
 						setLon(e.currentTarget.value);
 						dirtied();
 					}}
 				/>
+				{lon !== '' && !lonValid && (
+					<small className="has-field-err">Must be a number between −180 and 180.</small>
+				)}
 			</label>
 			<label className="has-field">
 				Units
@@ -163,9 +167,6 @@ export default function WeatherSettings() {
 					{saving ? 'Saving…' : 'Save & fetch'}
 				</button>
 				{saved && <span className="has-ok">Saved ✓</span>}
-				{!valid && (lat !== '' || lon !== '') && (
-					<span className="has-state-dim">enter a valid lat / lon</span>
-				)}
 			</div>
 
 			<div className="has-help">


### PR DESCRIPTION
A refinement pass across the plugin settings screens, reusing the existing `has-*` style vocabulary (no new design language).

## 1. List inputs → chip list (`TokenListField`)
Stocks (tickers) and MQTT (topics) collected a **list** in a raw `<textarea>` — no way to see or remove individual items. New reusable **`TokenListField`**: add-row (type + **Enter** / **Add**, or **paste a comma/newline list**) + removable chips, with dedupe. Mirrors NowPlaying's existing editable-list affordance.
- Stocks: tickers as `string[]`; `parseSymbols` reused (newline/comma, upper-cased).
- MQTT: topics as `string[]`; split on **newline only** (topic names may contain commas).

## 2. Inline field validation (Weather / RSS / Agenda)
Moved "enter a valid…" from a hint next to Save onto the **field itself** — `aria-invalid` red border + an inline message under the offending input.

## 3. HA entity browser — bulk expose
**"Expose all" / "Clear"** actions that act on the currently-**shown** (filter-aware) set, so "expose every `light.*`" is one click. Buttons relabel to "…shown" when a filter is active.

## 4. AI provider — model auto-refresh
Auto-loads the model list when the provider changes or its **saved** key becomes usable (keyed on `provider`/`hasKey`, **not** the typed key — no request per keystroke), instead of only on a manual ↻ Models click. The manual button stays for not-yet-saved keys.

**No change to what any panel saves** — input/affordance UX only.

## Verification
- client `check` / `lint` (0 warnings) / `test:unit` (**1313**, +8 new TokenListField) / `build` ✅
- Existing Stocks / MQTT / HA tests unaffected.

_Visual confirmation in the running studio (Plugins → each panel) recommended — all changes reuse existing tokens/classes, so layout risk is low._

🤖 Generated with [Claude Code](https://claude.com/claude-code)