### PR TITLE
fix(layout): hug fits content for groups too + CI actions v6 (0.0.44)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,9 +18,9 @@ jobs:
 
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
       - name: install Rust stable

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,9 +19,9 @@ jobs:
         toolchain:
           - stable
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20.x"
       - name: Build frontend
@@ -38,9 +38,9 @@ jobs:
     name: Linting for Rust backend
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20.x"
       - name: Build frontend
@@ -60,9 +60,9 @@ jobs:
       run:
         working-directory: ./client
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20.x"
       - run: npm ci

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5130,7 +5130,7 @@ dependencies = [
 
 [[package]]
 name = "widgetsack"
-version = "0.0.43"
+version = "0.0.44"
 dependencies = [
  "fontdb",
  "futures-util",

--- a/client/src/lib/core/flowStyle.test.ts
+++ b/client/src/lib/core/flowStyle.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { container, leaf, type WidgetInstance, type Leaf } from './layoutTree';
+import { container, group, leaf, type WidgetInstance, type Leaf } from './layoutTree';
 import { containerStyle, itemStyle, overlapChildStyle } from './flowStyle';
 
 const prim = (id: string, w = 10, h = 10): WidgetInstance => ({
@@ -128,6 +128,19 @@ describe('itemStyle (sizing)', () => {
 		});
 		// col → main axis is height, so the basis tracks the stored height.
 		expect(itemStyle({ ...leaf(prim('A', 40, 20), 'content') }, 'col').flexBasis).toBe('20px');
+	});
+
+	it("basis 'content' on a GROUP (dropped template) → group size as basis, floored at min-content", () => {
+		// The Network widget is a GROUP; hugging it must fit its content, not pin to the stored size.
+		const g = group('g', { w: 80, h: 120 }, container('c', 'col', []));
+		const s = itemStyle({ ...leaf(g, 'content') }, 'col');
+		expect(s).toMatchObject({
+			flexGrow: 0,
+			flexShrink: 0,
+			flexBasis: '120px', // group size on the main (col) axis
+			minWidth: 'min-content',
+			minHeight: 'min-content'
+		});
 	});
 
 	it("basis 'content' on an INTRINSIC text meter (clock/text) → content-fit (auto basis, shrinkable)", () => {

--- a/client/src/lib/core/flowStyle.ts
+++ b/client/src/lib/core/flowStyle.ts
@@ -162,18 +162,20 @@ export function itemStyle(node: LayoutNode, parentKind: Container['kind']): Styl
 		s.flexBasis = 'auto';
 		s.minWidth = 0;
 		s.minHeight = 0;
-	} else if (basis === 'content' && isLeaf(node) && !isGroup(node.unit)) {
-		// 'content' on a FILL meter (gauge / sparkline / cpu / GPU panel / …, no intrinsic size):
-		// keep its authored box as the DEFAULT extent (flex-basis), but FLOOR both axes at the
-		// content's min-content so it's never squeezed below its own content and then clipped by the
-		// slot's overflow:hidden — the cause of the GPU VRAM / network "hug clips" reports. The cross
-		// axis (stretch) otherwise has no min-content floor. Meter fonts are FIXED (only AnalogClock is
-		// container-query scaled), so min-content is stable: no measure→grow feedback. flex-shrink:0 +
-		// the floor mean a hugged meter sits at max(authored box, its content).
+	} else if (basis === 'content' && isLeaf(node)) {
+		// 'content' on a FILL meter (gauge / sparkline / cpu / GPU panel / …, no intrinsic size) OR a
+		// GROUP (a dropped template / nested layout): keep its authored box as the DEFAULT extent
+		// (flex-basis = the meter rect / the group size), but FLOOR both axes at the content's
+		// min-content so it's never squeezed below its own content and then clipped by the slot's
+		// overflow:hidden — the cause of the GPU VRAM / Network "hug clips" reports (the Network widget
+		// is a GROUP, so it MUST be included here, not just leaf meters). The cross axis (stretch) and a
+		// shrinking fr column otherwise have no min-content floor. Meter fonts are FIXED (only
+		// AnalogClock is container-query scaled), so min-content is stable — no measure→grow feedback.
+		// flex-shrink:0 + the floor mean a hugged widget sits at max(authored box, its content).
 		s.flexGrow = 0;
 		s.flexShrink = 0;
-		const rect = node.unit.rect;
-		s.flexBasis = `${parentKind === 'row' ? rect.w : rect.h}px`;
+		const box = isGroup(node.unit) ? node.unit.size : node.unit.rect;
+		s.flexBasis = `${parentKind === 'row' ? box.w : box.h}px`;
 		s.minWidth = 'min-content';
 		s.minHeight = 'min-content';
 	} else {

--- a/client/src/lib/widgets/Inspector.tsx
+++ b/client/src/lib/widgets/Inspector.tsx
@@ -574,7 +574,7 @@ export default function Inspector({
 						isFrBasis(widgetBasis) ? 'grow' : typeof widgetBasis === 'number' ? 'fixed' : 'fit'
 					}
 					options={[
-						{ value: 'fit', label: 'hug — its own size' },
+						{ value: 'fit', label: 'hug — fit content' },
 						{ value: 'grow', label: 'fill — grow to share' },
 						{ value: 'fixed', label: 'fixed (px)' }
 					]}
@@ -582,6 +582,9 @@ export default function Inspector({
 						op({
 							op: 'setBasis',
 							id,
+							// 'fit' → 'content' (not undefined): a content basis floors the group at its
+							// min-content in flowStyle, so hugging a GROUP (e.g. the Network widget) fits its
+							// content instead of clipping to a stale stored size.
 							basis:
 								v === 'grow'
 									? { fr: 1 }
@@ -589,7 +592,7 @@ export default function Inspector({
 									? typeof widgetBasis === 'number'
 										? widgetBasis
 										: 100
-									: undefined
+									: 'content'
 						})
 					}
 					aria-label="size in parent"

--- a/widgetsack/Cargo.toml
+++ b/widgetsack/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "widgetsack"
 # Keep in lockstep with tauri.conf.json's version (the bundle/updater source of truth).
-version = "0.0.43"
+version = "0.0.44"
 description = "widgetsack desktop widget platform"
 authors = ["you"]
 license = "MIT OR Apache-2.0"

--- a/widgetsack/tauri.conf.json
+++ b/widgetsack/tauri.conf.json
@@ -50,7 +50,7 @@
     "createUpdaterArtifacts": false
   },
   "productName": "widgetsack",
-  "version": "0.0.43",
+  "version": "0.0.44",
   "identifier": "io.github.gyng",
   "plugins": {},
   "app": {


### PR DESCRIPTION
## Problem
Follow-up to v0.0.43: the **Network** widget (a **group**) still clipped at hug. Two reasons:
1. v0.0.43's `min-content` floor was scoped to fill-meter **leaves** — groups were excluded.
2. The group size control's "hug" set `basis: undefined`, which skips the floor entirely (falls back to the stored `size`). So hugging a group never floored at content — it pinned to the stale stored size (your saved widget's was `104`, content ~`148`).

## Fix
- **`flowStyle.ts`** — include groups in the `content`-basis `min-content` floor. A hugged group now sits at `max(stored size, its content)`.
- **`Inspector.tsx`** — the group "hug" option sets `basis: 'content'` (was `undefined`) and is relabelled **"hug — fit content"**, so the floor is reachable from the UI.
- **CI** — `actions/checkout` + `actions/setup-node` bumped **v4 → v6** (clears the Node 20-deprecation warning) in both workflows.

## Verification
- type-check, lint, **1318 unit tests** (added a content-basis group flowStyle test), build — green.
- **Real-browser e2e: 32 passed** (clean).
- This PR's own CI run also validates the upgraded checkout/setup-node actions.

**For an existing Network widget** saved at `fr` basis: set it to **"hug — fit content"** to pick up the floor (or it can stay `fr` and be given more room).

🤖 Generated with [Claude Code](https://claude.com/claude-code)