### PR TITLE
fix(layout): hug-size fits content for fill meters (+ network/VRAM clips) (0.0.43)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5130,7 +5130,7 @@ dependencies = [
 
 [[package]]
 name = "widgetsack"
-version = "0.0.42"
+version = "0.0.43"
 dependencies = [
  "fontdb",
  "futures-util",

--- a/client/src/lib/core/flowStyle.test.ts
+++ b/client/src/lib/core/flowStyle.test.ts
@@ -112,9 +112,22 @@ describe('itemStyle (sizing)', () => {
 			flexBasis: '20px'
 		});
 		expect(itemStyle({ ...leaf(prim('A', 40, 20)) }, 'row').flexBasis).toBe('40px');
-		// 'content' on a FILL meter (gauge — no intrinsic content size) keeps its stored box so it can't
-		// collapse to 0; true content-fit is reserved for intrinsic meters (next test).
-		expect(itemStyle({ ...leaf(prim('A', 40, 20), 'content') }, 'row').flexBasis).toBe('40px');
+	});
+
+	it("basis 'content' on a FILL meter (gauge/gpu/…) → authored box as basis, floored at min-content", () => {
+		// Keeps the stored box as the default extent (can't collapse to 0), but floors BOTH axes at
+		// min-content so a content-bearing meter (e.g. GPU VRAM) is never squeezed below its content and
+		// clipped by the slot's overflow:hidden — the "hug clips" fix.
+		const s = itemStyle({ ...leaf(prim('A', 40, 20), 'content') }, 'row');
+		expect(s).toMatchObject({
+			flexGrow: 0,
+			flexShrink: 0,
+			flexBasis: '40px',
+			minWidth: 'min-content',
+			minHeight: 'min-content'
+		});
+		// col → main axis is height, so the basis tracks the stored height.
+		expect(itemStyle({ ...leaf(prim('A', 40, 20), 'content') }, 'col').flexBasis).toBe('20px');
 	});
 
 	it("basis 'content' on an INTRINSIC text meter (clock/text) → content-fit (auto basis, shrinkable)", () => {

--- a/client/src/lib/core/flowStyle.ts
+++ b/client/src/lib/core/flowStyle.ts
@@ -162,12 +162,26 @@ export function itemStyle(node: LayoutNode, parentKind: Container['kind']): Styl
 		s.flexBasis = 'auto';
 		s.minWidth = 0;
 		s.minHeight = 0;
+	} else if (basis === 'content' && isLeaf(node) && !isGroup(node.unit)) {
+		// 'content' on a FILL meter (gauge / sparkline / cpu / GPU panel / …, no intrinsic size):
+		// keep its authored box as the DEFAULT extent (flex-basis), but FLOOR both axes at the
+		// content's min-content so it's never squeezed below its own content and then clipped by the
+		// slot's overflow:hidden — the cause of the GPU VRAM / network "hug clips" reports. The cross
+		// axis (stretch) otherwise has no min-content floor. Meter fonts are FIXED (only AnalogClock is
+		// container-query scaled), so min-content is stable: no measure→grow feedback. flex-shrink:0 +
+		// the floor mean a hugged meter sits at max(authored box, its content).
+		s.flexGrow = 0;
+		s.flexShrink = 0;
+		const rect = node.unit.rect;
+		s.flexBasis = `${parentKind === 'row' ? rect.w : rect.h}px`;
+		s.minWidth = 'min-content';
+		s.minHeight = 'min-content';
 	} else {
-		// 'auto' / 'content' / unset: a LEAF takes its STORED main extent (primitive rect / group
-		// size) as the flex-basis, so a fill-meter (width/height:100%, no intrinsic size) keeps the
-		// authored box the solver used to give it via intrinsicMain — otherwise flex:0 0 auto would
-		// collapse it toward 0. A CONTAINER shrink-wraps its children (flex-basis:auto). The cross
-		// axis is filled by the container's default align-items:stretch.
+		// 'auto' / unset: a LEAF takes its STORED main extent (primitive rect / group size) as the
+		// flex-basis, so a fill-meter (width/height:100%, no intrinsic size) keeps the authored box the
+		// solver used to give it via intrinsicMain — otherwise flex:0 0 auto would collapse it toward 0.
+		// A CONTAINER shrink-wraps its children (flex-basis:auto). The cross axis is filled by the
+		// container's default align-items:stretch.
 		s.flexGrow = 0;
 		s.flexShrink = 0;
 		const size = isLeaf(node) ? (isGroup(node.unit) ? node.unit.size : node.unit.rect) : null;

--- a/client/src/lib/core/format.test.ts
+++ b/client/src/lib/core/format.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
 	formatBytes,
+	formatBytesPair,
 	formatClock,
 	formatDuration,
 	formatPercent,
@@ -20,6 +21,19 @@ describe('formatBytes', () => {
 	it('handles zero and non-finite input', () => {
 		expect(formatBytes(0)).toBe('0 B');
 		expect(formatBytes(Number.NaN)).toBe('0 B');
+	});
+});
+
+describe('formatBytesPair', () => {
+	it('shares one unit scaled to the total (compact VRAM readout)', () => {
+		// 6 GiB / 12 GiB → "5.6 / 11.2 GiB" (one unit, not "5.6 GiB / 11.2 GiB")
+		expect(formatBytesPair(6_000_000_000, 12_000_000_000)).toBe('5.6 / 11.2 GiB');
+	});
+	it('scales the used value to the total unit even when much smaller', () => {
+		expect(formatBytesPair(512 * 1024 * 1024, 16 * 1024 ** 3)).toBe('0.5 / 16.0 GiB');
+	});
+	it('falls back to two units when the total is missing/zero', () => {
+		expect(formatBytesPair(1024, 0)).toContain('/');
 	});
 });
 

--- a/client/src/lib/core/format.ts
+++ b/client/src/lib/core/format.ts
@@ -14,6 +14,22 @@ export function formatBytes(bytes: number, decimals = 1): string {
 	return `${scaled.toFixed(i === 0 ? 0 : decimals)} ${BYTE_UNITS[i]}`;
 }
 
+/** A compact "used / total UNIT" pair that shares ONE unit (scaled to the total), e.g.
+ * `12.3 GiB / 16.0 GiB` → `12.3 / 16.0 GiB`. Used for the GPU panel's VRAM readout, where the
+ * per-stat grid cell is narrow — dropping the redundant first unit keeps it from ellipsizing. */
+export function formatBytesPair(used: number, total: number, decimals = 1): string {
+	if (!Number.isFinite(total) || total <= 0) {
+		return `${formatBytes(used, decimals)} / ${formatBytes(total, decimals)}`;
+	}
+	const i = Math.min(
+		BYTE_UNITS.length - 1,
+		Math.max(0, Math.floor(Math.log(total) / Math.log(1024)))
+	);
+	const scale = 1024 ** i;
+	const fmt = (b: number) => (Math.max(0, b) / scale).toFixed(i === 0 ? 0 : decimals);
+	return `${fmt(used)} / ${fmt(total)} ${BYTE_UNITS[i]}`;
+}
+
 /** Bytes-per-second as a human-readable rate. */
 export function formatRate(bytesPerSec: number, decimals = 1): string {
 	return `${formatBytes(bytesPerSec, decimals)}/s`;

--- a/client/src/lib/core/gpu.ts
+++ b/client/src/lib/core/gpu.ts
@@ -1,7 +1,7 @@
 // Pure stat-list builder for the GPU panel: pick the metrics that are actually reported and format
 // them. No React/DOM — unit-tested (gpu.test.ts). The meter extracts the raw values from its sensor
 // map and renders the returned list. Units: vram bytes, temp °C, power W, clock MHz, fan %.
-import { formatBytes } from './format';
+import { formatBytesPair } from './format';
 
 export type GpuStat = { key: string; label: string; value: string };
 
@@ -24,7 +24,7 @@ export function gpuStats(v: {
 		out.push({
 			key: 'vram',
 			label: 'vram',
-			value: `${formatBytes(v.vramUsed)} / ${formatBytes(v.vramTotal)}`
+			value: formatBytesPair(v.vramUsed, v.vramTotal)
 		});
 	if (num(v.power)) out.push({ key: 'power', label: 'power', value: `${Math.round(v.power)} W` });
 	if (num(v.clockCore))

--- a/client/src/lib/core/templates.ts
+++ b/client/src/lib/core/templates.ts
@@ -169,7 +169,11 @@ function systemTree(): Container {
 const HIST_H = 60; // fixed histogram row height (px)
 const HIST_GAP = 4; // margin between the up + down histograms
 const HIST_TEXT_GAP = 8; // margin between the histogram cluster and the rate text row
+const RATE_H = 18; // the rate-text row height (the leaf hint + line-height headroom)
 const HIST_SECONDS = 90; // 1.5× the default 60s window — the histograms retain more history
+// The template's def box must fit the stacked content (two fixed histograms + their margins + the
+// rate row), else the bottom rows clip. Derived from the constants so it can't drift when they change.
+const NETWORK_H = HIST_H * 2 + HIST_GAP + HIST_TEXT_GAP + RATE_H; // 150
 function networkTree(): Container {
 	const rate = (
 		id: string,
@@ -186,7 +190,7 @@ function networkTree(): Container {
 				{
 					sensor,
 					w: 75,
-					h: 16,
+					h: RATE_H,
 					css: alignEnd ? '.np-text { justify-content: flex-end; }' : undefined
 				}
 			),
@@ -327,7 +331,7 @@ export const TEMPLATES: Template[] = [
 		id: 'network',
 		name: 'Network',
 		description: 'Up/down throughput histograms + rate text',
-		size: { w: 170, h: 104 },
+		size: { w: 170, h: NETWORK_H },
 		tree: networkTree
 	},
 	{

--- a/widgetsack/Cargo.toml
+++ b/widgetsack/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "widgetsack"
 # Keep in lockstep with tauri.conf.json's version (the bundle/updater source of truth).
-version = "0.0.42"
+version = "0.0.43"
 description = "widgetsack desktop widget platform"
 authors = ["you"]
 license = "MIT OR Apache-2.0"

--- a/widgetsack/tauri.conf.json
+++ b/widgetsack/tauri.conf.json
@@ -50,7 +50,7 @@
     "createUpdaterArtifacts": false
   },
   "productName": "widgetsack",
-  "version": "0.0.42",
+  "version": "0.0.43",
   "identifier": "io.github.gyng",
   "plugins": {},
   "app": {


### PR DESCRIPTION
## Problem
Widgets clipped at "hug" (fit-content) size: the Network template, the GPU panel, and GPU **VRAM** text (ellipsized).

"Hug" (`basis: 'content'`) already shrink-wrapped **text** leaves, but **fill meters** (gauge / sparkline / cpu / GPU panel) were pinned to their *authored box* and clipped by the slot's `overflow:hidden` whenever their content needed more.

## Fix (three layers)
- **Systemic** — `flowStyle.ts`: a `content`-basis fill meter keeps its authored box as the default extent but **floors both axes at `min-content`**, so a hugged meter sits at **max(box, its content)** and never clips. Safe because meter fonts are *fixed* (only AnalogClock is container-query scaled) → `min-content` is stable, no measure→grow feedback. Text leaves were already correct; this extends correct hug to fill meters.
- **Network template** — `templates.ts`: box `h:104` → derived `NETWORK_H` (~150) from the layout constants (two 60px histograms + margins + rate row), so it fits and can't drift.
- **GPU VRAM** — `format.ts`/`gpu.ts`: `formatBytesPair` shares one unit (`"12.3 GiB / 16.0 GiB"` → `"5.6 / 11.2 GiB"`) so the value fits the narrow stat cell.

## Verification
- type-check, lint, **1317 unit tests** (flowStyle + format tests pin the new behavior), build — green.
- **Real-browser e2e: 31 passed.** The 1 "failure" is a pre-existing flaky QuickJS-WASM timing test (passes on re-run; my change only touches `content` basis, while added widgets use `fr`).
- Visual confirmation of the live GPU/network widgets is Windows-only (real telemetry) — to eyeball after install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)