### PR TITLE
fix(layout): hug a group at max-content so it fits its full content (0.0.45)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5130,7 +5130,7 @@ dependencies = [
 
 [[package]]
 name = "widgetsack"
-version = "0.0.44"
+version = "0.0.45"
 dependencies = [
  "fontdb",
  "futures-util",

--- a/client/e2e/groupHug.spec.ts
+++ b/client/e2e/groupHug.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from '@playwright/test';
+
+// Verifies the CSS the group-hug fix relies on (flowStyle.ts): a content-basis GROUP slot floored at
+// `min-height: max-content` grows to its FULL content — two fixed-height histogram rows PLUS the
+// rate-text row whose `fr` (min-height:0) text leaves let it collapse out of `min-content`. So
+// `min-content` lands ~one-row short and clips the rate row (the live Network "hug clips" bug), while
+// `max-content` fits it. WebView2 is Chromium, same engine as this test.
+const groupHtml = (floor: 'min-content' | 'max-content') => `
+  <div style="height:600px; width:300px; display:flex; flex-direction:column; align-items:stretch;">
+    <!-- the group slot: stale 104px flex-basis, floored at \`floor\` (the fix uses max-content) -->
+    <div id="grp" style="flex:0 0 104px; min-height:${floor}; display:flex; flex-direction:column;
+                          overflow:hidden; align-items:stretch;">
+      <!-- the group's child renders with FlowNode \`fill\` (width/height:100%) — load-bearing for the
+           min-content collapse: it's why the rate row drops out of the group's min-content. -->
+      <div style="width:100%; height:100%; display:flex; flex-direction:column; align-items:stretch;
+                  overflow:hidden;">
+        <div style="flex:0 0 60px; margin-bottom:4px; background:#123;"></div>
+        <div style="flex:0 0 60px; margin-bottom:8px; background:#135;"></div>
+        <!-- rate-text row: a content row whose fr text leaves have min-height:0 (collapsible) -->
+        <div id="rate" style="flex:0 0 auto; display:flex; flex-direction:row; gap:6px;">
+          <span style="flex:1 1 0; min-width:0; min-height:0;">▲ 1.2 MB/s</span>
+          <span style="flex:1 1 0; min-width:0; min-height:0;">▼ 3.4 MB/s</span>
+        </div>
+      </div>
+    </div>
+  </div>`;
+
+async function measure(page: import('@playwright/test').Page) {
+	return page.evaluate(() => {
+		const grp = document.getElementById('grp');
+		const rate = document.getElementById('rate');
+		if (!grp || !rate) throw new Error('missing test nodes');
+		const g = grp.getBoundingClientRect();
+		const r = rate.getBoundingClientRect();
+		return { grpH: g.height, grpBottom: g.bottom, rateBottom: r.bottom, rateH: r.height };
+	});
+}
+
+test('a content-basis group floored at max-content sizes to its FULL content (rate row included)', async ({
+	page
+}) => {
+	await page.setContent(groupHtml('max-content'));
+	const m = await measure(page);
+	// Grows well past the stale 104px flex-basis to the full content (2×60 + 12 margins + the rate
+	// row ≈ 148) — so a hugged Network group fits regardless of its stored size.
+	expect(m.grpH).toBeGreaterThan(144);
+	// The rate row is fully inside the group box — NOT clipped at the bottom.
+	expect(m.rateBottom).toBeLessThanOrEqual(m.grpBottom + 1);
+	expect(m.rateH).toBeGreaterThan(5);
+});

--- a/client/src/lib/core/flowStyle.test.ts
+++ b/client/src/lib/core/flowStyle.test.ts
@@ -130,16 +130,17 @@ describe('itemStyle (sizing)', () => {
 		expect(itemStyle({ ...leaf(prim('A', 40, 20), 'content') }, 'col').flexBasis).toBe('20px');
 	});
 
-	it("basis 'content' on a GROUP (dropped template) → group size as basis, floored at min-content", () => {
-		// The Network widget is a GROUP; hugging it must fit its content, not pin to the stored size.
+	it("basis 'content' on a GROUP (dropped template) → group size as basis, floored at MAX-content", () => {
+		// The Network widget is a GROUP; hugging it must fit its FULL content (a collapsing sub-row
+		// falls out of min-content), so groups floor at max-content — not min-content like fill meters.
 		const g = group('g', { w: 80, h: 120 }, container('c', 'col', []));
 		const s = itemStyle({ ...leaf(g, 'content') }, 'col');
 		expect(s).toMatchObject({
 			flexGrow: 0,
 			flexShrink: 0,
 			flexBasis: '120px', // group size on the main (col) axis
-			minWidth: 'min-content',
-			minHeight: 'min-content'
+			minWidth: 'max-content',
+			minHeight: 'max-content'
 		});
 	});
 

--- a/client/src/lib/core/flowStyle.ts
+++ b/client/src/lib/core/flowStyle.ts
@@ -165,19 +165,26 @@ export function itemStyle(node: LayoutNode, parentKind: Container['kind']): Styl
 	} else if (basis === 'content' && isLeaf(node)) {
 		// 'content' on a FILL meter (gauge / sparkline / cpu / GPU panel / …, no intrinsic size) OR a
 		// GROUP (a dropped template / nested layout): keep its authored box as the DEFAULT extent
-		// (flex-basis = the meter rect / the group size), but FLOOR both axes at the content's
-		// min-content so it's never squeezed below its own content and then clipped by the slot's
-		// overflow:hidden — the cause of the GPU VRAM / Network "hug clips" reports (the Network widget
-		// is a GROUP, so it MUST be included here, not just leaf meters). The cross axis (stretch) and a
-		// shrinking fr column otherwise have no min-content floor. Meter fonts are FIXED (only
-		// AnalogClock is container-query scaled), so min-content is stable — no measure→grow feedback.
-		// flex-shrink:0 + the floor mean a hugged widget sits at max(authored box, its content).
+		// (flex-basis = the meter rect / the group size), but FLOOR both axes at the content extent so
+		// it's never squeezed below its own content and clipped by the slot's overflow:hidden — the
+		// GPU VRAM / Network "hug clips" reports. The cross axis (stretch) and a shrinking fr column
+		// otherwise have no such floor.
+		//
+		// The floor differs by kind. A GROUP floors at MAX-content — its full natural content: a
+		// collapsing sub-row (e.g. the Network rate-text row, whose fr text leaves can shrink to 0)
+		// falls OUT of min-content, so a min-content floor lands short and clips that row. A GROUP has
+		// well-defined max-content (real children), so max-content captures the whole thing. A FILL
+		// meter floors at min-content: max-content is ill-defined for a width/height:100% meter with no
+		// intrinsic content (it can collapse toward 0), so min-content is the safe non-collapsing floor.
+		// Meter fonts are FIXED (only AnalogClock is container-query scaled) → the floor is stable, no
+		// measure→grow feedback. flex-shrink:0 + the floor mean a hugged widget sits at max(box, content).
 		s.flexGrow = 0;
 		s.flexShrink = 0;
 		const box = isGroup(node.unit) ? node.unit.size : node.unit.rect;
 		s.flexBasis = `${parentKind === 'row' ? box.w : box.h}px`;
-		s.minWidth = 'min-content';
-		s.minHeight = 'min-content';
+		const floor = isGroup(node.unit) ? 'max-content' : 'min-content';
+		s.minWidth = floor;
+		s.minHeight = floor;
 	} else {
 		// 'auto' / unset: a LEAF takes its STORED main extent (primitive rect / group size) as the
 		// flex-basis, so a fill-meter (width/height:100%, no intrinsic size) keeps the authored box the

--- a/widgetsack/Cargo.toml
+++ b/widgetsack/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "widgetsack"
 # Keep in lockstep with tauri.conf.json's version (the bundle/updater source of truth).
-version = "0.0.44"
+version = "0.0.45"
 description = "widgetsack desktop widget platform"
 authors = ["you"]
 license = "MIT OR Apache-2.0"

--- a/widgetsack/tauri.conf.json
+++ b/widgetsack/tauri.conf.json
@@ -50,7 +50,7 @@
     "createUpdaterArtifacts": false
   },
   "productName": "widgetsack",
-  "version": "0.0.44",
+  "version": "0.0.45",
   "identifier": "io.github.gyng",
   "plugins": {},
   "app": {


### PR DESCRIPTION
## Problem
After v0.0.44, the Network widget (a hugged **group**) still clipped its **rate-text row** on the live overlay — with empty space *below* it (confirmed by a screen capture of the running v0.0.44 instance).

Root cause: v0.0.44 floored content-basis groups at **`min-content`**, but the rate-text row is a content row whose `fr` text leaves have `min-height: 0`, so it **collapses out of `min-content`**. The group landed ~one row (~16px) short and clipped it.

## Fix
- **`flowStyle.ts`** — a content-basis **group** now floors at **`max-content`** (its full natural content, rate row included). A group has well-defined `max-content` (real children); a **fill meter** keeps `min-content` (`max-content` is ill-defined for a `width/height:100%` meter and can collapse to 0).
- **`e2e/groupHug.spec.ts`** — verifies in Chromium that `min-height: max-content` sizes a group to its full content (rate row stays inside the box).

## Verification
- type-check, lint, **1318 unit tests** (flowStyle group test updated), build — green.
- **Real-browser e2e: 33 passed** (incl. the new group-hug test).
- **Honest caveat:** I could not reproduce the exact live-overlay `min-content` shortfall in a synthetic test (it's specific to the nested fr/grid layout). `max-content` is full-content sizing and is always ≥ the prior floor, so it can only help — but the live fix needs an install-and-eyeball to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)