### PR TITLE
fix(layout): preserve 'content' (hug) basis on load — overlay no longer clips (0.0.46)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5130,7 +5130,7 @@ dependencies = [
 
 [[package]]
 name = "widgetsack"
-version = "0.0.45"
+version = "0.0.46"
 dependencies = [
  "fontdb",
  "futures-util",

--- a/client/src/lib/core/migration.test.ts
+++ b/client/src/lib/core/migration.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { Layout as LayoutV1, WidgetInstance } from './layout';
 import { emptyRoot, type MonitorLayout } from './layoutTree';
-import { migrateMonitorKeys, migrateV1, parseLayoutAny } from './migration';
+import { migrateMonitorKeys, migrateV1, parseLayoutAny, parseLayoutNode } from './migration';
 
 describe('migrateMonitorKeys', () => {
 	const mon = (): MonitorLayout => ({ root: emptyRoot(), floating: [] });
@@ -250,5 +250,40 @@ describe('parseLayoutAny', () => {
 		expect(
 			parseLayoutAny({ version: '1', monitors: { default: { widgets: [validWidget] } } })
 		).toBeNull();
+	});
+});
+
+describe("parseLayoutNode preserves a 'content' (hug) basis", () => {
+	// Regression: isLength dropped 'content', so a hugged widget/group rendered fine in the studio
+	// (in-memory) but clipped on the overlay (re-parsed from disk with the basis gone).
+	const basisOf = (n: unknown) => (n as { basis?: unknown } | null)?.basis;
+
+	it('on a primitive leaf', () => {
+		const n = parseLayoutNode({
+			id: 't',
+			unit: { id: 't', type: 'text', rect: { x: 0, y: 0, w: 10, h: 10 }, config: {} },
+			basis: 'content'
+		});
+		expect(basisOf(n)).toBe('content');
+	});
+
+	it('on a GROUP leaf (the Network widget)', () => {
+		const n = parseLayoutNode({
+			id: 'g',
+			unit: {
+				id: 'g',
+				kind: 'group',
+				size: { w: 170, h: 104 },
+				child: { id: 'c', kind: 'col', children: [] }
+			},
+			basis: 'content'
+		});
+		expect(basisOf(n)).toBe('content');
+	});
+
+	it('on a container', () => {
+		expect(basisOf(parseLayoutNode({ id: 'r', kind: 'row', children: [], basis: 'content' }))).toBe(
+			'content'
+		);
 	});
 });

--- a/client/src/lib/core/migration.ts
+++ b/client/src/lib/core/migration.ts
@@ -287,6 +287,10 @@ function isJustify(j: unknown): boolean {
 }
 
 function isLength(b: unknown): boolean {
-	if (b === 'auto' || typeof b === 'number') return true;
+	// Length = number | 'auto' | 'content' | { fr }. Omitting 'content' here silently DROPPED a hug
+	// (content) basis on every load (parseLeaf / parseContainer), so a hugged widget/group looked
+	// right in the studio (in-memory) but clipped on the overlay (re-parsed) — the Network "hug
+	// clips" bug.
+	if (b === 'auto' || b === 'content' || typeof b === 'number') return true;
 	return typeof b === 'object' && b !== null && typeof (b as { fr?: unknown }).fr === 'number';
 }

--- a/widgetsack/Cargo.toml
+++ b/widgetsack/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "widgetsack"
 # Keep in lockstep with tauri.conf.json's version (the bundle/updater source of truth).
-version = "0.0.45"
+version = "0.0.46"
 description = "widgetsack desktop widget platform"
 authors = ["you"]
 license = "MIT OR Apache-2.0"

--- a/widgetsack/tauri.conf.json
+++ b/widgetsack/tauri.conf.json
@@ -50,7 +50,7 @@
     "createUpdaterArtifacts": false
   },
   "productName": "widgetsack",
-  "version": "0.0.45",
+  "version": "0.0.46",
   "identifier": "io.github.gyng",
   "plugins": {},
   "app": {


### PR DESCRIPTION
## Root cause (the real one)
`isLength` — the layout parser's length validator (`migration.ts`) — accepted `number` / `'auto'` / `{ fr }` but **not `'content'`**. So `parseLeaf` / `parseContainer` silently **dropped a hug (`content`) basis on every load**.

A hugged widget/group therefore looked right in the **studio** (basis set in memory) but **clipped on the overlay**, which re-parses the layout from disk and lost the basis → no content floor → clip. The flowStyle `min/max-content` floors shipped in 0.0.43–0.0.45 were all correct, but **never ran on the overlay** because the basis was gone before they were reached.

## Fix
- `migration.ts`: `isLength` now accepts `'content'`.
- `migration.test.ts`: `parseLayoutNode` preserves `'content'` on a primitive leaf, a **GROUP** leaf, and a container.

## Verification (end-to-end, not a guess)
Traced via a live CDP inspection of the running DISPLAY3 overlay, then built the fixed exe and re-inspected the **same** group on the **same** saved layout:
- before: `min-height: auto`, group height **104px**, rate row clipped
- after: `min-height: max-content`, group height **150px**, **rate row inside the box (not clipped)**

Plus: type-check, lint, **migration tests (21, +3)**, full unit suite, build. No re-hug needed — existing saved layouts fix on next load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)