### PR TITLE
ci(build): don't save the un-restorable Rust cache on release builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,14 @@ jobs:
         # webkitgtk 4.0 is for Tauri v1 - webkitgtk 4.1 is for Tauri v2.
         # You can remove the one that doesn't apply to your app to speed up the workflow a bit.
       - uses: Swatinem/rust-cache@v2
+        with:
+          # Restore the Rust cache, but DON'T save one here. This workflow only runs on `release`
+          # (which executes on the tag ref) and `workflow_dispatch`. A cache saved on a tag ref can
+          # never be restored — the next release is a new tag, tag refs don't share caches, and this
+          # job never runs on `main` to seed a default-branch cache — so saving just accumulates
+          # ~620 MB of dead, un-restorable cache per release, pushing the repo over the 10 GB limit and
+          # evicting the test.yml caches that DO get hit. The test workflow owns the useful Rust cache.
+          save-if: false
       - name: install frontend dependencies
         run: npm ci
         working-directory: ./client


### PR DESCRIPTION
## Problem
`Swatinem/rust-cache` works fine for **test.yml** (full cache hits on PRs/main), but the release build logged **`No cache found`** every time and was cold ~10 min.

Root cause: `build.yml` only runs on `release` (which executes on the **tag ref**) and `workflow_dispatch`. A cache saved on a tag ref can never be restored — the next release is a new tag, tag refs don't share caches, and this job never runs on `main` to seed a default-branch cache. So each release saved ~620 MB of **dead, un-restorable** cache. With ~13 of them that put the repo at **10.8 GB — over GitHub's 10 GB/repo limit** — which was LRU-evicting the `test.yml` caches that *do* get hit.

## Fix
- `save-if: false` on the release build's `rust-cache` step — still restores (in case a usable cache ever exists), never saves the dead per-tag cache.
- (Out of band) deleted the ~12 existing dead `build-tauri` tag caches; repo cache footprint dropped from **10.8 GB → ~4.5 GB**, so the working test caches stay resident.

Release-build *speed* is unchanged (it was already cold and stays cold) — properly caching it would need a release-profile cache seeded on `main`, which isn't worth a full build per main push for a manually-released app. This PR just stops the waste.

🤖 Generated with [Claude Code](https://claude.com/claude-code)