### PR TITLE
test(coverage): restore to ~99.6/99.0/99.9/99.9 + gate coverage in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,7 +77,10 @@ jobs:
       - run: npm ci
       - run: npm run check
       - run: npm run build
-      - run: npm run test:unit
+      # Coverage-gated (replaces plain test:unit): vite.config's ratchet thresholds fail this
+      # job on regression, so coverage can never silently drift again (it slid 99.4→97.7
+      # unnoticed because CI only ran the tests, never the thresholds).
+      - run: npm run test:coverage
       - run: npm run lint
       # Fail if docs/widgets.md drifted from the widget registry (run `npm run gen:docs` to refresh).
       - run: npm run check:docs

--- a/client/src/lib/components/NowPlaying/priority.test.ts
+++ b/client/src/lib/components/NowPlaying/priority.test.ts
@@ -115,6 +115,37 @@ describe('priority', () => {
 		expect(sorted.at(2)!.source).toBe('barbaz');
 	});
 
+	it('treats a session with no `source` field as unranked (falls through the ?? fallback)', () => {
+		// A malformed/legacy record missing `source` entirely (not just empty) — the `a?.source` /
+		// `b?.source` optional chains yield undefined, exercising the `?? '_____FIXME_____'` fallback.
+		// Mirrors the 'sorts media by priority in list' case, with the unranked session source-less
+		// instead of a non-matching string — both must land in the same (last / MAX_VALUE) slot.
+		const { source: _drop, ...noSource } = { ...sessionRecord, session_id: 4 };
+		void _drop;
+		const sessions: Record<number, SessionRecord> = {
+			0: { ...sessionRecord, session_id: 0, source: 'foobar' },
+			2: { ...sessionRecord, session_id: 2, source: 'barbaz' },
+			4: noSource as SessionRecord
+		};
+		const priority = 'barbaz\nfoobar';
+		const sorted = sortSessionsByPriority(sessions, priority);
+		expect(sorted.at(2)!.source).toBe('barbaz');
+		expect(sorted.at(1)!.source).toBe('foobar');
+		expect(sorted.at(0)!.source).toBeUndefined();
+
+		// Same outcome with the source-less record FIRST, so it also lands in the comparator's
+		// b-slot (both the `a?.source` and `b?.source` fallbacks run).
+		const reversed: Record<number, SessionRecord> = {
+			0: { ...(noSource as SessionRecord), session_id: 0 },
+			2: { ...sessionRecord, session_id: 2, source: 'barbaz' },
+			4: { ...sessionRecord, session_id: 4, source: 'foobar' }
+		};
+		const sorted2 = sortSessionsByPriority(reversed, priority);
+		expect(sorted2.at(2)!.source).toBe('barbaz');
+		expect(sorted2.at(1)!.source).toBe('foobar');
+		expect(sorted2.at(0)!.source).toBeUndefined();
+	});
+
 	it('sorts media by last updated timestamp otherwise', () => {
 		const sessions: Record<number, SessionRecord> = {
 			0: {
@@ -177,6 +208,15 @@ describe('filterIgnored', () => {
 		const sessions = make({ 0: 'foobar2000.exe', 1: 'spotify.exe', 2: 'chrome.exe' });
 		const kept = filterIgnored(sessions, 'foobar2000\n\nchrome');
 		expect(Object.values(kept).map((s) => s.source)).toEqual(['spotify.exe']);
+	});
+
+	it('treats a record with no `source` field as an empty string, not a match', () => {
+		const { source: _drop, ...noSource } = { ...sessionRecord, session_id: 3 };
+		void _drop;
+		const sessions: Record<number, SessionRecord> = { 3: noSource as SessionRecord };
+		const kept = filterIgnored(sessions, 'foobar2000');
+		// '' doesn't contain 'foobar2000' → the record survives the filter.
+		expect(Object.keys(kept)).toEqual(['3']);
 	});
 });
 

--- a/client/src/lib/components/NowPlaying/sourceList.test.ts
+++ b/client/src/lib/components/NowPlaying/sourceList.test.ts
@@ -36,6 +36,10 @@ describe('moveEntry', () => {
 		expect(moveEntry('a\nb\nc', 0, 99)).toBe('b\nc\na');
 		expect(moveEntry('a\nb\nc', 1, 1)).toBe('a\nb\nc');
 	});
+	it('is a no-op when `from` is out of range', () => {
+		expect(moveEntry('a\nb\nc', 5, 0)).toBe('a\nb\nc');
+		expect(moveEntry('a\nb\nc', -1, 0)).toBe('a\nb\nc');
+	});
 });
 
 describe('normalizeList', () => {

--- a/client/src/lib/core/agenda.test.ts
+++ b/client/src/lib/core/agenda.test.ts
@@ -21,6 +21,12 @@ describe('parseAgendaList', () => {
 		]);
 		expect(parseAgendaList(null)).toEqual([]);
 	});
+
+	it('defaults location to an empty string when absent or non-string', () => {
+		expect(parseAgendaList([{ summary: 'No location', start: '2027-01-02T09:00:00' }])).toEqual([
+			{ summary: 'No location', start: '2027-01-02T09:00:00', allDay: false, location: '' }
+		]);
+	});
 });
 
 describe('upcomingEvents', () => {
@@ -67,5 +73,9 @@ describe('formatEventWhen', () => {
 	it('omits the time for all-day events', () => {
 		expect(formatEventWhen('2027-01-01', true, now)).toBe('Today');
 		expect(formatEventWhen('2027-01-02', true, now)).toBe('Tomorrow');
+	});
+
+	it("returns '' for an unparseable start", () => {
+		expect(formatEventWhen('not a date', false, now)).toBe('');
 	});
 });

--- a/client/src/lib/core/background.test.ts
+++ b/client/src/lib/core/background.test.ts
@@ -49,8 +49,19 @@ describe('parseBackgroundSpec', () => {
 		expect(parseBackgroundSpec({ kind: 'color', src: '' })).toBeUndefined();
 	});
 
+	it('treats a missing or non-string src as cleared too (the typeof src !== "string" arm)', () => {
+		expect(parseBackgroundSpec({ kind: 'web' })).toBeUndefined();
+		expect(parseBackgroundSpec({ kind: 'color', src: 42 })).toBeUndefined();
+	});
+
 	it('trims the source', () => {
 		expect(parseBackgroundSpec({ kind: 'web', src: '  https://x  ' })?.src).toBe('https://x');
+	});
+
+	it('leaves an in-range opacity/dim untouched (the clamp01 pass-through branch)', () => {
+		const s = parseBackgroundSpec({ kind: 'color', src: '#fff', opacity: 0.5, dim: 0.25 });
+		expect(s?.opacity).toBe(0.5);
+		expect(s?.dim).toBe(0.25);
 	});
 });
 

--- a/client/src/lib/core/condition.test.ts
+++ b/client/src/lib/core/condition.test.ts
@@ -38,6 +38,11 @@ describe('parseCondition', () => {
 		expect(parseCondition({ kind: 'appOpen' })).toBeUndefined();
 		expect(parseCondition({ kind: 'appOpen', matchExe: '  ' })).toBeUndefined();
 	});
+	it('keeps matchClass and matchTitle on an appOpen', () => {
+		expect(
+			parseCondition({ kind: 'appOpen', matchClass: 'Chrome_WidgetWin_1', matchTitle: 'YouTube' })
+		).toEqual({ kind: 'appOpen', matchClass: 'Chrome_WidgetWin_1', matchTitle: 'YouTube' });
+	});
 	it('parses a sensor condition; requires id + valid op', () => {
 		expect(parseCondition({ kind: 'sensor', sensorId: 'cpu.total', op: '>', value: '80' })).toEqual(
 			{
@@ -56,6 +61,23 @@ describe('parseCondition', () => {
 		expect(
 			parseCondition({ kind: 'sensor', sensorId: 's', op: '==', value: 5, negate: true })
 		).toEqual({ kind: 'sensor', sensorId: 's', op: '==', value: '5', negate: true });
+	});
+	it('coerces a missing/null value to an empty string', () => {
+		expect(parseCondition({ kind: 'sensor', sensorId: 's', op: '==' })).toEqual({
+			kind: 'sensor',
+			sensorId: 's',
+			op: '==',
+			value: ''
+		});
+		expect(parseCondition({ kind: 'sensor', sensorId: 's', op: '==', value: null })).toEqual({
+			kind: 'sensor',
+			sensorId: 's',
+			op: '==',
+			value: ''
+		});
+	});
+	it('rejects a non-string op', () => {
+		expect(parseCondition({ kind: 'sensor', sensorId: 's', op: 5, value: '1' })).toBeUndefined();
 	});
 	it('returns undefined for non-objects / unknown kinds', () => {
 		expect(parseCondition(null)).toBeUndefined();
@@ -82,6 +104,12 @@ describe('comparableOf', () => {
 		expect(comparableOf({ kind: 'json', value: { nope: 1 } })).toBeNull();
 		expect(comparableOf(null)).toBeNull();
 	});
+	it('json with a non-primitive .state (e.g. a nested object) is not comparable', () => {
+		expect(comparableOf({ kind: 'json', value: { state: { nested: true } } })).toBeNull();
+	});
+	it('an empty series (no samples yet) is not comparable', () => {
+		expect(comparableOf({ kind: 'series', value: [] })).toBeNull();
+	});
 });
 
 describe('conditionMet — appOpen', () => {
@@ -95,6 +123,11 @@ describe('conditionMet — appOpen', () => {
 		const hide: Condition = { kind: 'appOpen', matchExe: 'spotify.exe', negate: true };
 		expect(conditionMet(hide, ctx([win('x/Spotify.exe')]))).toBe(false);
 		expect(conditionMet(hide, ctx([]))).toBe(true);
+	});
+	it('a fieldless appOpen (constructed directly, bypassing parseCondition) is inert — always shown', () => {
+		const inert: Condition = { kind: 'appOpen' };
+		expect(conditionMet(inert, ctx([]))).toBe(true);
+		expect(conditionMet(inert, ctx([win('x/Spotify.exe')]))).toBe(true);
 	});
 });
 
@@ -128,6 +161,16 @@ describe('conditionMet — sensor', () => {
 			true
 		);
 		expect(conditionMet(c, ctx([], { light: { kind: 'text', value: 'off' } }))).toBe(false);
+	});
+	it('numeric equality/inequality (bothNum branch of == and !=)', () => {
+		const eq: Condition = { kind: 'sensor', sensorId: 'cpu.total', op: '==', value: '80' };
+		expect(conditionMet(eq, ctx([], s(80)))).toBe(true);
+		expect(conditionMet(eq, ctx([], s(81)))).toBe(false);
+	});
+	it('string inequality (bothNum false branch of !=)', () => {
+		const ne: Condition = { kind: 'sensor', sensorId: 'light', op: '!=', value: 'on' };
+		expect(conditionMet(ne, ctx([], { light: { kind: 'text', value: 'off' } }))).toBe(true);
+		expect(conditionMet(ne, ctx([], { light: { kind: 'text', value: 'on' } }))).toBe(false);
 	});
 	it('negate flips, and != is the inverse of ==', () => {
 		const ne: Condition = { kind: 'sensor', sensorId: 'cpu.total', op: '!=', value: '0' };

--- a/client/src/lib/core/controls.defaults.test.ts
+++ b/client/src/lib/core/controls.defaults.test.ts
@@ -1,7 +1,20 @@
 import { describe, expect, it } from 'vitest';
 // Importing the defaults registers the built-in inventory as a side-effect.
 import './controls.defaults';
-import { detectConflicts, getControl, listControls } from './controls';
+import { detectConflicts, formatTrigger, getControl, listControls } from './controls';
+import type { ControlContext, Trigger } from './controls';
+
+const baseCtx: ControlContext = {
+	scope: 'studio',
+	studio: false,
+	editMode: false,
+	menuOpen: false,
+	dirty: false,
+	hasSelection: false,
+	spaceDown: false,
+	panning: false,
+	previewing: false
+};
 
 describe('built-in controls', () => {
 	it('registers the full inventory with no two controls sharing a trigger', () => {
@@ -30,5 +43,125 @@ describe('built-in controls', () => {
 		expect(getControl('studio.sectionPrev')).toBeDefined();
 		// still conflict-free with the new bindings
 		expect(detectConflicts(listControls())).toEqual([]);
+	});
+});
+
+describe('canEdit (the studio.undo `when` gate)', () => {
+	// studio.undo's `when` is the bare `canEdit` predicate, so it isolates the branches of
+	// `c.studio || (c.editMode && !c.previewing)` without any other gate mixed in.
+	const when = getControl('studio.undo')!.when!;
+
+	it('is true in the studio regardless of editMode/previewing (the studio short-circuit)', () => {
+		expect(when({ ...baseCtx, studio: true, editMode: false, previewing: true })).toBe(true);
+	});
+
+	it('is false in the overlay when edit mode is off', () => {
+		expect(when({ ...baseCtx, studio: false, editMode: false, previewing: false })).toBe(false);
+	});
+
+	it('is true in the overlay when edit mode is on and not previewing', () => {
+		expect(when({ ...baseCtx, studio: false, editMode: true, previewing: false })).toBe(true);
+	});
+
+	it('is false in the overlay edit mode while a template preview is showing', () => {
+		expect(when({ ...baseCtx, studio: false, editMode: true, previewing: true })).toBe(false);
+	});
+});
+
+describe('selection-count-aware hint labels (studio.delete, studio.nudge)', () => {
+	it('studio.delete reads "remove" for no/singular selection and "remove (N)" for plural', () => {
+		const hintLabel = getControl('studio.delete')!.hintLabel!;
+		expect(hintLabel({ ...baseCtx })).toBe('remove'); // selectionCount undefined → the `?? 0` arm
+		expect(hintLabel({ ...baseCtx, selectionCount: 1 })).toBe('remove');
+		expect(hintLabel({ ...baseCtx, selectionCount: 3 })).toBe('remove (3)');
+	});
+
+	it('studio.nudge reads "nudge" for no/singular selection and "nudge (N)" for plural', () => {
+		const hintLabel = getControl('studio.nudge')!.hintLabel!;
+		expect(hintLabel({ ...baseCtx })).toBe('nudge'); // selectionCount undefined → the `?? 0` arm
+		expect(hintLabel({ ...baseCtx, selectionCount: 1 })).toBe('nudge');
+		expect(hintLabel({ ...baseCtx, selectionCount: 2 })).toBe('nudge (2)');
+	});
+});
+
+describe('per-control gating predicates (when / hintWhen / hint)', () => {
+	const when = (id: string) => getControl(id)!.when!;
+	const studioCtx = { ...baseCtx, studio: true };
+
+	it('studio.closeMenu fires for an open menu OR a studio selection', () => {
+		const w = when('studio.closeMenu');
+		expect(w({ ...baseCtx, menuOpen: true })).toBe(true);
+		expect(w({ ...studioCtx, hasSelection: true })).toBe(true);
+		expect(w({ ...baseCtx, hasSelection: true })).toBe(false); // selection alone, outside the studio
+		expect(w(baseCtx)).toBe(false);
+	});
+
+	it('studio.save requires the studio AND unsaved changes', () => {
+		const w = when('studio.save');
+		expect(w({ ...studioCtx, dirty: true })).toBe(true);
+		expect(w(studioCtx)).toBe(false);
+		expect(w({ ...baseCtx, dirty: true })).toBe(false);
+	});
+
+	it('studio.undo is advertised only with history to undo', () => {
+		const hintWhen = getControl('studio.undo')!.hintWhen!;
+		expect(hintWhen({ ...studioCtx, canUndo: true })).toBe(true);
+		expect(hintWhen(studioCtx)).toBe(false); // canUndo absent → !! coerces to false
+	});
+
+	it('studio.panHold needs studio edit mode', () => {
+		const w = when('studio.panHold');
+		expect(w({ ...studioCtx, editMode: true })).toBe(true);
+		expect(w(studioCtx)).toBe(false);
+	});
+
+	it('the studio-only gates (sections, panDrag, zoom) pass in the studio, fail in the overlay', () => {
+		for (const id of [
+			'studio.section',
+			'studio.sectionNext',
+			'studio.sectionPrev',
+			'studio.panDrag',
+			'studio.zoom'
+		]) {
+			expect(when(id)(studioCtx)).toBe(true);
+			expect(when(id)(baseCtx)).toBe(false);
+		}
+	});
+
+	it('delete and nudge need an editable context AND a selection; their key text is fixed', () => {
+		for (const id of ['studio.delete', 'studio.nudge']) {
+			expect(when(id)({ ...studioCtx, hasSelection: true })).toBe(true);
+			expect(when(id)(studioCtx)).toBe(false); // no selection
+			expect(when(id)({ ...baseCtx, hasSelection: true })).toBe(false); // not editable
+		}
+		expect(getControl('studio.delete')!.hint!(studioCtx, [])).toBe('Del');
+		expect(getControl('studio.nudge')!.hint!(studioCtx, [])).toBe('Arrows');
+	});
+
+	it('studio.marqueeAdd hides its hint while Space is held (Space+drag pans)', () => {
+		const hintWhen = getControl('studio.marqueeAdd')!.hintWhen!;
+		expect(hintWhen(studioCtx)).toBe(true);
+		expect(hintWhen({ ...studioCtx, spaceDown: true })).toBe(false);
+	});
+});
+
+describe('studio.panDrag hint (Space+drag vs middle-drag, plus the `pick ?? ts[0]` fallback)', () => {
+	const hint = getControl('studio.panDrag')!.hint!;
+	const triggers = getControl('studio.panDrag')!.triggers;
+
+	it('picks the middle-drag trigger when Space is not held', () => {
+		expect(hint({ ...baseCtx, spaceDown: false }, triggers)).toBe('Middle-drag');
+	});
+
+	it('picks the Space+left-drag trigger when Space is held', () => {
+		expect(hint({ ...baseCtx, spaceDown: true }, triggers)).toBe('Space+Drag');
+	});
+
+	it('falls back to triggers[0] when no trigger matches the search (the `pick ?? ts[0]` arm)', () => {
+		// A triggers array with no pointer entry at all: `find` returns undefined for either branch of
+		// the spaceDown ternary, so `pick` stays undefined and formatTrigger falls back to ts[0].
+		const noMatch: Trigger[] = [{ type: 'key', key: 'a' }];
+		expect(hint({ ...baseCtx, spaceDown: false }, noMatch)).toBe(formatTrigger(noMatch[0]));
+		expect(hint({ ...baseCtx, spaceDown: true }, noMatch)).toBe(formatTrigger(noMatch[0]));
 	});
 });

--- a/client/src/lib/core/cssLint.test.ts
+++ b/client/src/lib/core/cssLint.test.ts
@@ -40,4 +40,10 @@ describe('balanceDiagnostics', () => {
 		expect(d).toHaveLength(1);
 		expect(d[0].message).toMatch(/Unexpected "\)"/);
 	});
+
+	it('treats an unterminated /* comment as running to the end of the source', () => {
+		// No closing `*/`: indexOf returns -1, so the scan skips straight to the end — brackets
+		// inside the dangling comment (the `{` here) are never seen, and nothing is flagged.
+		expect(balanceDiagnostics('/* unterminated { comment')).toEqual([]);
+	});
 });

--- a/client/src/lib/core/cssThreats.test.ts
+++ b/client/src/lib/core/cssThreats.test.ts
@@ -38,6 +38,14 @@ describe('scanCssThreats', () => {
 		expect(scanCssThreats(undefined)).toEqual([]);
 		expect(scanCssThreats('')).toEqual([]);
 	});
+
+	it('truncates a long match to ~80 chars with an ellipsis', () => {
+		const longUrl = `url(https://evil.example/${'a'.repeat(100)})`;
+		const t = scanCssThreats(`.a { background: ${longUrl} }`);
+		expect(t).toHaveLength(1);
+		expect(t[0].detail.length).toBe(78);
+		expect(t[0].detail.endsWith('…')).toBe(true);
+	});
 });
 
 describe('threatSummary', () => {
@@ -50,5 +58,18 @@ describe('threatSummary', () => {
 		]);
 		expect(s).toContain('2 remote resources');
 		expect(s).toContain('1 full-screen overlay rule');
+	});
+
+	it('uses singular wording for exactly one remote resource, omitting the overlay clause', () => {
+		const s = threatSummary([{ kind: 'remote-url', detail: 'url(https://h/a)' }]);
+		expect(s).toBe('1 remote resource (could phone home)');
+	});
+
+	it('uses plural wording for multiple overlay rules, omitting the remote clause', () => {
+		const s = threatSummary([
+			{ kind: 'overlay', detail: 'position: fixed' },
+			{ kind: 'overlay', detail: 'position: sticky' }
+		]);
+		expect(s).toBe('2 full-screen overlay rules');
 	});
 });

--- a/client/src/lib/core/format.test.ts
+++ b/client/src/lib/core/format.test.ts
@@ -8,6 +8,7 @@ import {
 	formatRate,
 	formatScalar,
 	guessSensorFormat,
+	localeDayNames,
 	SCALAR_FORMATS
 } from './format';
 
@@ -34,6 +35,9 @@ describe('formatBytesPair', () => {
 	});
 	it('falls back to two units when the total is missing/zero', () => {
 		expect(formatBytesPair(1024, 0)).toContain('/');
+	});
+	it('drops decimals entirely in the plain-byte range (unit index 0)', () => {
+		expect(formatBytesPair(100, 512)).toBe('100 / 512 B');
 	});
 });
 
@@ -160,6 +164,43 @@ describe('guessSensorFormat', () => {
 		expect(guessSensorFormat('battery.rate')).toBe('integer');
 		expect(guessSensorFormat('battery.capacity.remaining')).toBe('integer');
 	});
+
+	it('falls back to integer for an id matching no known shape', () => {
+		expect(guessSensorFormat('weird.sensor')).toBe('integer');
+	});
+});
+
+describe('localeDayNames', () => {
+	it('defaults to short English weekday names, Sunday-first', () => {
+		expect(localeDayNames()).toEqual(['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']);
+	});
+
+	it('returns long English weekday names when asked', () => {
+		expect(localeDayNames('en', 'long')).toEqual([
+			'Sunday',
+			'Monday',
+			'Tuesday',
+			'Wednesday',
+			'Thursday',
+			'Friday',
+			'Saturday'
+		]);
+	});
+
+	it('returns short/long Japanese weekday names', () => {
+		expect(localeDayNames('ja', 'short')).toEqual(['日', '月', '火', '水', '木', '金', '土']);
+		expect(localeDayNames('ja', 'long')[1]).toBe('月曜日');
+	});
+
+	it('falls back to English for an unknown locale', () => {
+		expect(localeDayNames('xx')).toEqual(['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']);
+	});
+
+	it('returns a fresh copy each call (not a shared reference)', () => {
+		const a = localeDayNames();
+		a[0] = 'mutated';
+		expect(localeDayNames()[0]).toBe('Sun');
+	});
 });
 
 describe('formatClock', () => {
@@ -198,5 +239,13 @@ describe('formatClock', () => {
 
 	it('falls back to English for an unknown locale', () => {
 		expect(formatClock(d, 'ddd', 'xx')).toBe('Mon');
+	});
+
+	it('renders 12 for the noon/midnight hour and PM/pm after midday', () => {
+		const noon = new Date(2026, 5, 1, 12, 0, 0);
+		expect(formatClock(noon, 'h A')).toBe('12 PM');
+		expect(formatClock(noon, 'hh a')).toBe('12 pm');
+		const midnight = new Date(2026, 5, 1, 0, 30, 0);
+		expect(formatClock(midnight, 'h:mm A')).toBe('12:30 AM');
 	});
 });

--- a/client/src/lib/core/gpu.test.ts
+++ b/client/src/lib/core/gpu.test.ts
@@ -22,4 +22,9 @@ describe('gpuStats', () => {
 		expect(gpuStats({ vramUsed: 1e9 }).some((s) => s.key === 'vram')).toBe(false);
 		expect(gpuStats({})).toEqual([]);
 	});
+
+	it('includes fan when reported', () => {
+		const stats = gpuStats({ fan: 42.4 });
+		expect(stats).toEqual([{ key: 'fan', label: 'fan', value: '42%' }]);
+	});
 });

--- a/client/src/lib/core/haControls.test.ts
+++ b/client/src/lib/core/haControls.test.ts
@@ -49,6 +49,17 @@ describe('haControls — light', () => {
 		expect(lightColorTempKelvin(1000, attrs).data.color_temp_kelvin).toBe(2200);
 	});
 
+	it('defaults the kelvin range to 2000..6500 when the device reports none', () => {
+		expect(lightColorTempKelvin(10000, {}).data.color_temp_kelvin).toBe(6500);
+		expect(lightColorTempKelvin(500, {}).data.color_temp_kelvin).toBe(2000);
+	});
+
+	it('treats a light with no supported_color_modes as capability-less', () => {
+		expect(lightSupports({}, 'brightness')).toBe(false);
+		expect(lightSupports({}, 'color_temp')).toBe(false);
+		expect(lightSupports({}, 'rgb')).toBe(false);
+	});
+
 	it('clamps rgb components to 0..255', () => {
 		expect(lightRgb(300, -10, 128).data.rgb_color).toEqual([255, 0, 128]);
 	});
@@ -58,6 +69,8 @@ describe('haControls — climate', () => {
 	it('detects single-setpoint vs range', () => {
 		expect(climateUsesRange({ temperature: 21 })).toBe(false);
 		expect(climateUsesRange({ target_temp_high: 24, target_temp_low: 18 })).toBe(true);
+		// Only one side of the range set still counts as a range setpoint.
+		expect(climateUsesRange({ target_temp_low: 18 })).toBe(true);
 	});
 
 	it('builds set_temperature clamped to min/max', () => {
@@ -67,12 +80,23 @@ describe('haControls — climate', () => {
 		expect(climateSetTemperature(0, attrs).data.temperature).toBe(10);
 	});
 
+	it('defaults min/max to 7..35 when the entity reports no range', () => {
+		expect(climateSetTemperature(21, {}).data.temperature).toBe(21);
+		expect(climateSetTemperature(99, {}).data.temperature).toBe(35);
+		expect(climateSetTemperature(0, {}).data.temperature).toBe(7);
+	});
+
 	it('nudges the setpoint by ± one step from the current target', () => {
 		const attrs = { temperature: 21, target_temp_step: 0.5, min_temp: 7, max_temp: 35 };
 		expect(climateNudge(attrs, 1).data.temperature).toBe(21.5);
 		expect(climateNudge(attrs, -1).data.temperature).toBe(20.5);
 		// Clamped at the max.
 		expect(climateNudge({ temperature: 35, max_temp: 35 }, 1).data.temperature).toBe(35);
+	});
+
+	it('nudges from current_temperature when temperature is unset, or 20 when neither is set', () => {
+		expect(climateNudge({ current_temperature: 18 }, 1).data.temperature).toBe(18.5);
+		expect(climateNudge({}, 1).data.temperature).toBe(20.5);
 	});
 
 	it('builds set_hvac_mode', () => {
@@ -119,6 +143,12 @@ describe('haControls — fan / cover / input helpers', () => {
 		expect(inputNumberSetValue(20, attrs).data.value).toBe(20);
 		expect(inputNumberSetValue(99, attrs).data.value).toBe(30);
 		expect(inputNumberSetValue(0, attrs).data.value).toBe(5);
+	});
+
+	it('defaults input_number min/max to 0..100 when the helper reports none', () => {
+		expect(inputNumberSetValue(50, {}).data.value).toBe(50);
+		expect(inputNumberSetValue(150, {}).data.value).toBe(100);
+		expect(inputNumberSetValue(-10, {}).data.value).toBe(0);
 	});
 
 	it('builds input_select.select_option + input_text.set_value', () => {

--- a/client/src/lib/core/haRegistry.test.ts
+++ b/client/src/lib/core/haRegistry.test.ts
@@ -8,6 +8,16 @@ const reg = (over: Partial<HaRegistry> = {}): HaRegistry => ({
 	...over
 });
 
+// A device-less entity assigned straight to an area (for the area-ordering tests).
+const ent = (id: string, area: string) => ({
+	entity_id: id,
+	device_id: null,
+	area_id: area,
+	name: null,
+	original_name: id,
+	platform: 'p'
+});
+
 describe('buildRegistryTree', () => {
 	it('groups an entity under its device within the device area (inherited area)', () => {
 		const tree = buildRegistryTree(
@@ -135,6 +145,72 @@ describe('buildRegistryTree', () => {
 		expect(byId['sensor.a'].unit).toBe('°C');
 		expect(byId['sensor.b'].name).toBe('Override B');
 		expect(byId['sensor.c'].name).toBe('sensor.c');
+	});
+
+	it('falls back to the raw area_id for sorting/display when it has no matching area registry entry', () => {
+		const tree = buildRegistryTree(
+			reg({
+				areas: [{ area_id: 'k', name: 'Kitchen' }],
+				devices: [],
+				entities: [
+					{
+						entity_id: 'sensor.ghost',
+						device_id: null,
+						area_id: 'ghost', // dangling: no matching entry in `areas`
+						name: null,
+						original_name: 'Ghost',
+						platform: 'p'
+					}
+				]
+			}),
+			{}
+		);
+		const ghost = tree.find((a) => a.areaId === 'ghost');
+		expect(ghost?.name).toBe('ghost'); // falls back to the raw id, not a friendly name
+	});
+
+	it('falls back to the raw device id as its display name when the device has no name', () => {
+		const tree = buildRegistryTree(
+			reg({
+				devices: [{ id: 'd9', name: null, area_id: null, manufacturer: null, model: null }],
+				entities: [
+					{
+						entity_id: 'switch.s',
+						device_id: 'd9',
+						area_id: null,
+						name: null,
+						original_name: 'S',
+						platform: 'p'
+					}
+				]
+			}),
+			{}
+		);
+		expect(tree[0].devices[0].name).toBe('d9');
+	});
+
+	it('sorts several named areas alphabetically by friendly name, dangling ids by raw id', () => {
+		const tree = buildRegistryTree(
+			reg({
+				areas: [
+					{ area_id: 'k', name: 'Kitchen' },
+					{ area_id: 'b', name: 'Bedroom' }
+				],
+				devices: [],
+				entities: [ent('sensor.k', 'k'), ent('sensor.b', 'b'), ent('sensor.g', 'attic')]
+			}),
+			{}
+		);
+		// 'attic' has no registry entry so it sorts by its raw id, ahead of the friendly names.
+		expect(tree.map((a) => a.name)).toEqual(['attic', 'Bedroom', 'Kitchen']);
+	});
+
+	it('orders two dangling area ids against each other by raw id', () => {
+		const tree = buildRegistryTree(
+			reg({ entities: [ent('sensor.z', 'zeta'), ent('sensor.a', 'alpha')] }),
+			{}
+		);
+		expect(tree.map((a) => a.name)).toEqual(['alpha', 'zeta']);
 	});
 
 	it('groups a device with no area under Unassigned', () => {

--- a/client/src/lib/core/layout.test.ts
+++ b/client/src/lib/core/layout.test.ts
@@ -35,6 +35,11 @@ describe('parseLayout', () => {
 		expect(parseLayout({ version: 1, monitors: { default: {} } })).toBeNull();
 	});
 
+	it('returns null when a monitor entry is not an object', () => {
+		expect(parseLayout({ version: 1, monitors: { default: 'nope' } })).toBeNull();
+		expect(parseLayout({ version: 1, monitors: { default: null } })).toBeNull();
+	});
+
 	it('drops malformed widgets but keeps valid ones', () => {
 		const parsed = parseLayout({
 			version: 1,

--- a/client/src/lib/core/layoutEdit.test.ts
+++ b/client/src/lib/core/layoutEdit.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from 'vitest';
 import type { WidgetInstance } from './layout';
-import { container, group, isContainer, leaf, type Container, type Library } from './layoutTree';
+import {
+	container,
+	group,
+	isContainer,
+	leaf,
+	type Container,
+	type Group,
+	type Library
+} from './layoutTree';
 import {
 	allContainers,
 	collapseContainer,
@@ -119,6 +127,22 @@ describe('collapseContainer', () => {
 		const out = findNode(collapseContainer(root, 'cell'), 'cell') as Container;
 		expect(out.children.map((c) => c.id)).toEqual(['W1', 'W2']);
 	});
+
+	it('keeps a pulled-up sub-container that still holds a widget deeper down, drops empty ones', () => {
+		// cell = col[ sub=col[inner=row[W1]], sub2=col[innerEmpty=row[]] ] → col[inner]
+		const cell = container('cell', 'col', [
+			container('sub', 'col', [container('inner', 'row', [leaf(prim('W1'))])]),
+			container('sub2', 'col', [container('innerEmpty', 'row', [])])
+		]);
+		const root = container('root', 'col', [cell]);
+		const out = findNode(collapseContainer(root, 'cell'), 'cell') as Container;
+		expect(out.children.map((c) => c.id)).toEqual(['inner']);
+	});
+
+	it('is a no-op when the id names a leaf, not a container', () => {
+		const r = collapseContainer(tree(), 'A');
+		expect((findNode(r, 'rowA') as Container).children.map((c) => c.id)).toEqual(['A', 'B']);
+	});
 });
 
 describe('insertChild', () => {
@@ -148,6 +172,11 @@ describe('insertChild', () => {
 		const t = tree();
 		const r = insertChild(t, 'rowA', leaf(prim('D')), 99);
 		expect((findNode(r, 'rowA') as Container).children.map((c) => c.id)).toEqual(['A', 'B', 'D']);
+	});
+
+	it('is a no-op when the target parent is a leaf, not a container', () => {
+		const r = insertChild(tree(), 'A', leaf(prim('D')));
+		expect(flowLeaves(r).map((l) => l.id)).toEqual(['A', 'B', 'C']);
 	});
 });
 
@@ -190,6 +219,13 @@ describe('moveNode', () => {
 		expect(r.children.map((c) => c.id)).toEqual(['rowA', 'C']);
 	});
 
+	it('refuses to move a container into one of its own descendants', () => {
+		// rowA → its own child A would orphan the subtree; the deep cycle guard refuses.
+		const r = moveNode(tree(), 'rowA', 'A', 0);
+		expect(r.children.map((c) => c.id)).toEqual(['rowA', 'C']);
+		expect((findNode(r, 'rowA') as Container).children.map((c) => c.id)).toEqual(['A', 'B']);
+	});
+
 	it('is a no-op for an absent node', () => {
 		const r = moveNode(tree(), 'nope', 'rowA', 0);
 		expect(r.children.map((c) => c.id)).toEqual(['rowA', 'C']);
@@ -207,6 +243,12 @@ describe('updateNode / updateContainer', () => {
 	it('updateNode replaces a matched node via fn', () => {
 		const r = updateNode(tree(), 'A', (n) => (isContainer(n) ? n : { ...n, basis: { fr: 1 } }));
 		expect(findNode(r, 'A')).toMatchObject({ basis: { fr: 1 } });
+	});
+
+	it('updateContainer is a no-op when the id names a leaf, not a container', () => {
+		const t = tree();
+		const r = updateContainer(t, 'A', { gap: 12 });
+		expect(findNode(r, 'A')).toEqual(findNode(t, 'A'));
 	});
 });
 
@@ -266,6 +308,14 @@ describe('ungroupNode', () => {
 	it('is a no-op for a non-group id', () => {
 		const t = tree();
 		expect(ungroupNode(t, 'A').children.map((c) => c.id)).toEqual(['rowA', 'C']);
+	});
+
+	it('removes a group with no resolvable child (no def match, no inline child)', () => {
+		// A group loaded from persisted JSON can arrive with no inline child; with nothing to
+		// unwrap to, ungrouping drops the group leaf entirely.
+		const childless = { id: 'g', kind: 'group', size: { w: 1, h: 1 } } as Group;
+		const root = container('root', 'col', [leaf(childless), leaf(prim('Z'))]);
+		expect(ungroupNode(root, 'g').children.map((c) => c.id)).toEqual(['Z']);
 	});
 });
 
@@ -354,5 +404,58 @@ describe('dropTarget', () => {
 		const edge = dropTarget(root, solved, { x: 95, y: 50 }, 'W');
 		expect(edge?.into).toBeUndefined();
 		expect(edge?.merge).toBeUndefined();
+	});
+
+	it('skips grid-cell interiors when intoCells is false (plain before/after)', () => {
+		const c0 = container('c0', 'col', [leaf(prim('A'))], { align: 'stretch' });
+		const grid = container('g', 'grid', [c0, leaf(prim('L1'))], { cols: 2 });
+		const root = container('root', 'col', [grid], { align: 'stretch' });
+		const solved = new Map<string, Rect>([
+			['root', { x: 0, y: 0, w: 200, h: 100 }],
+			['g', { x: 0, y: 0, w: 200, h: 100 }],
+			['A', { x: 0, y: 0, w: 100, h: 100 }],
+			['L1', { x: 100, y: 0, w: 100, h: 100 }]
+		]);
+		// Interior of L1's cell, but cell drops are off → before/after the leaf instead.
+		expect(dropTarget(root, solved, { x: 150, y: 50 }, 'W', false)).toEqual({
+			parentId: 'g',
+			index: 2
+		});
+	});
+
+	it('never merges a dragged node with its own grid cell', () => {
+		const grid = container('g', 'grid', [leaf(prim('L0'))], { cols: 1 });
+		const root = container('root', 'col', [grid], { align: 'stretch' });
+		const solved = new Map<string, Rect>([
+			['root', { x: 0, y: 0, w: 100, h: 100 }],
+			['g', { x: 0, y: 0, w: 100, h: 100 }]
+		]);
+		// Interior of L0's own cell while dragging L0 → falls through to "into the grid".
+		expect(dropTarget(root, solved, { x: 50, y: 50 }, 'L0')).toEqual({ parentId: 'g', index: 0 });
+	});
+
+	it('prefers the first-found grid cell when two same-depth grids overlap the point', () => {
+		const g1 = container('g1', 'grid', [leaf(prim('L1'))], { cols: 1 });
+		const g2 = container('g2', 'grid', [leaf(prim('L2'))], { cols: 1 });
+		const root = container('root', 'row', [g1, g2]);
+		// Overlapping boxes (stale mid-drag measurements) — the later same-depth hit must not win.
+		const solved = new Map<string, Rect>([
+			['root', { x: 0, y: 0, w: 100, h: 100 }],
+			['g1', { x: 0, y: 0, w: 100, h: 100 }],
+			['g2', { x: 0, y: 0, w: 100, h: 100 }]
+		]);
+		expect(dropTarget(root, solved, { x: 50, y: 50 }, 'W')).toEqual({
+			parentId: 'g1',
+			index: 0,
+			merge: 'L1'
+		});
+	});
+
+	it('ignores a grid not yet measured when looking for cell drops', () => {
+		const grid = container('g', 'grid', [leaf(prim('L0'))], { cols: 1 });
+		const root = container('root', 'col', [grid]);
+		// No 'g' box → no cell/merge drop; the leaf pass takes over (before L0's left half).
+		const solved = new Map<string, Rect>([['L0', { x: 0, y: 0, w: 100, h: 100 }]]);
+		expect(dropTarget(root, solved, { x: 10, y: 50 }, 'W')).toEqual({ parentId: 'g', index: 0 });
 	});
 });

--- a/client/src/lib/core/monitorInputs.test.ts
+++ b/client/src/lib/core/monitorInputs.test.ts
@@ -136,6 +136,21 @@ describe('sourceEditorRows', () => {
 			{ value: 0x1b, defaultName: 'Input 0x1B', label: 'Console', include: true, detected: false }
 		]);
 	});
+
+	it('de-duplicates a repeated value in `detected`, keeping only the first row', () => {
+		const rows = sourceEditorRows([0x11, 0x11, 0x12], '');
+		expect(rows.map((r) => r.value)).toEqual([0x11, 0x12]);
+	});
+
+	it('leaves a manual (undetected) row unlabeled when its spec label matches the default name', () => {
+		// No explicit `=label` on the 0x1b entry → parseSourceSpec defaults its label to inputName(0x1b),
+		// so p.label === defaultName and the manual row's `label` stays '' (not the redundant default).
+		const rows = sourceEditorRows([0x11], '0x11, 0x1b');
+		expect(rows).toEqual([
+			{ value: 0x11, defaultName: 'HDMI 1', label: '', include: true, detected: true },
+			{ value: 0x1b, defaultName: 'Input 0x1B', label: '', include: true, detected: false }
+		]);
+	});
 });
 
 describe('buildSourceSpec', () => {

--- a/client/src/lib/core/palette.test.ts
+++ b/client/src/lib/core/palette.test.ts
@@ -10,6 +10,7 @@ import {
 	deriveTokens,
 	rgbCss,
 	rgbaCss,
+	type Bucket,
 	type RGB
 } from './palette';
 
@@ -119,6 +120,18 @@ describe('quantize + pickSeed', () => {
 
 	it('averageLuminance is 0 for an empty sample set', () => {
 		expect(averageLuminance([])).toBe(0);
+	});
+
+	it('does not let a later, less-saturated bucket overwrite the current most-saturated one', () => {
+		// Both buckets fail the strict accent gate (s < 0.2), so the result depends purely on the
+		// `mostSaturated` tracker: the first (more saturated) bucket must win, proving the second
+		// bucket's `s > mostSaturated.s` check is false and the assignment is skipped.
+		const buckets: Bucket[] = [
+			{ color: [150, 130, 110], count: 50 }, // s ≈ 0.16 — becomes mostSaturated first
+			{ color: [130, 125, 120], count: 10 } // s ≈ 0.04 — must NOT replace it
+		];
+		expect(rgbToHsl(buckets[0].color)[1]).toBeGreaterThan(rgbToHsl(buckets[1].color)[1]);
+		expect(pickSeed(buckets)).toEqual([150, 130, 110]);
 	});
 });
 

--- a/client/src/lib/core/ping.test.ts
+++ b/client/src/lib/core/ping.test.ts
@@ -17,6 +17,13 @@ describe('pingSensors', () => {
 		expect(pingSensors('')).toEqual({ ms: 'net.ping.1.1.1.1.ms', up: 'net.ping.1.1.1.1.up' });
 		expect(pingSensors('  ')).toEqual({ ms: 'net.ping.1.1.1.1.ms', up: 'net.ping.1.1.1.1.up' });
 	});
+
+	it('defaults a nullish host to 1.1.1.1', () => {
+		expect(pingSensors(null as unknown as string)).toEqual({
+			ms: 'net.ping.1.1.1.1.ms',
+			up: 'net.ping.1.1.1.1.up'
+		});
+	});
 });
 
 describe('pingLevel', () => {

--- a/client/src/lib/core/pluginPackage.test.ts
+++ b/client/src/lib/core/pluginPackage.test.ts
@@ -176,6 +176,22 @@ describe('parsePluginPackage', () => {
 		if (!r.ok) expect(r.reason).toContain('"templates" must be an array');
 	});
 
+	it('accepts a manifest with no "templates" key at all (defaults to an empty list)', () => {
+		const r = parsePluginPackage(
+			'weather-pack',
+			JSON.stringify({
+				manifestVersion: 1,
+				id: 'weather-pack',
+				name: 'Weather pack',
+				version: '1.0.0'
+			})
+		);
+		expect(r.ok).toBe(true);
+		if (!r.ok) return;
+		expect(r.pkg.manifest.templates).toEqual([]);
+		expect(r.pkg.warnings).toEqual([]);
+	});
+
 	it('drops a duplicate template id (second occurrence) with a warning', () => {
 		const r = parsePluginPackage(
 			'weather-pack',
@@ -302,6 +318,13 @@ describe('parsePluginPackage — template + param validation', () => {
 		expect(r.ok).toBe(true);
 		if (!r.ok) return;
 		expect(r.pkg.manifest.templates[0].params).toBeUndefined();
+	});
+
+	it('accepts a minimal param spec with only a key (no label/target/targets/choices/default)', () => {
+		const r = tpl({ params: [{ key: 'onlykey' }] });
+		expect(r.ok).toBe(true);
+		if (!r.ok) return;
+		expect(r.pkg.manifest.templates[0].params).toEqual([{ key: 'onlykey' }]);
 	});
 });
 

--- a/client/src/lib/core/procWatch.test.ts
+++ b/client/src/lib/core/procWatch.test.ts
@@ -15,4 +15,11 @@ describe('procWatchSensors', () => {
 		expect(procWatchSensors('').running).toBe('proc.watch.chrome.exe.running');
 		expect(procWatchSensors('  ').cpu).toBe('proc.watch.chrome.exe.cpu');
 	});
+
+	it('defaults a nullish name to chrome.exe', () => {
+		expect(procWatchSensors(null as unknown as string).running).toBe(
+			'proc.watch.chrome.exe.running'
+		);
+		expect(procWatchSensors(undefined as unknown as string).cpu).toBe('proc.watch.chrome.exe.cpu');
+	});
 });

--- a/client/src/lib/core/recyclebin.test.ts
+++ b/client/src/lib/core/recyclebin.test.ts
@@ -21,4 +21,8 @@ describe('binLevel', () => {
 	it('never flags full when the threshold is disabled (0)', () => {
 		expect(binLevel(5, 99 * GB, 0)).toBe('has');
 	});
+
+	it('treats a null byte count as 0 when checking the threshold', () => {
+		expect(binLevel(5, null, GB)).toBe('has');
+	});
 });

--- a/client/src/lib/core/sack.test.ts
+++ b/client/src/lib/core/sack.test.ts
@@ -12,6 +12,12 @@ const groupLeaf = (id: string, def: string): Leaf => ({
 	unit: { id, kind: 'group', def, size: { w: 1, h: 1 }, child: widgetLeaf(`${id}-c`) }
 });
 
+// A group leaf with no `def` (an inline group whose child is used directly).
+const inlineGroupLeaf = (id: string): Leaf => ({
+	id,
+	unit: { id, kind: 'group', size: { w: 1, h: 1 }, child: widgetLeaf(`${id}-c`) }
+});
+
 const mkDef = (id: string, child: Leaf = widgetLeaf(`${id}-c`)): WidgetDef => ({
 	id,
 	name: id.toUpperCase(),
@@ -33,6 +39,15 @@ describe('sack pack/unpack', () => {
 		expect(packSack({ library: { version: 1, defs: [] } })).toEqual({
 			kind: 'widgetsack/sack',
 			version: 1
+		});
+	});
+
+	it('omits an empty tokens object but includes a non-empty one', () => {
+		expect(packSack({ tokens: {} })).toEqual({ kind: 'widgetsack/sack', version: 1 });
+		expect(packSack({ tokens: { '--np-accent': 'red' } })).toEqual({
+			kind: 'widgetsack/sack',
+			version: 1,
+			tokens: { '--np-accent': 'red' }
 		});
 	});
 
@@ -92,5 +107,38 @@ describe('mergeLibrary', () => {
 		mergeLibrary(into, [incoming]);
 		expect(incoming.id).toBe('a');
 		expect(((incoming.child as Leaf).unit as { def: string }).def).toBe('a');
+	});
+
+	it('leaves an inline group (no def) untouched — remapRefs just recurses into its child', () => {
+		const into: Library = { version: 1, defs: [mkDef('a')] };
+		const incomingA = mkDef('a', inlineGroupLeaf('g'));
+		const { library, idMap } = mergeLibrary(into, [incomingA]);
+		const mergedA = library.defs.find((d) => d.id === idMap.a);
+		const grp = (mergedA!.child as Leaf).unit as { def?: string };
+		expect(grp.def).toBeUndefined();
+	});
+
+	it('leaves a group.def unchanged when it references a def outside the incoming batch', () => {
+		// 'x' is already in the library and isn't part of this merge, so it never lands in idMap —
+		// the reference must be left exactly as-is (not blanked or rewritten).
+		const into: Library = { version: 1, defs: [mkDef('a'), mkDef('x')] };
+		const incomingB = mkDef('b', groupLeaf('g', 'x'));
+		const { library, idMap } = mergeLibrary(into, [incomingB]);
+		const mergedB = library.defs.find((d) => d.id === idMap.b);
+		const grp = (mergedB!.child as Leaf).unit as { def: string };
+		expect(grp.def).toBe('x');
+	});
+
+	it('merges into an undefined library (fresh library, version defaults to 1)', () => {
+		const { library, idMap } = mergeLibrary(undefined, [mkDef('a')]);
+		expect(library).toEqual({ version: 1, defs: [mkDef('a')] });
+		expect(idMap).toEqual({ a: 'a' });
+	});
+
+	it('resolves a chain of collisions (base and base-2 both taken) by skipping past both', () => {
+		const into: Library = { version: 1, defs: [mkDef('a'), mkDef('a-2')] };
+		const { library, idMap } = mergeLibrary(into, [mkDef('a')]);
+		expect(idMap.a).toBe('a-3');
+		expect(library.defs.map((d) => d.id)).toEqual(['a', 'a-2', 'a-3']);
 	});
 });

--- a/client/src/lib/core/sensorList.test.ts
+++ b/client/src/lib/core/sensorList.test.ts
@@ -26,6 +26,10 @@ describe('formatSensorValue', () => {
 		expect(formatSensorValue({ kind: 'series', value: [] })).toBe('[ ]');
 	});
 
+	it('renders a non-integer last point to 1dp', () => {
+		expect(formatSensorValue({ kind: 'series', value: [1, 2, 3.14159] })).toBe('3.1 ⋯');
+	});
+
 	it('renders json compactly (truncated)', () => {
 		expect(formatSensorValue({ kind: 'json', value: { a: 1 } })).toBe('{"a":1}');
 	});

--- a/client/src/lib/core/solve.test.ts
+++ b/client/src/lib/core/solve.test.ts
@@ -388,6 +388,15 @@ describe('collectRenderables', () => {
 		expect(inl?.defId).toBeUndefined();
 	});
 
+	it('skips flow and floating primitives whose rect is not yet measured (first frame)', () => {
+		const mon: MonitorLayout = {
+			root: container('root', 'col', [leaf(prim('F', 100, 20))], { align: 'stretch' }),
+			floating: [leaf(prim('W', 160, 40))]
+		};
+		// An empty measured map (before the ResizeObserver has fired) surfaces nothing.
+		expect(collectRenderables(mon, new Map())).toEqual([]);
+	});
+
 	it('a FLOATING group WITHOUT a def resolves its inline child (defId omitted)', () => {
 		// No def → resolveGroup falls back to the inline child; `lf.unit.def ?? null` takes the null arm.
 		const g = group('gi', { w: 40, h: 26 }, leaf(prim('inl', 40, 26, { type: 'bar' })));
@@ -433,6 +442,19 @@ describe('collectContainerRects', () => {
 		expect(byId['root']).toMatchObject({ kind: 'col', rect: { x: 0, y: 0, w: 200, h: 100 } });
 		expect(byId['row1']?.kind).toBe('row');
 		expect(boxes).toHaveLength(2);
+	});
+
+	it('skips a container whose box is not yet measured, still descending to its children', () => {
+		const root = container(
+			'root',
+			'col',
+			[container('row1', 'row', [leaf(prim('A', 40, 20))], { align: 'stretch' })],
+			{ align: 'stretch' }
+		);
+		const mon: MonitorLayout = { root, floating: [] };
+		// Only the nested row is measured — the unmeasured root is skipped, not fatal.
+		const solved: Solved = new Map([['row1', { x: 0, y: 0, w: 200, h: 100 }]]);
+		expect(collectContainerRects(mon, solved).map((b) => b.id)).toEqual(['row1']);
 	});
 
 	it('does not descend into group internals (only flow-tree containers)', () => {
@@ -496,6 +518,13 @@ describe('collectGridPlaceholders', () => {
 		const cells = collectGridPlaceholders(mon, solved);
 		expect(cells).toHaveLength(1); // cell 0 filled by A, cell 1 is the placeholder
 		expect(cells[0]).toEqual({ gridId: 'g', index: 1, rect: { x: 100, y: 0, w: 100, h: 100 } });
+	});
+
+	it('emits nothing for a grid whose own box is not yet measured', () => {
+		const grid = container('g', 'grid', [], { cols: 2, basis: { fr: 1 } });
+		const root = container('root', 'col', [grid], { align: 'stretch' });
+		const mon: MonitorLayout = { root, floating: [] };
+		expect(collectGridPlaceholders(mon, new Map())).toEqual([]);
 	});
 });
 
@@ -630,6 +659,14 @@ describe('collectSplitters', () => {
 		// `b` is absent from the solved map (not yet measured) → the boundary can't be placed.
 		const solved: Solved = new Map([['a', { x: 0, y: 0, w: 100, h: 50 }]]);
 		expect(collectSplitters(mon, solved)).toHaveLength(0);
+	});
+
+	it('emits no grid splitters when the grid box is unmeasured', () => {
+		const grid = container('g', 'grid', [leaf(prim('A', 10, 10)), leaf(prim('B', 10, 10))], {
+			cols: 2
+		});
+		const mon: MonitorLayout = { root: container('root', 'col', [grid]), floating: [] };
+		expect(collectSplitters(mon, new Map())).toEqual([]);
 	});
 
 	it('a col with three fr children yields two horizontal bars', () => {

--- a/client/src/lib/core/style.test.ts
+++ b/client/src/lib/core/style.test.ts
@@ -117,6 +117,30 @@ describe('assembleStyles', () => {
 		expect(assembleStyles({ monitor })).toBe('');
 	});
 
+	it('skips a library def with no css (nothing pushed for its [data-def] block)', () => {
+		const lib: Library = {
+			version: 1,
+			defs: [{ id: 'blank', name: 'blank', size: { w: 1, h: 1 }, child: leaf(prim('x')) }]
+		};
+		const monitor: MonitorLayout = { root: emptyRoot(), floating: [] };
+		expect(assembleStyles({ library: lib, monitor })).toBe('');
+	});
+
+	it('skips a node that is neither a container nor a leaf (malformed/stale layout data)', () => {
+		// LayoutNode is nominally Container | Leaf, but a hand-edited or stale widgets.json could carry
+		// a node satisfying neither shape (no `kind` in row/col/grid, no `unit`); walk() must degrade to
+		// a no-op for it rather than throwing.
+		const ghost = { id: 'ghost' } as unknown as ReturnType<typeof leaf>;
+		const monitor: MonitorLayout = {
+			root: container('root', 'col', [leaf(prim('a', 'color: red')), ghost]),
+			floating: []
+		};
+		expect(() => assembleStyles({ monitor })).not.toThrow();
+		const css = assembleStyles({ monitor });
+		expect(css).toContain('[data-w="a"]');
+		expect(css).not.toContain('ghost');
+	});
+
 	it('prepends the DEFAULT_TOKENS :root base when includeDefaults, before the theme', () => {
 		const monitor: MonitorLayout = { root: emptyRoot(), floating: [] };
 		const css = assembleStyles({

--- a/client/src/lib/core/templatingDocs.test.ts
+++ b/client/src/lib/core/templatingDocs.test.ts
@@ -44,4 +44,31 @@ describe('templatingReferenceMarkdown', () => {
 		expect(md).toContain('{{');
 		expect(md).toContain('–');
 	});
+
+	it('falls back to [] when a meta has no configFields, and skips non-expr fields', () => {
+		const noFields: WidgetMeta[] = [{ type: 'gauge', label: 'Gauge' }];
+		const nonExpr: WidgetMeta[] = [
+			{
+				type: 'bar',
+				label: 'Bar',
+				configFields: [{ key: 'min', label: 'min', kind: 'number' }]
+			}
+		];
+		const out = templatingReferenceMarkdown([...noFields, ...nonExpr]);
+		expect(out).toContain('_No formula fields in the current registry._');
+	});
+
+	it('omits the override note when target equals the field key, and blanks it when there is no help', () => {
+		const noHelpMetas: WidgetMeta[] = [
+			{
+				type: 'text',
+				label: 'Text',
+				configFields: [
+					{ key: 'x', label: 'x', kind: 'expr', result: 'number', target: 'x' } // target === key
+				]
+			}
+		];
+		const out = templatingReferenceMarkdown(noHelpMetas);
+		expect(out).toContain('| `text` | `x` | formula → number |  |');
+	});
 });

--- a/client/src/lib/core/textTemplate.test.ts
+++ b/client/src/lib/core/textTemplate.test.ts
@@ -46,6 +46,12 @@ describe('parseTemplate', () => {
 	it('returns plain text unchanged', () => {
 		expect(parseTemplate('just text')).toEqual([{ kind: 'text', text: 'just text' }]);
 	});
+
+	it('tolerates an unterminated string literal inside an expr (runs to end of source)', () => {
+		// The opening quote never finds its match, so the inner scan exhausts the source and the
+		// "append the closing quote" step is skipped — the expr just ends with whatever was read.
+		expect(parseTemplate(`{ 'abc`)).toEqual([{ kind: 'expr', src: `'abc` }]);
+	});
 });
 
 describe('exprRefs / templateRefs', () => {

--- a/client/src/lib/core/widgetDocs.test.ts
+++ b/client/src/lib/core/widgetDocs.test.ts
@@ -63,4 +63,35 @@ describe('widgetReferenceMarkdown', () => {
 		]);
 		expect(piped).toContain('a \\| b');
 	});
+
+	it('documents an empty/catalog select, expr fields (with/without a target), and a numeric range', () => {
+		const kitchen: WidgetMeta = {
+			type: 'kitchen',
+			label: 'Kitchen',
+			binds: 'scalar',
+			configFields: [
+				{ key: 'src', label: 'src', kind: 'select', options: [], catalog: 'sensors' },
+				{ key: 'e1', label: 'e1', kind: 'expr', result: 'number', target: 'foo' },
+				{ key: 'e2', label: 'e2', kind: 'expr', result: 'text' },
+				{ key: 'range', label: 'range', kind: 'number', min: 0, max: 10, step: 1 },
+				{ key: 'preset', label: 'preset', kind: 'text', default: 'hi' }
+			]
+		};
+		const md = widgetReferenceMarkdown([kitchen]);
+		expect(md).toContain('(runtime list) — from `sensors`');
+		expect(md).toContain('→ number (sets `foo`)');
+		expect(md).toContain('| `e2` | expr | ');
+		expect(md).toContain('→ text |');
+		expect(md).toContain('min 0, max 10, step 1');
+		expect(md).toContain('| `preset` | text | "hi" |');
+	});
+
+	it('falls back to the type when label is missing, "scalar" when binds is missing, and notes interactive widgets', () => {
+		const blob: WidgetMeta = { type: 'blob', interactive: true };
+		const md = widgetReferenceMarkdown([blob]);
+		expect(md).toContain('### blob — `blob`');
+		expect(md).toContain('![blob widget]');
+		expect(md).toContain('binds a `scalar` sensor');
+		expect(md).toContain('- **Interactive:** catches clicks in passive mode');
+	});
 });

--- a/client/src/lib/core/windowMatch.test.ts
+++ b/client/src/lib/core/windowMatch.test.ts
@@ -40,6 +40,10 @@ describe('windowMatches / anyWindowMatches', () => {
 		expect(windowMatches(spotify, { exe: 'spotify.exe', title: 'Nope' })).toBe(false);
 		expect(windowMatches(spotify, { className: 'Chrome_WidgetWin_?' })).toBe(true);
 	});
+
+	it('a mismatched class rejects the window even when nothing else is specified', () => {
+		expect(windowMatches(spotify, { className: 'Nope' })).toBe(false);
+	});
 	it('a fieldless rule never matches (no accidental catch-all)', () => {
 		expect(windowMatches(spotify, {})).toBe(false);
 	});

--- a/client/src/lib/core/yaml.test.ts
+++ b/client/src/lib/core/yaml.test.ts
@@ -9,6 +9,12 @@ describe('toYaml', () => {
 		expect(toYaml('hello')).toBe('hello');
 	});
 
+	it('emits false, and non-finite numbers as null', () => {
+		expect(toYaml(false)).toBe('false');
+		expect(toYaml(NaN)).toBe('null');
+		expect(toYaml(Infinity)).toBe('null');
+	});
+
 	it('quotes ambiguous strings (numbers, bools, empties, indicators)', () => {
 		expect(toYaml('123')).toBe('"123"');
 		expect(toYaml('true')).toBe('"true"');
@@ -19,6 +25,12 @@ describe('toYaml', () => {
 
 	it('emits a flat object', () => {
 		expect(toYaml({ type: 'gauge', min: 0, max: 100 })).toBe('type: gauge\nmin: 0\nmax: 100');
+	});
+
+	it('quotes an ambiguous object key (numeric-like, `: `-bearing, dash-led)', () => {
+		expect(toYaml({ '123': 1 })).toBe('"123": 1');
+		expect(toYaml({ 'a: b': 1 })).toBe('"a: b": 1');
+		expect(toYaml({ '-x': 1 })).toBe('"-x": 1');
 	});
 
 	it('nests objects on indented lines', () => {
@@ -32,6 +44,27 @@ describe('toYaml', () => {
 
 	it('renders empty array / object inline', () => {
 		expect(toYaml({ actions: [], config: {} })).toBe('actions: []\nconfig: {}');
+	});
+
+	it('renders a top-level array / empty array / empty object', () => {
+		expect(toYaml([1, 2, 3])).toBe('- 1\n- 2\n- 3');
+		expect(toYaml([])).toBe('[]');
+		expect(toYaml({})).toBe('{}');
+	});
+
+	it('renders an array item object with a single key with no continuation lines', () => {
+		expect(toYaml({ actions: [{ domain: 'media' }] })).toBe('actions:\n  - domain: media');
+	});
+
+	it('keeps a blank line inside a multi-line block scalar', () => {
+		expect(toYaml({ css: 'a\n\nb' })).toBe('css: |-\n  a\n\n  b');
+	});
+
+	it('quotes a top-level scalar string containing a tab or leading/trailing whitespace', () => {
+		expect(toYaml('a\tb')).toBe('"a\\tb"');
+		expect(toYaml(' leading')).toBe('" leading"');
+		expect(toYaml('trailing ')).toBe('"trailing "');
+		expect(toYaml('a #comment-ish')).toBe('"a #comment-ish"');
 	});
 
 	it('renders a multi-line string as a block scalar (e.g. css)', () => {

--- a/client/src/lib/formula/engine.hostthrow.test.ts
+++ b/client/src/lib/formula/engine.hostthrow.test.ts
@@ -1,0 +1,22 @@
+// evalExpr's last-resort catch: QuickJS evaluates the expression fine, but bringing the RESULT
+// across (ctx.dump) explodes host-side on a pathologically deep value — evalExpr must yield null,
+// not an exception. Kept in its OWN file with NO afterAll dispose: the aborted dump strands QuickJS
+// handles, and disposing the runtime afterwards would trip QuickJS's leak assertion — the vitest
+// worker teardown reclaims the WASM instance instead. (engine.test.ts owns the normal
+// init/dispose lifecycle.)
+import { describe, expect, it } from 'vitest';
+import { evalExpr, initFormulaEngine, isFormulaEngineReady } from './engine';
+
+describe('evalExpr — host-side dump failure', () => {
+	it('returns null when the result is too deep to serialize back, and keeps working', async () => {
+		await initFormulaEngine();
+		expect(isFormulaEngineReady()).toBe(true);
+		// Built iteratively (no sandbox recursion): a 100k-deep nested array evaluates fine inside
+		// QuickJS but the host-side dump recurses over it and throws → the catch → null.
+		const deep =
+			'(function () { var a = []; var cur = a; for (var i = 0; i < 100000; i++) { var n = []; cur.push(n); cur = n; } return a; })()';
+		expect(evalExpr(deep, {})).toBeNull();
+		// The engine survives for subsequent, well-behaved evaluations.
+		expect(evalExpr('1 + 1', {})).toBe(2);
+	});
+});

--- a/client/src/lib/formula/packageSandbox.hostthrow.test.ts
+++ b/client/src/lib/formula/packageSandbox.hostthrow.test.ts
@@ -1,0 +1,35 @@
+// evalJson's last-resort catch: a hostile script THROWS a value so deep that dumping the error
+// object host-side (ctx.dump(out.error)) explodes — the tick must come back as { ok:false },
+// never as an exception. Kept in its OWN file with NO dispose calls: the aborted dump strands
+// QuickJS handles, and disposing that runtime would trip QuickJS's leak assertion — the vitest
+// worker teardown reclaims the WASM instance instead. (packageSandbox.test.ts owns the normal
+// create/dispose lifecycle.)
+import { describe, expect, it } from 'vitest';
+import { createPackageSandbox } from './packageSandbox';
+
+// requests() throws a 100k-deep nested array (built iteratively — no sandbox recursion): QuickJS
+// propagates the value as the eval error, and serializing it back to the host blows the dump.
+const THROW_DEEP_SCRIPT = `
+module.exports = {
+	requests: function () {
+		var a = []; var cur = a;
+		for (var i = 0; i < 100000; i++) { var n = []; cur.push(n); cur = n; }
+		throw a;
+	},
+	transform: function () { return []; }
+};
+`;
+
+describe('package sandbox — host-side dump failure', () => {
+	it('reports ok:false when the thrown error value cannot be brought across', async () => {
+		const r = await createPackageSandbox(THROW_DEEP_SCRIPT);
+		expect(r.ok).toBe(true);
+		if (!r.ok) return;
+
+		const out = r.sandbox.requests();
+		expect(out.ok).toBe(false);
+		if (!out.ok) expect(out.error.length).toBeGreaterThan(0);
+		// The sandbox survives for subsequent, well-behaved calls on the same runtime.
+		expect(r.sandbox.transform([])).toEqual({ ok: true, value: [] });
+	});
+});

--- a/client/src/lib/monitorLabel.test.ts
+++ b/client/src/lib/monitorLabel.test.ts
@@ -16,6 +16,12 @@ describe('compareMonitorOptions', () => {
 			'DISPLAY10'
 		]);
 	});
+
+	it('treats two "default" entries as equal', () => {
+		expect(
+			compareMonitorOptions({ key: 'default', name: 'A' }, { key: 'default', name: 'B' })
+		).toBe(0);
+	});
 });
 
 describe('monitorOptionLabel', () => {

--- a/client/src/lib/stt.test.ts
+++ b/client/src/lib/stt.test.ts
@@ -252,4 +252,40 @@ describe('stt', () => {
 		expect(() => rec2.cancel()).not.toThrow();
 		expect(tracks[0]!.stop).toHaveBeenCalled();
 	});
+
+	it('cancel() skips rec.stop() when the recorder is already inactive, still releasing the mic', async () => {
+		const tracks = [{ stop: vi.fn() }];
+		const created: FakeRecorder[] = [];
+		class FakeRecorder {
+			state = 'recording';
+			mimeType = '';
+			ondataavailable: ((e: { data: Blob }) => void) | null = null;
+			onstop: (() => void) | null = null;
+			onerror: (() => void) | null = null;
+			stopped = 0;
+			constructor() {
+				created.push(this);
+			}
+			start(): void {
+				/* no-op */
+			}
+			stop(): void {
+				this.stopped++;
+			}
+			static isTypeSupported(): boolean {
+				return false;
+			}
+		}
+		vi.stubGlobal('MediaRecorder', FakeRecorder);
+		vi.stubGlobal('navigator', {
+			mediaDevices: { getUserMedia: async () => ({ getTracks: () => tracks }) }
+		});
+
+		const rec = await startRecording();
+		const inst = created[0]!;
+		inst.state = 'inactive'; // the recorder already stopped on its own
+		rec.cancel();
+		expect(inst.stopped).toBe(0); // no redundant stop() on an inactive recorder
+		expect(tracks[0]!.stop).toHaveBeenCalled(); // mic still released
+	});
 });

--- a/client/src/lib/widgets/AudioSwitcherHost.test.tsx
+++ b/client/src/lib/widgets/AudioSwitcherHost.test.tsx
@@ -136,4 +136,16 @@ describe('AudioSwitcherHost (container wiring)', () => {
 		});
 		expect(listAudioOutputs).not.toHaveBeenCalled();
 	});
+
+	it('a stray interval tick after teardown is swallowed by the alive guard', async () => {
+		const setIntervalSpy = vi.spyOn(window, 'setInterval');
+		const { unmount } = render(<AudioSwitcherHost />);
+		await act(async () => undefined); // settle the mount refresh
+		const tick = setIntervalSpy.mock.calls.at(-1)?.[0] as () => void;
+		unmount();
+		listAudioOutputs.mockClear();
+		// clearInterval normally prevents this; if a queued tick slips through it must not refresh.
+		tick();
+		expect(listAudioOutputs).not.toHaveBeenCalled();
+	});
 });

--- a/client/src/lib/widgets/BackgroundLayer.test.tsx
+++ b/client/src/lib/widgets/BackgroundLayer.test.tsx
@@ -57,4 +57,15 @@ describe('BackgroundLayer', () => {
 		);
 		expect(container.querySelector('.bg-layer')).toBeNull();
 	});
+
+	it('uses the src verbatim when no resolveSrc is injected (identity default)', () => {
+		const { container } = render(<BackgroundLayer spec={{ kind: 'image', src: 'x.png' }} />);
+		const fill = container.querySelector('.bg-fill') as HTMLElement;
+		expect(fill.style.backgroundImage).toContain('x.png');
+	});
+
+	it('renders nothing when the spec has no src at all', () => {
+		const { container } = render(<BackgroundLayer spec={{ kind: 'image' }} />);
+		expect(container.querySelector('.bg-layer')).toBeNull();
+	});
 });

--- a/client/src/lib/widgets/BackgroundPanel.test.tsx
+++ b/client/src/lib/widgets/BackgroundPanel.test.tsx
@@ -96,6 +96,12 @@ describe('BackgroundPanel — colour kind', () => {
 		const color = container.querySelector('input[type="color"]') as HTMLInputElement;
 		expect(color.value).toBe('#0b0b0e');
 	});
+
+	it('falls back to the default colour when src is missing entirely', () => {
+		const { container } = renderPanel({ kind: 'color' });
+		const color = container.querySelector('input[type="color"]') as HTMLInputElement;
+		expect(color.value).toBe('#0b0b0e');
+	});
 });
 
 describe('BackgroundPanel — web kind', () => {
@@ -106,6 +112,12 @@ describe('BackgroundPanel — web kind', () => {
 		fireEvent.change(url, { target: { value: '  https://b  ' } });
 		fireEvent.blur(url);
 		expect(h.patchBg).toHaveBeenCalledWith({ src: 'https://b' });
+	});
+
+	it('renders an empty URL field for a web background with no src yet', () => {
+		const { container } = renderPanel({ kind: 'web' });
+		const url = container.querySelector('input[type="text"]') as HTMLInputElement;
+		expect(url.value).toBe('');
 	});
 });
 

--- a/client/src/lib/widgets/ColorField.test.tsx
+++ b/client/src/lib/widgets/ColorField.test.tsx
@@ -39,4 +39,31 @@ describe('ColorField', () => {
 		fireEvent.click(screen.getByLabelText('clear'));
 		expect(onChange).toHaveBeenCalledWith('');
 	});
+
+	it('does not re-commit an unchanged value on blur', () => {
+		const onChange = vi.fn();
+		render(<ColorField value="gold" ariaLabel="accent" onChange={onChange} />);
+		fireEvent.blur(screen.getByLabelText('accent'));
+		expect(onChange).not.toHaveBeenCalled(); // no redundant undo/save entry
+	});
+
+	it('falls back to a generic swatch label when no ariaLabel is given', () => {
+		render(<ColorField value="#112233" onChange={vi.fn()} />);
+		// Without an ariaLabel prop the swatch names itself "colour swatch" (default a11y label).
+		expect(screen.getByLabelText('colour swatch')).toBeInTheDocument();
+	});
+
+	it('resyncs the text field when the external value prop changes (store-previous idiom)', () => {
+		const onChange = vi.fn();
+		const { rerender } = render(<ColorField value="red" ariaLabel="accent" onChange={onChange} />);
+		const text = screen.getByLabelText('accent') as HTMLInputElement;
+		// A local (uncommitted) edit lives only in `text` until blur.
+		fireEvent.change(text, { target: { value: 'gr' } });
+		expect(text.value).toBe('gr');
+		// An external change (Clear / theme switch / selecting another widget) overwrites the local text.
+		rerender(<ColorField value="blue" ariaLabel="accent" onChange={onChange} />);
+		expect((screen.getByLabelText('accent') as HTMLInputElement).value).toBe('blue');
+		// The resync must not have committed the in-progress local edit.
+		expect(onChange).not.toHaveBeenCalled();
+	});
 });

--- a/client/src/lib/widgets/CssEditorImpl.test.tsx
+++ b/client/src/lib/widgets/CssEditorImpl.test.tsx
@@ -49,6 +49,17 @@ describe('CssEditorImpl', () => {
 		expect(onChange.mock.calls.at(-1)?.[0]).toBe('abc');
 	});
 
+	it('does not fire onChange for a doc-unchanged update (selection move only)', async () => {
+		const onChange = vi.fn();
+		const { container } = render(<CssEditorImpl value="abc" onChange={onChange} />);
+		await waitFor(() => expect(cmEditor(container)).toBeTruthy());
+		// A transaction with no document change still runs the updateListener — but must not commit.
+		act(() => {
+			view(container).dispatch({ selection: { anchor: 1 } });
+		});
+		expect(onChange).not.toHaveBeenCalled();
+	});
+
 	it('fires onBlur with the current doc when the content blurs', async () => {
 		const onBlur = vi.fn();
 		const { container } = render(<CssEditorImpl value="x: 1" onBlur={onBlur} />);

--- a/client/src/lib/widgets/DesignerListPanel.test.tsx
+++ b/client/src/lib/widgets/DesignerListPanel.test.tsx
@@ -7,6 +7,7 @@ vi.mock('../overlay', () => ({ copyToClipboard: vi.fn(() => Promise.resolve(true
 
 import DesignerListPanel from './DesignerListPanel';
 import { copyToClipboard } from '../overlay';
+import { registerTemplates, unregisterTemplates, TEMPLATES } from '../core/templates';
 import type { Library } from '../core/layoutTree';
 import type { DefEditor } from './canvas/useDefEditor';
 
@@ -133,6 +134,19 @@ describe('DesignerListPanel template groups', () => {
 	it('highlights the previewed template row by name', () => {
 		const { getByText } = render(<DesignerListPanel {...baseProps()} previewName="Network" />);
 		expect(getByText('Network').closest('.dl-item')!.className).toContain('cur');
+	});
+
+	it('labels a plugin template group "Templates · <group>" (built-ins stay plain "Templates")', () => {
+		// A plugin package contributes its own group; the built-in group keeps the unqualified header.
+		registerTemplates('My Pack', [{ ...TEMPLATES[1], id: 'pack-system', name: 'Pack System' }]);
+		try {
+			const { getByText } = render(<DesignerListPanel {...baseProps()} />);
+			expect(getByText('Templates')).toBeTruthy();
+			expect(getByText('Templates · My Pack')).toBeTruthy();
+			expect(getByText('Pack System')).toBeTruthy();
+		} finally {
+			unregisterTemplates('My Pack');
+		}
 	});
 });
 

--- a/client/src/lib/widgets/DiagnosticsPanel.test.tsx
+++ b/client/src/lib/widgets/DiagnosticsPanel.test.tsx
@@ -39,7 +39,8 @@ import {
 	reloadWindow,
 	requestDiagnostics,
 	setSubsystemProfiling,
-	setWindowInteractive
+	setWindowInteractive,
+	type SubsystemTiming
 } from '../diag';
 import { resetWidgetProfile, widgetCosts } from './canvas/widgetProfile';
 
@@ -169,6 +170,29 @@ describe('DiagnosticsPanel backend subsystem timings', () => {
 		expect(container.querySelector('.diag-cost-row[data-hot]')).toBeTruthy();
 		expect(container.querySelectorAll('.diag-cost-row[data-hot]').length).toBe(1);
 		await flush();
+	});
+
+	it('ignores a timings poll that resolves after unmount (alive guard)', async () => {
+		// The mount poll's promise is held open past unmount; resolving it then must hit the
+		// `if (alive)` bail — no setState on the dead tree (which would warn on console.error).
+		let resolveTimings: ((t: SubsystemTiming[]) => void) | undefined;
+		vi.mocked(getSubsystemTimings).mockImplementationOnce(
+			() =>
+				new Promise((r) => {
+					resolveTimings = r;
+				})
+		);
+		const { unmount } = render(<DiagnosticsPanel />);
+		await flush();
+		unmount();
+		const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+		await act(async () => {
+			resolveTimings?.([
+				{ key: 'sensors', avgMs: 1, lastMs: 1, samples: 1, perSec: 1, msPerSec: 1 }
+			]);
+		});
+		expect(errorSpy).not.toHaveBeenCalled();
+		errorSpy.mockRestore();
 	});
 });
 

--- a/client/src/lib/widgets/DragSnapLayer.test.tsx
+++ b/client/src/lib/widgets/DragSnapLayer.test.tsx
@@ -94,6 +94,28 @@ const MIXED_FLOATING_LAYOUT = JSON.stringify({
 	}
 });
 
+// LAYOUT with its only floating zone under a DIFFERENT id — for the stale-probe test, where a drag
+// snapshot taken against z1 resolves after the zone set has been re-snapshotted to this one.
+const OTHER_ZONE_LAYOUT = JSON.stringify({
+	version: 2,
+	monitors: {
+		default: {
+			root: { id: 'root', kind: 'col', children: [] },
+			floating: [
+				{
+					id: 'z2',
+					unit: {
+						id: 'z2',
+						type: 'zone',
+						rect: { x: 960, y: 0, w: 960, h: 1080 },
+						config: { matchExe: 'notepad.exe' }
+					}
+				}
+			]
+		}
+	}
+});
+
 // The layout loadLayoutRaw() serves; swapped per test, reset in beforeEach.
 let layoutJson = LAYOUT;
 
@@ -134,6 +156,7 @@ vi.mock('../overlay', () => ({
 }));
 
 import DragSnapLayer from './DragSnapLayer';
+import { currentMonitor } from '@tauri-apps/api/window';
 
 const settle = () => act(async () => void (await new Promise((r) => setTimeout(r, 0))));
 const pollOnce = () => act(async () => void (await new Promise((r) => setTimeout(r, 80))));
@@ -361,6 +384,67 @@ describe('DragSnapLayer (zone widgets)', () => {
 		// Only the single zone is a snap target; the group + clock contribute nothing.
 		expect(snapWindow).toHaveBeenCalledTimes(1);
 		expect(snapWindow).toHaveBeenCalledWith(7, { x: 0, y: 0, w: 960, h: 1080 });
+	});
+
+	it('tolerates currentMonitor() resolving null — keeps the default origin, still loads zones', async () => {
+		vi.mocked(currentMonitor).mockResolvedValueOnce(null);
+		pointerProbe.mockResolvedValue({ x: 480, y: 540, shift: true });
+		render(<DragSnapLayer />);
+		await settle();
+
+		act(() => handlers['win_drag_start']?.({ payload: { hwnd: 7 } }));
+		await pollOnce();
+		await act(async () => {
+			handlers['win_drag_end']?.({ payload: { hwnd: 7 } });
+			await Promise.resolve();
+		});
+
+		// The default monitor (origin 0,0 · scale 1) stands in, so the zone still arms and snaps.
+		expect(snapWindow).toHaveBeenCalledWith(7, { x: 0, y: 0, w: 960, h: 1080 });
+	});
+
+	it('drops the highlight when a stale probe resolves against a re-snapshotted zone set', async () => {
+		// tick() captures the phys zone list BEFORE awaiting the probe but reads the local-rect map
+		// AFTER it — so a probe that resolves after a layout change + a new drag re-snapshot can arm a
+		// zone that is no longer in the map. The highlight must fall back to null, not crash.
+		let resolveProbe: ((p: { x: number; y: number; shift: boolean }) => void) | null = null;
+		pointerProbe
+			.mockResolvedValueOnce({ x: 480, y: 540, shift: true }) // tick 1: arms z1 → highlight shows
+			.mockImplementationOnce(
+				() =>
+					new Promise((r) => {
+						resolveProbe = r;
+					})
+			) // tick 2: held open across the re-snapshot
+			.mockResolvedValue({ x: 0, y: 0, shift: false });
+		const view = render(<DragSnapLayer />);
+		await settle();
+
+		// Drag 1 snapshots zone z1; its first tick arms z1, the second blocks on the deferred probe.
+		act(() => handlers['win_drag_start']?.({ payload: { hwnd: 7 } }));
+		await act(async () => void (await new Promise((r) => setTimeout(r, 120))));
+		expect(view.container.querySelector('.zone-drag-highlight')).toBeTruthy();
+		expect(resolveProbe).toBeTruthy();
+
+		// The layout is replaced (only zone now z2) and a new drag re-snapshots the refs.
+		layoutJson = OTHER_ZONE_LAYOUT;
+		await act(async () => {
+			handlers['layout_changed']?.({ payload: {} });
+			await new Promise((r) => setTimeout(r, 0));
+		});
+		act(() => handlers['win_drag_start']?.({ payload: { hwnd: 7 } }));
+
+		// The stale probe (armed inside z1, absent from the new local map) resolves → highlight null.
+		await act(async () => {
+			resolveProbe?.({ x: 480, y: 540, shift: true });
+			await new Promise((r) => setTimeout(r, 0));
+		});
+		expect(view.container.querySelector('.zone-drag-highlight')).toBeNull();
+
+		await act(async () => {
+			handlers['win_drag_end']?.({ payload: { hwnd: 7 } });
+			await Promise.resolve();
+		});
 	});
 
 	it('unmounting before currentMonitor() resolves cancels the setup (alive guard)', async () => {

--- a/client/src/lib/widgets/ErrorBoundary.test.tsx
+++ b/client/src/lib/widgets/ErrorBoundary.test.tsx
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import ErrorBoundary from './ErrorBoundary';
+
+// A child that throws during render (what an error boundary catches) when given a value to throw.
+function Boom({ thrown }: { thrown?: unknown }) {
+	if (thrown !== undefined) throw thrown;
+	return <div>healthy</div>;
+}
+
+describe('ErrorBoundary', () => {
+	beforeEach(() => {
+		// React logs every caught render error to console.error; silence it (and let us assert on it).
+		vi.spyOn(console, 'error').mockImplementation(() => undefined);
+	});
+	afterEach(() => vi.restoreAllMocks());
+
+	it('renders its children when they do not throw', () => {
+		const { getByText, queryByRole } = render(
+			<ErrorBoundary label="settings">
+				<Boom />
+			</ErrorBoundary>
+		);
+		expect(getByText('healthy')).toBeTruthy();
+		expect(queryByRole('alert')).toBeNull();
+	});
+
+	it('shows a labelled inline fallback with the error message when a child throws', () => {
+		const { getByRole } = render(
+			<ErrorBoundary label="HA settings">
+				<Boom thrown={new Error('kaboom')} />
+			</ErrorBoundary>
+		);
+		expect(getByRole('alert').textContent).toContain('HA settings failed to render: kaboom');
+	});
+
+	it('falls back to the default label when none is given', () => {
+		const { getByRole } = render(
+			<ErrorBoundary>
+				<Boom thrown={new Error('kaboom')} />
+			</ErrorBoundary>
+		);
+		expect(getByRole('alert').textContent).toContain('This panel failed to render: kaboom');
+	});
+
+	it('stringifies a non-Error throw (a plugin can throw anything)', () => {
+		const { getByRole } = render(
+			<ErrorBoundary>
+				<Boom thrown="plain failure" />
+			</ErrorBoundary>
+		);
+		expect(getByRole('alert').textContent).toContain('failed to render: plain failure');
+	});
+
+	it('logs the crash to console.error, using the label when given and "panel" otherwise', () => {
+		render(
+			<ErrorBoundary>
+				<Boom thrown={new Error('kaboom')} />
+			</ErrorBoundary>
+		);
+		expect(console.error).toHaveBeenCalledWith('panel crashed', expect.any(Error));
+		render(
+			<ErrorBoundary label="HA settings">
+				<Boom thrown={new Error('kaboom')} />
+			</ErrorBoundary>
+		);
+		expect(console.error).toHaveBeenCalledWith('HA settings crashed', expect.any(Error));
+	});
+});

--- a/client/src/lib/widgets/GroupFrame.test.tsx
+++ b/client/src/lib/widgets/GroupFrame.test.tsx
@@ -163,6 +163,19 @@ describe('GroupFrame', () => {
 		expect(onSelect).toHaveBeenCalledWith({ id: 'grp-1' });
 	});
 
+	it('subsequent moves after crossing the slop keep firing onChange (moved is latched)', () => {
+		const onChange = vi.fn();
+		const { container } = render(
+			<GroupFrame id="grp-1" rect={rect} editMode selected onChange={onChange} />
+		);
+		const ov = overlay(container);
+		fireEvent.pointerDown(ov, { button: 0, pointerId: 1, clientX: 10, clientY: 10 });
+		fireEvent.pointerMove(ov, { pointerId: 1, clientX: 40, clientY: 10 }); // crosses the slop
+		// back within the slop radius of the press: still a move — the gate only applies pre-drag
+		fireEvent.pointerMove(ov, { pointerId: 1, clientX: 12, clientY: 10 });
+		expect(onChange).toHaveBeenCalledTimes(2);
+	});
+
 	it('right-button press is a free-move (skipFlow): commit skips flow + suppresses the next menu', () => {
 		const onChange = vi.fn();
 		const onCommit = vi.fn();

--- a/client/src/lib/widgets/Inspector.wiring.test.tsx
+++ b/client/src/lib/widgets/Inspector.wiring.test.tsx
@@ -1,0 +1,1268 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
+import Inspector from './Inspector';
+import {
+	container,
+	group,
+	leaf,
+	type Group,
+	type WidgetDef,
+	type WidgetInstance
+} from '../core/layoutTree';
+import type { ConfigField } from '../core/widget';
+import type { LayoutOp } from './ops';
+import { registerTemplates, unregisterTemplates } from '../core/templates';
+
+// The hover popover renders real meters; every wiring test asserts on the popover's text, never a
+// live render, so stub it to a cheap div.
+vi.mock('./WidgetPreview', () => ({ default: () => null }));
+
+// CodeMirror is lazy-loaded (Suspense) and never resolves under happy-dom, so the real CssEditor
+// renders only its loading placeholder and its onBlur never fires. Swap it for a plain textarea whose
+// blur forwards the current text — that's the exact contract the Inspector's css setters consume.
+vi.mock('./CssEditor', () => ({
+	default: (props: {
+		value?: string;
+		ariaLabel?: string;
+		placeholder?: string;
+		onBlur: (value: string) => void;
+	}) => (
+		<textarea
+			aria-label={props.ariaLabel}
+			placeholder={props.placeholder}
+			defaultValue={props.value ?? ''}
+			onBlur={(e) => props.onBlur(e.currentTarget.value)}
+		/>
+	)
+}));
+
+// The monitor-sources field's effect calls the Tauri-backed DDC adapter; stub it to "no inputs".
+vi.mock('../ddc/monitors', () => ({
+	listMonitorInputs: vi.fn().mockResolvedValue([]),
+	setMonitorInput: vi.fn().mockResolvedValue(true)
+}));
+
+const w = (over: Partial<WidgetInstance> = {}): WidgetInstance => ({
+	id: 'w1',
+	type: 'clock',
+	rect: { x: 0, y: 0, w: 160, h: 40 },
+	config: {},
+	...over
+});
+const gaugeWidget = (config: Record<string, unknown> = {}): WidgetInstance => ({
+	id: 'w1',
+	type: 'gauge',
+	rect: { x: 0, y: 0, w: 110, h: 110 },
+	config
+});
+
+const panel = (): HTMLElement => screen.getByRole('tabpanel');
+const palette = (): HTMLElement =>
+	screen.getByText(/＋ Add widget/).closest('details') as HTMLElement;
+const lastOp = (onOp: ReturnType<typeof vi.fn>, op: string): LayoutOp | undefined =>
+	onOp.mock.calls
+		.map((c) => c[0] as LayoutOp)
+		.reverse()
+		.find((o) => o.op === op);
+const configPatch = (onOp: ReturnType<typeof vi.fn>): Record<string, unknown> | undefined => {
+	const p = lastOp(onOp, 'patchWidget');
+	return p && p.op === 'patchWidget' ? (p.patch.config as Record<string, unknown>) : undefined;
+};
+
+// ---------------------------------------------------------------------------------------------------
+describe('Inspector manual-save dirty tracking (computeDirty)', () => {
+	it('flags a widget field that differs from its saved baseline, and leaves matching ones clean', () => {
+		const widget = w({
+			sensor: 'cpu.total',
+			rect: { x: 1, y: 2, w: 3, h: 4 },
+			config: { a: 1 },
+			css: 'x'
+		});
+		// The baseline differs in sensor / rect.x / config / css; y·w·h match.
+		const base = w({ sensor: undefined, rect: { x: 9, y: 2, w: 3, h: 4 }, config: { b: 2 } });
+		render(
+			<Inspector
+				widget={widget}
+				baseWidget={base}
+				baseTokens={{ '--np-fg': 'blue', '--np-bg': 'x', '--np-label': 'same' }}
+				tokens={{ '--np-fg': 'red', '--np-accent': 'z', '--np-label': 'same' }}
+				placement="floating"
+				node={leaf(widget)}
+				onOp={vi.fn()}
+			/>
+		);
+		expect(within(panel()).getByText('sensor').closest('label')!.className).toContain('dirty');
+		// y matched the baseline → not flagged.
+		expect(within(panel()).getByText('y').closest('label')!.className).not.toContain('dirty');
+	});
+
+	it('does not flag any widget field when the baseline is identical', () => {
+		const widget = w({ sensor: 'cpu.total', config: { a: 1 } });
+		render(
+			<Inspector
+				widget={widget}
+				baseWidget={w({ sensor: 'cpu.total', config: { a: 1 } })}
+				placement="floating"
+				node={leaf(widget)}
+				onOp={vi.fn()}
+			/>
+		);
+		expect(within(panel()).getByText('sensor').closest('label')!.className).not.toContain('dirty');
+	});
+
+	it('treats every field of a brand-new node as dirty (nodeIsNew ignores the baseline)', () => {
+		const widget = w({ sensor: 'cpu.total' });
+		render(
+			<Inspector
+				widget={widget}
+				baseWidget={w({ sensor: 'cpu.total' })}
+				nodeIsNew
+				placement="floating"
+				node={leaf(widget)}
+				onOp={vi.fn()}
+			/>
+		);
+		// Same values as the baseline, but a new node reads everything as changed.
+		expect(within(panel()).getByText('sensor').closest('label')!.className).toContain('dirty');
+	});
+
+	it('flags changed container fields against a baseline', () => {
+		const c = container('root', 'col', [], {
+			cols: 2,
+			rows: 2,
+			gap: 4,
+			pad: 8,
+			margin: 2,
+			align: 'center',
+			justify: 'center',
+			basis: { fr: 1 },
+			overlap: true,
+			cellW: 10,
+			cellH: 20,
+			aspect: 1.5,
+			condition: { kind: 'appOpen' }
+		});
+		const baseC = container('root', 'grid', [], {});
+		render(<Inspector container={c} baseContainer={baseC} isGridCell onOp={vi.fn()} />);
+		expect(within(panel()).getByText('kind').closest('label')!.className).toContain('dirty');
+	});
+
+	it('flags changed group name / css / params against a baseline', () => {
+		const child = leaf(w({ id: 'c', type: 'clock' }));
+		const g = group('g1', { w: 1, h: 1 }, child, { name: 'A', css: 'x', params: { p: 'PVAL' } });
+		const base = group('g1', { w: 1, h: 1 }, child, { name: 'B', params: { q: '2' } });
+		const def: WidgetDef = {
+			id: 'd1',
+			name: 'Def',
+			size: { w: 1, h: 1 },
+			child,
+			params: [{ key: 'p', label: 'P', target: 'unit.config.p' }]
+		};
+		render(<Inspector groupUnit={g} baseGroup={base} def={def} placement="flow" onOp={vi.fn()} />);
+		expect(screen.getByText('name').closest('label')!.className).toContain('dirty');
+		// The param label's text is split across nodes ("P → unit.config.p"), so getByText('P') can't
+		// find it — locate the label through its input's (distinct) display value instead.
+		expect(screen.getByDisplayValue('PVAL').closest('label')!.className).toContain('dirty');
+	});
+
+	it('leaves group fields clean when they match the baseline exactly', () => {
+		const child = leaf(w({ id: 'c', type: 'clock' }));
+		const g = group('g1', { w: 9, h: 9 }, child, { name: 'Same', params: { p: 'PVAL' } });
+		const base = group('g1', { w: 9, h: 9 }, child, { name: 'Same', params: { p: 'PVAL' } });
+		const def: WidgetDef = {
+			id: 'd1',
+			name: 'Def',
+			size: { w: 9, h: 9 },
+			child,
+			params: [{ key: 'p', label: 'P', target: 'unit.config.p' }]
+		};
+		render(<Inspector groupUnit={g} baseGroup={base} def={def} placement="flow" onOp={vi.fn()} />);
+		expect(screen.getByText('name').closest('label')!.className).not.toContain('dirty');
+		expect(screen.getByDisplayValue('PVAL').closest('label')!.className).not.toContain('dirty');
+	});
+});
+
+// ---------------------------------------------------------------------------------------------------
+describe('Inspector add-palette hover preview (debounced popover)', () => {
+	beforeEach(() => vi.useFakeTimers());
+	afterEach(() => vi.useRealTimers());
+
+	const gaugeType = [{ type: 'gauge', label: 'Gauge', category: 'Meters' }];
+	const libDef: WidgetDef = {
+		id: 'd1',
+		name: 'My Widget',
+		size: { w: 100, h: 40 },
+		child: leaf(w({ id: 'd1-w', type: 'clock' }))
+	};
+
+	it('opens a preview after the debounce and closes it on mouse-leave', () => {
+		render(<Inspector widgetTypes={gaugeType} onOp={vi.fn()} />);
+		const gauge = within(palette()).getByRole('button', { name: /^Gauge/ });
+		fireEvent.mouseEnter(gauge);
+		// Debounced — nothing yet.
+		expect(document.querySelector('.palette-preview')).toBeNull();
+		act(() => vi.advanceTimersByTime(300));
+		expect(screen.getByText('Gauge', { selector: '.pp-name' })).toBeTruthy();
+		expect(document.querySelector('.pp-desc')).toBeTruthy(); // gauge meta has a description
+		expect(screen.getByText('Click to add · drag to place', { selector: '.pp-hint' })).toBeTruthy();
+		fireEvent.mouseLeave(gauge);
+		expect(document.querySelector('.palette-preview')).toBeNull();
+	});
+
+	it('names the destination container in the hint when one is selected', () => {
+		render(
+			<Inspector widgetTypes={gaugeType} container={container('root', 'col', [])} onOp={vi.fn()} />
+		);
+		fireEvent.mouseEnter(within(palette()).getByRole('button', { name: /^Gauge/ }));
+		act(() => vi.advanceTimersByTime(300));
+		expect(screen.getByText(/Click to add into the col/, { selector: '.pp-hint' })).toBeTruthy();
+	});
+
+	it('previews a library def with no description (hint only)', () => {
+		render(<Inspector defs={[libDef]} onOp={vi.fn()} />);
+		fireEvent.mouseEnter(within(palette()).getByRole('button', { name: 'My Widget' }));
+		act(() => vi.advanceTimersByTime(300));
+		expect(screen.getByText('My Widget', { selector: '.pp-name' })).toBeTruthy();
+		expect(document.querySelector('.pp-desc')).toBeNull(); // a def carries no description
+	});
+
+	it('previews a template on hover', () => {
+		render(<Inspector onOp={vi.fn()} />);
+		fireEvent.mouseEnter(within(palette()).getByRole('button', { name: /^System monitor/ }));
+		act(() => vi.advanceTimersByTime(300));
+		expect(screen.getByText('System monitor', { selector: '.pp-name' })).toBeTruthy();
+	});
+
+	it('cancels a pending preview when the pointer moves to another entry', () => {
+		render(
+			<Inspector
+				widgetTypes={[
+					{ type: 'gauge', label: 'Gauge', category: 'Meters' },
+					{ type: 'clock', label: 'Clock', category: 'Clocks' }
+				]}
+				onOp={vi.fn()}
+			/>
+		);
+		fireEvent.mouseEnter(within(palette()).getByRole('button', { name: /^Gauge/ }));
+		// Re-hover before the first debounce elapses → the first timer is cleared.
+		fireEvent.mouseEnter(within(palette()).getByRole('button', { name: /^Clock/ }));
+		act(() => vi.advanceTimersByTime(300));
+		expect(screen.getByText('Clock', { selector: '.pp-name' })).toBeTruthy();
+		expect(screen.queryByText('Gauge', { selector: '.pp-name' })).toBeNull();
+	});
+
+	it('clears a pending preview timer on unmount without firing', () => {
+		const { unmount } = render(<Inspector widgetTypes={gaugeType} onOp={vi.fn()} />);
+		fireEvent.mouseEnter(within(palette()).getByRole('button', { name: /^Gauge/ }));
+		unmount();
+		// The cleanup cancelled the timer — advancing must not throw or resurrect a popover.
+		act(() => vi.advanceTimersByTime(300));
+		expect(document.querySelector('.palette-preview')).toBeNull();
+	});
+});
+
+// ---------------------------------------------------------------------------------------------------
+describe('Inspector add-palette open state', () => {
+	it('collapses when a node is selected and re-opens when the selection clears', () => {
+		const { rerender } = render(<Inspector onOp={vi.fn()} />);
+		const details = palette() as HTMLDetailsElement;
+		expect(details.open).toBe(true); // nothing selected → the primary add affordance is open
+		rerender(<Inspector widget={w()} placement="floating" onOp={vi.fn()} />);
+		expect((palette() as HTMLDetailsElement).open).toBe(false); // selecting collapses it
+		rerender(<Inspector onOp={vi.fn()} />);
+		expect((palette() as HTMLDetailsElement).open).toBe(true); // clearing re-opens it
+	});
+
+	it('keeps its open state in sync when the user toggles the panel', () => {
+		render(<Inspector onOp={vi.fn()} />);
+		const details = palette() as HTMLDetailsElement;
+		details.open = false;
+		fireEvent(details, new Event('toggle'));
+		expect(screen.getByText(/＋ Add widget/)).toBeTruthy(); // still rendered, no crash
+	});
+
+	it('shows a plugin template group under its own heading', () => {
+		registerTemplates('MyPlugin', [
+			{
+				id: 'plug-1',
+				name: 'Plugin Widget',
+				description: 'from a plugin',
+				size: { w: 10, h: 10 },
+				tree: () => leaf(w({ id: 'p', type: 'text' }))
+			}
+		]);
+		try {
+			render(<Inspector onOp={vi.fn()} />);
+			expect(within(palette()).getByText('Templates · MyPlugin', { selector: '.hd' })).toBeTruthy();
+			expect(within(palette()).getByRole('button', { name: /^Plugin Widget/ })).toBeTruthy();
+		} finally {
+			unregisterTemplates('MyPlugin');
+		}
+	});
+});
+
+// ---------------------------------------------------------------------------------------------------
+describe('Inspector widget actions + rect + sensor', () => {
+	it('emits dock / make widget / reset / remove from a floating widget', () => {
+		const onOp = vi.fn<(op: LayoutOp) => void>();
+		render(<Inspector widget={w()} placement="floating" onOp={onOp} />);
+		fireEvent.click(within(panel()).getByRole('button', { name: 'Dock →flow' }));
+		expect(lastOp(onOp, 'dock')).toEqual({ op: 'dock', id: 'w1' });
+		fireEvent.click(within(panel()).getByRole('button', { name: 'Make widget' }));
+		expect(lastOp(onOp, 'makeWidget')).toEqual({ op: 'makeWidget', id: 'w1' });
+		fireEvent.click(within(panel()).getByRole('button', { name: 'Reset' }));
+		expect(lastOp(onOp, 'resetWidget')).toEqual({ op: 'resetWidget', id: 'w1' });
+		fireEvent.click(within(panel()).getByRole('button', { name: 'Remove' }));
+		expect(lastOp(onOp, 'remove')).toEqual({ op: 'remove', id: 'w1' });
+	});
+
+	it('emits float from a flow widget', () => {
+		const onOp = vi.fn<(op: LayoutOp) => void>();
+		render(<Inspector widget={w()} placement="flow" onOp={onOp} />);
+		fireEvent.click(within(panel()).getByRole('button', { name: 'Float' }));
+		expect(lastOp(onOp, 'float')).toEqual({ op: 'float', id: 'w1' });
+	});
+
+	it('edits the floating rect via updateRect', () => {
+		const onOp = vi.fn<(op: LayoutOp) => void>();
+		render(<Inspector widget={w()} placement="floating" onOp={onOp} />);
+		fireEvent.input(within(panel()).getByRole('spinbutton', { name: 'x' }), {
+			target: { value: '50' }
+		});
+		expect(lastOp(onOp, 'patchWidget')).toMatchObject({ patch: { rect: { x: 50 } } });
+	});
+
+	it('edits the flow fixed w/h via updateRect', () => {
+		const onOp = vi.fn<(op: LayoutOp) => void>();
+		render(<Inspector widget={w()} placement="flow" onOp={onOp} />);
+		fireEvent.input(within(panel()).getByRole('spinbutton', { name: 'w (fixed)' }), {
+			target: { value: '80' }
+		});
+		expect(lastOp(onOp, 'patchWidget')).toMatchObject({ patch: { rect: { w: 80 } } });
+	});
+
+	it('sets and clears the sensor through the typeahead', () => {
+		const onOp = vi.fn<(op: LayoutOp) => void>();
+		render(<Inspector widget={w()} placement="floating" sensors={['gpu.util']} onOp={onOp} />);
+		const input = screen.getByRole('combobox', { name: 'sensor' });
+		fireEvent.change(input, { target: { value: 'gpu.util' } });
+		expect(lastOp(onOp, 'patchWidget')).toMatchObject({ patch: { sensor: 'gpu.util' } });
+		fireEvent.change(input, { target: { value: '' } });
+		expect(lastOp(onOp, 'patchWidget')).toMatchObject({ patch: { sensor: undefined } });
+	});
+
+	it('labels a sensor option by name only when it carries no unit', () => {
+		render(
+			<Inspector
+				widget={w()}
+				placement="floating"
+				sensors={['ha.x']}
+				sensorMeta={{ 'ha.x': { label: 'Kitchen' } }}
+				onOp={vi.fn()}
+			/>
+		);
+		fireEvent.click(screen.getByRole('combobox', { name: 'sensor' }));
+		expect(screen.getByText('Kitchen', { selector: '.np-select-opt-label' })).toBeTruthy();
+	});
+});
+
+// ---------------------------------------------------------------------------------------------------
+describe('Inspector per-leaf placement controls (flow widget)', () => {
+	it('sets horizontal and vertical alignment via setLeafAlign', () => {
+		const onOp = vi.fn<(op: LayoutOp) => void>();
+		render(<Inspector widget={w()} placement="flow" widgetValign="top" onOp={onOp} />);
+		fireEvent.click(within(panel()).getByLabelText('horizontal align'));
+		fireEvent.click(screen.getByText('center', { selector: '.np-select-opt-label' }));
+		expect(lastOp(onOp, 'setLeafAlign')).toEqual({
+			op: 'setLeafAlign',
+			id: 'w1',
+			halign: 'center',
+			valign: 'top'
+		});
+	});
+
+	it('sets vertical alignment keeping the current horizontal placement', () => {
+		const onOp = vi.fn<(op: LayoutOp) => void>();
+		render(<Inspector widget={w()} placement="flow" widgetHalign="right" onOp={onOp} />);
+		fireEvent.click(within(panel()).getByLabelText('vertical align'));
+		fireEvent.click(screen.getByText('middle', { selector: '.np-select-opt-label' }));
+		expect(lastOp(onOp, 'setLeafAlign')).toEqual({
+			op: 'setLeafAlign',
+			id: 'w1',
+			halign: 'right',
+			valign: 'middle'
+		});
+	});
+
+	it('edits the leaf margin and pad boxes via setLeafBox', () => {
+		const onOp = vi.fn<(op: LayoutOp) => void>();
+		const widget = w();
+		render(<Inspector widget={widget} placement="flow" node={leaf(widget)} onOp={onOp} />);
+		fireEvent.input(within(panel()).getByLabelText('margin all sides'), { target: { value: '8' } });
+		expect(lastOp(onOp, 'setLeafBox')).toEqual({
+			op: 'setLeafBox',
+			id: 'w1',
+			field: 'margin',
+			value: 8
+		});
+		fireEvent.input(within(panel()).getByLabelText('pad all sides'), { target: { value: '4' } });
+		expect(lastOp(onOp, 'setLeafBox')).toEqual({
+			op: 'setLeafBox',
+			id: 'w1',
+			field: 'pad',
+			value: 4
+		});
+	});
+});
+
+// ---------------------------------------------------------------------------------------------------
+describe('Inspector group flow sizing (leafSizingControls)', () => {
+	const grp = (): Group =>
+		group('g1', { w: 100, h: 40 }, leaf(w({ id: 'c', type: 'clock' })), { name: 'G' });
+
+	// NB: the group branch renders a plain `.fields` div (no role="tabpanel" — only the container and
+	// widget branches carry one), so these query at screen level.
+	it('shows "grow" for an fr basis and emits a content basis for "hug"', () => {
+		const onOp = vi.fn<(op: LayoutOp) => void>();
+		const g = grp();
+		render(
+			<Inspector
+				groupUnit={g}
+				placement="flow"
+				widgetBasis={{ fr: 1 }}
+				node={leaf(g)}
+				onOp={onOp}
+			/>
+		);
+		const trigger = screen.getByLabelText('size in parent');
+		expect(trigger).toHaveTextContent(/fill/i);
+		fireEvent.click(trigger);
+		fireEvent.click(screen.getByText('hug — fit content', { selector: '.np-select-opt-label' }));
+		expect(lastOp(onOp, 'setBasis')).toEqual({ op: 'setBasis', id: 'g1', basis: 'content' });
+	});
+
+	it('emits an fr basis for "fill" from a fit start', () => {
+		const onOp = vi.fn<(op: LayoutOp) => void>();
+		const g = grp();
+		render(<Inspector groupUnit={g} placement="flow" node={leaf(g)} onOp={onOp} />);
+		const trigger = screen.getByLabelText('size in parent');
+		expect(trigger).toHaveTextContent(/hug/i); // no basis → fit
+		fireEvent.click(trigger);
+		fireEvent.click(screen.getByText('fill — grow to share', { selector: '.np-select-opt-label' }));
+		expect(lastOp(onOp, 'setBasis')).toEqual({ op: 'setBasis', id: 'g1', basis: { fr: 1 } });
+	});
+
+	it('emits a 100px basis for "fixed" and edits the px input when the basis is numeric', () => {
+		const onOp = vi.fn<(op: LayoutOp) => void>();
+		const g = grp();
+		// Start from grow so picking "fixed" is an actual change.
+		const { rerender } = render(
+			<Inspector
+				groupUnit={g}
+				placement="flow"
+				widgetBasis={{ fr: 1 }}
+				node={leaf(g)}
+				onOp={onOp}
+			/>
+		);
+		fireEvent.click(screen.getByLabelText('size in parent'));
+		fireEvent.click(screen.getByText('fixed (px)', { selector: '.np-select-opt-label' }));
+		expect(lastOp(onOp, 'setBasis')).toEqual({ op: 'setBasis', id: 'g1', basis: 100 });
+
+		// A numeric basis exposes the px input.
+		rerender(
+			<Inspector groupUnit={g} placement="flow" widgetBasis={120} node={leaf(g)} onOp={onOp} />
+		);
+		expect(screen.getByLabelText('size in parent')).toHaveTextContent(/fixed/i);
+		fireEvent.input(screen.getByRole('spinbutton', { name: 'size (px)' }), {
+			target: { value: '75' }
+		});
+		expect(lastOp(onOp, 'setBasis')).toEqual({ op: 'setBasis', id: 'g1', basis: 75 });
+	});
+});
+
+// ---------------------------------------------------------------------------------------------------
+describe('Inspector container wiring', () => {
+	it('writes cross-axis align and main-axis justify via setAlignField', () => {
+		const onOp = vi.fn<(op: LayoutOp) => void>();
+		render(
+			<Inspector container={container('root', 'col', [], { align: 'stretch' })} onOp={onOp} />
+		);
+		// A col: "Horizontal" writes align, "Vertical" writes justify.
+		fireEvent.click(within(panel()).getByLabelText('Horizontal'));
+		fireEvent.click(screen.getByText('left', { selector: '.np-select-opt-label' }));
+		expect(lastOp(onOp, 'patchContainer')).toEqual({
+			op: 'patchContainer',
+			id: 'root',
+			patch: { align: 'start' }
+		});
+		fireEvent.click(within(panel()).getByLabelText('Vertical'));
+		fireEvent.click(screen.getByText('middle', { selector: '.np-select-opt-label' }));
+		expect(lastOp(onOp, 'patchContainer')).toEqual({
+			op: 'patchContainer',
+			id: 'root',
+			patch: { justify: 'center' }
+		});
+	});
+
+	it('sets a fixed 100px container basis via setContainerSizing', () => {
+		const onOp = vi.fn<(op: LayoutOp) => void>();
+		render(
+			<Inspector container={container('root', 'col', [], { basis: { fr: 1 } })} onOp={onOp} />
+		);
+		fireEvent.click(within(panel()).getByLabelText('container size in parent'));
+		fireEvent.click(screen.getByText('fixed (px)', { selector: '.np-select-opt-label' }));
+		expect(lastOp(onOp, 'patchContainer')).toEqual({
+			op: 'patchContainer',
+			id: 'root',
+			patch: { basis: 100 }
+		});
+	});
+
+	it('coerces an emptied fixed-px basis input to 0', () => {
+		const onOp = vi.fn<(op: LayoutOp) => void>();
+		render(<Inspector container={container('root', 'col', [], { basis: 120 })} onOp={onOp} />);
+		fireEvent.input(within(panel()).getByRole('spinbutton', { name: 'size (px)' }), {
+			target: { value: '' }
+		});
+		expect(lastOp(onOp, 'patchContainer')).toEqual({
+			op: 'patchContainer',
+			id: 'root',
+			patch: { basis: 0 }
+		});
+	});
+
+	it('clears overlap back to undefined when unchecked', () => {
+		const onOp = vi.fn<(op: LayoutOp) => void>();
+		render(<Inspector container={container('root', 'col', [], { overlap: true })} onOp={onOp} />);
+		fireEvent.click(within(panel()).getByRole('checkbox', { name: /stack children/i }));
+		expect(lastOp(onOp, 'patchContainer')).toEqual({
+			op: 'patchContainer',
+			id: 'root',
+			patch: { overlap: undefined }
+		});
+	});
+
+	it('edits container rows and the container margin box', () => {
+		const onOp = vi.fn<(op: LayoutOp) => void>();
+		render(<Inspector container={container('g', 'grid', [], { cols: 2, rows: 2 })} onOp={onOp} />);
+		fireEvent.input(within(panel()).getByRole('spinbutton', { name: 'rows' }), {
+			target: { value: '3' }
+		});
+		expect(lastOp(onOp, 'patchContainer')).toEqual({
+			op: 'patchContainer',
+			id: 'g',
+			patch: { rows: 3 }
+		});
+		fireEvent.input(within(panel()).getByLabelText('margin all sides'), { target: { value: '6' } });
+		expect(lastOp(onOp, 'patchContainer')).toEqual({
+			op: 'patchContainer',
+			id: 'g',
+			patch: { margin: 6 }
+		});
+	});
+
+	it('offers "Reset tracks (even)" once tracks have been dragged, emitting distributeEvenly', () => {
+		const onOp = vi.fn<(op: LayoutOp) => void>();
+		render(
+			<Inspector
+				container={container('g', 'grid', [], { cols: 2, rows: 2, colFr: [2, 1] })}
+				onOp={onOp}
+			/>
+		);
+		fireEvent.click(within(panel()).getByRole('button', { name: /Reset tracks/ }));
+		expect(lastOp(onOp, 'distributeEvenly')).toEqual({ op: 'distributeEvenly', containerId: 'g' });
+	});
+
+	it('edits grid-cell height and aspect, and clears them when emptied', () => {
+		const onOp = vi.fn<(op: LayoutOp) => void>();
+		render(
+			<Inspector
+				container={container('cell', 'col', [], { cellW: 5, cellH: 40, aspect: 1.5 })}
+				isGridCell
+				onOp={onOp}
+			/>
+		);
+		fireEvent.input(within(panel()).getByRole('spinbutton', { name: 'height (px)' }), {
+			target: { value: '64' }
+		});
+		expect(lastOp(onOp, 'patchContainer')).toEqual({
+			op: 'patchContainer',
+			id: 'cell',
+			patch: { cellH: 64 }
+		});
+		fireEvent.input(within(panel()).getByRole('spinbutton', { name: /aspect/ }), {
+			target: { value: '' }
+		});
+		expect(lastOp(onOp, 'patchContainer')).toEqual({
+			op: 'patchContainer',
+			id: 'cell',
+			patch: { aspect: undefined }
+		});
+	});
+});
+
+// ---------------------------------------------------------------------------------------------------
+describe('Inspector CSS editors', () => {
+	it('commits widget css on blur, mapping an empty value to undefined', () => {
+		const onOp = vi.fn<(op: LayoutOp) => void>();
+		render(<Inspector widget={w()} placement="floating" onOp={onOp} />);
+		const css = screen.getByLabelText('widget css');
+		fireEvent.change(css, { target: { value: 'color: red;' } });
+		fireEvent.blur(css);
+		expect(lastOp(onOp, 'patchWidget')).toEqual({
+			op: 'patchWidget',
+			id: 'w1',
+			patch: { css: 'color: red;' }
+		});
+		fireEvent.change(css, { target: { value: '' } });
+		fireEvent.blur(css);
+		expect(lastOp(onOp, 'patchWidget')).toEqual({
+			op: 'patchWidget',
+			id: 'w1',
+			patch: { css: undefined }
+		});
+	});
+
+	it('commits group css and def css on blur', () => {
+		const onOp = vi.fn<(op: LayoutOp) => void>();
+		const child = leaf(w({ id: 'c', type: 'clock' }));
+		const g = group('g1', { w: 1, h: 1 }, child, { name: 'G', def: 'd1' });
+		const def: WidgetDef = { id: 'd1', name: 'Def', size: { w: 1, h: 1 }, child };
+		render(<Inspector groupUnit={g} def={def} placement="flow" onOp={onOp} />);
+		const groupCss = screen.getByLabelText('group css');
+		fireEvent.change(groupCss, { target: { value: '.g {}' } });
+		fireEvent.blur(groupCss);
+		expect(lastOp(onOp, 'patchGroup')).toMatchObject({ patch: { css: '.g {}' } });
+		const defCss = screen.getByLabelText('def css');
+		fireEvent.change(defCss, { target: { value: '.d {}' } });
+		fireEvent.blur(defCss);
+		expect(lastOp(onOp, 'setDefCss')).toEqual({ op: 'setDefCss', defId: 'd1', css: '.d {}' });
+	});
+});
+
+// ---------------------------------------------------------------------------------------------------
+describe('Inspector group def params + floating group', () => {
+	it('adds a def param with no target (target omitted)', () => {
+		const onOp = vi.fn<(op: LayoutOp) => void>();
+		const child = leaf(w({ id: 'c', type: 'clock' }));
+		const g = group('g1', { w: 1, h: 1 }, child, { name: 'G', def: 'd1' });
+		const def: WidgetDef = { id: 'd1', name: 'Def', size: { w: 1, h: 1 }, child };
+		render(<Inspector groupUnit={g} def={def} placement="flow" onOp={onOp} />);
+		fireEvent.change(screen.getByPlaceholderText('param key'), { target: { value: 'k' } });
+		fireEvent.click(screen.getByRole('button', { name: 'Add param' }));
+		expect(lastOp(onOp, 'addDefParam')).toEqual({
+			op: 'addDefParam',
+			defId: 'd1',
+			key: 'k',
+			target: undefined
+		});
+	});
+
+	it('does not add a param when the key field is empty', () => {
+		const onOp = vi.fn<(op: LayoutOp) => void>();
+		const child = leaf(w({ id: 'c', type: 'clock' }));
+		const g = group('g1', { w: 1, h: 1 }, child, { name: 'G', def: 'd1' });
+		const def: WidgetDef = { id: 'd1', name: 'Def', size: { w: 1, h: 1 }, child };
+		render(<Inspector groupUnit={g} def={def} placement="flow" onOp={onOp} />);
+		fireEvent.click(screen.getByRole('button', { name: 'Add param' })); // key still empty
+		expect(onOp.mock.calls.some((c) => (c[0] as LayoutOp).op === 'addDefParam')).toBe(false);
+	});
+
+	it('defaults a floating group anchor to 0 when its config carries no coordinates', () => {
+		const onOp = vi.fn<(op: LayoutOp) => void>();
+		const g = group('g1', { w: 30, h: 20 }, leaf(w({ id: 'c', type: 'clock' })), { config: {} });
+		render(<Inspector groupUnit={g} placement="floating" onOp={onOp} />);
+		const [x, y, wIn, hIn] = within(screen.getByText('group · g1').closest('.fields')!)
+			.getAllByRole('spinbutton')
+			.slice(0, 4) as HTMLInputElement[];
+		// x/y default to 0 (no config), w/h fall back to the group size.
+		expect(x.value).toBe('0');
+		expect(y.value).toBe('0');
+		expect(wIn.value).toBe('30');
+		expect(hIn.value).toBe('20');
+		fireEvent.input(x, { target: { value: '12' } });
+		expect(lastOp(onOp, 'patchGroup')).toMatchObject({ patch: { config: { x: 12 } } });
+	});
+});
+
+// ---------------------------------------------------------------------------------------------------
+describe('Inspector config-field reset (macro / monitorSources / toggle)', () => {
+	it('resets a toggle field to its default', () => {
+		const onOp = vi.fn<(op: LayoutOp) => void>();
+		const fields: ConfigField[] = [{ key: 'fill', label: 'fill', kind: 'toggle', default: false }];
+		render(
+			<Inspector
+				widget={gaugeWidget({ fill: true })}
+				placement="floating"
+				configFields={fields}
+				onOp={onOp}
+			/>
+		);
+		fireEvent.click(within(panel()).getByTitle('Reset to default'));
+		expect(configPatch(onOp)).toEqual({ fill: false });
+	});
+
+	it('resets a macro field to its default', () => {
+		const onOp = vi.fn<(op: LayoutOp) => void>();
+		const fields: ConfigField[] = [
+			{ key: 'actions', label: 'actions', kind: 'macro', default: [] }
+		];
+		render(
+			<Inspector
+				widget={{
+					...gaugeWidget(),
+					type: 'button',
+					config: { actions: [{ kind: 'media', action: 'playpause' }] }
+				}}
+				placement="floating"
+				configFields={fields}
+				onOp={onOp}
+			/>
+		);
+		fireEvent.click(within(panel()).getByTitle('Reset to default'));
+		expect(configPatch(onOp)).toEqual({ actions: [] });
+	});
+
+	it('resets a monitorSources field to its default', async () => {
+		const onOp = vi.fn<(op: LayoutOp) => void>();
+		const fields: ConfigField[] = [
+			{ key: 'sources', label: 'sources', kind: 'monitorSources', default: '' }
+		];
+		render(
+			<Inspector
+				widget={{ ...gaugeWidget(), type: 'monitorswitch', config: { sources: '0x11=A' } }}
+				placement="floating"
+				configFields={fields}
+				onOp={onOp}
+			/>
+		);
+		// With a non-empty spec the editor shows a (manual) row, not the empty-state placeholder —
+		// wait for the detect effect to settle on the row-count status before interacting.
+		await screen.findByText('1 input');
+		fireEvent.click(within(panel()).getByTitle('Reset to default'));
+		expect(configPatch(onOp)).toEqual({ sources: '' });
+	});
+});
+
+// ---------------------------------------------------------------------------------------------------
+describe('Inspector select catalogs (microphones / displayNames)', () => {
+	it('fills a microphones select with the system-default row and the runtime devices', () => {
+		const onOp = vi.fn<(op: LayoutOp) => void>();
+		const fields: ConfigField[] = [
+			{ key: 'mic', label: 'microphone', kind: 'select', options: [], catalog: 'microphones' }
+		];
+		render(
+			<Inspector
+				widget={gaugeWidget()}
+				placement="floating"
+				configFields={fields}
+				microphones={[{ id: 'm1', name: 'Boom Mic' }]}
+				onOp={onOp}
+			/>
+		);
+		fireEvent.click(within(panel()).getByLabelText('microphone'));
+		expect(screen.getByText('System default', { selector: '.np-select-opt-label' })).toBeTruthy();
+		fireEvent.click(screen.getByText('Boom Mic', { selector: '.np-select-opt-label' }));
+		expect(configPatch(onOp)).toEqual({ mic: 'm1' });
+	});
+
+	it('fills a displayNames select with the primary-monitor row and the runtime monitors', () => {
+		const onOp = vi.fn<(op: LayoutOp) => void>();
+		const fields: ConfigField[] = [
+			{ key: 'monitor', label: 'monitor', kind: 'select', options: [], catalog: 'displayNames' }
+		];
+		render(
+			<Inspector
+				widget={gaugeWidget()}
+				placement="floating"
+				configFields={fields}
+				displayNames={[{ id: '\\\\.\\DISPLAY1', name: 'Dell' }]}
+				onOp={onOp}
+			/>
+		);
+		fireEvent.click(within(panel()).getByLabelText('monitor'));
+		expect(screen.getByText('Primary monitor', { selector: '.np-select-opt-label' })).toBeTruthy();
+		fireEvent.click(screen.getByText('Dell', { selector: '.np-select-opt-label' }));
+		expect(configPatch(onOp)).toEqual({ monitor: '\\\\.\\DISPLAY1' });
+	});
+});
+
+// ---------------------------------------------------------------------------------------------------
+describe('Inspector expr-field hint edge cases', () => {
+	it('renders no sensor-hint for an empty or reference-free formula', () => {
+		const fields: ConfigField[] = [
+			{ key: 'value', label: 'value', kind: 'expr', result: 'number' }
+		];
+		const { rerender } = render(
+			<Inspector widget={gaugeWidget()} placement="floating" configFields={fields} onOp={vi.fn()} />
+		);
+		expect(document.querySelector('.cfg-expr-refs')).toBeNull(); // empty source
+		rerender(
+			<Inspector
+				widget={gaugeWidget({ value: '1 + 2' })}
+				placement="floating"
+				configFields={fields}
+				onOp={vi.fn()}
+			/>
+		);
+		expect(document.querySelector('.cfg-expr-refs')).toBeNull(); // no sensor references
+	});
+});
+
+// ---------------------------------------------------------------------------------------------------
+describe('Inspector per-widget token overrides (set)', () => {
+	it('sets a widget token override via a token field', () => {
+		const onOp = vi.fn<(op: LayoutOp) => void>();
+		render(<Inspector widget={w()} placement="floating" onOp={onOp} />);
+		const radius = screen.getByLabelText('radius');
+		fireEvent.change(radius, { target: { value: '6px' } });
+		fireEvent.blur(radius);
+		expect(lastOp(onOp, 'setWidgetToken')).toEqual({
+			op: 'setWidgetToken',
+			id: 'w1',
+			key: '--np-radius',
+			value: '6px'
+		});
+	});
+
+	it('sets a group token override scoped to the group id', () => {
+		const onOp = vi.fn<(op: LayoutOp) => void>();
+		const g = group('g1', { w: 1, h: 1 }, leaf(w({ id: 'c', type: 'clock' })), { name: 'G' });
+		render(<Inspector groupUnit={g} placement="flow" onOp={onOp} />);
+		const radius = screen.getByLabelText('radius');
+		fireEvent.change(radius, { target: { value: '3px' } });
+		fireEvent.blur(radius);
+		expect(lastOp(onOp, 'setWidgetToken')).toEqual({
+			op: 'setWidgetToken',
+			id: 'g1',
+			key: '--np-radius',
+			value: '3px'
+		});
+	});
+});
+
+// ---------------------------------------------------------------------------------------------------
+describe('Inspector Data tab wiring', () => {
+	const widget = w();
+	const node = leaf(widget);
+
+	it('resyncs the JSON buffer when the selected node identity changes, and hides the tabs when null', () => {
+		const { rerender } = render(
+			<Inspector widget={widget} placement="floating" node={node} onOp={vi.fn()} />
+		);
+		fireEvent.click(screen.getByText('Data'));
+		expect((screen.getByLabelText('Node JSON') as HTMLTextAreaElement).value).toContain(
+			'"id": "w1"'
+		);
+		const widget2 = w({ id: 'w2' });
+		rerender(
+			<Inspector widget={widget2} placement="floating" node={leaf(widget2)} onOp={vi.fn()} />
+		);
+		expect((screen.getByLabelText('Node JSON') as HTMLTextAreaElement).value).toContain(
+			'"id": "w2"'
+		);
+		// Losing the node drops the Fields/Data tabs entirely.
+		rerender(<Inspector widget={widget2} placement="floating" node={null} onOp={vi.fn()} />);
+		expect(screen.queryByRole('tab', { name: 'Data' })).toBeNull();
+	});
+
+	it('rejects a JSON array with "Expected a JSON object"', () => {
+		const onOp = vi.fn<(op: LayoutOp) => void>();
+		render(<Inspector widget={widget} placement="floating" node={node} onOp={onOp} />);
+		fireEvent.click(screen.getByText('Data'));
+		fireEvent.change(screen.getByLabelText('Node JSON'), { target: { value: '[1, 2]' } });
+		fireEvent.click(screen.getByText('Apply'));
+		expect(screen.getByText(/Expected a JSON object/)).toBeTruthy();
+		expect(onOp.mock.calls.some((c) => c[0].op === 'replaceNode')).toBe(false);
+	});
+
+	it('rejects an object that is neither a widget nor a container', () => {
+		const onOp = vi.fn<(op: LayoutOp) => void>();
+		render(<Inspector widget={widget} placement="floating" node={node} onOp={onOp} />);
+		fireEvent.click(screen.getByText('Data'));
+		fireEvent.change(screen.getByLabelText('Node JSON'), { target: { value: '{ "foo": 1 }' } });
+		fireEvent.click(screen.getByText('Apply'));
+		expect(screen.getByText(/Expected a widget .* or a container/)).toBeTruthy();
+	});
+
+	it('applies a valid container node via replaceNode', () => {
+		const onOp = vi.fn<(op: LayoutOp) => void>();
+		const c = container('root', 'col', []);
+		render(<Inspector container={c} node={c} onOp={onOp} />);
+		fireEvent.click(screen.getByText('Data'));
+		fireEvent.change(screen.getByLabelText('Node JSON'), {
+			target: { value: '{ "kind": "row", "children": [] }' }
+		});
+		fireEvent.click(screen.getByText('Apply'));
+		const applied = lastOp(onOp, 'replaceNode');
+		expect(applied && applied.op === 'replaceNode' && applied.node).toMatchObject({
+			kind: 'row',
+			id: 'root'
+		});
+	});
+
+	it('reverts the buffer, toggles JSON/YAML formats, and returns to the Fields tab', () => {
+		render(<Inspector widget={widget} placement="floating" node={node} onOp={vi.fn()} />);
+		fireEvent.click(screen.getByText('Data'));
+		const area = () => screen.getByLabelText('Node JSON') as HTMLTextAreaElement;
+		fireEvent.change(area(), { target: { value: 'scratch edit' } });
+		fireEvent.click(screen.getByText('Revert'));
+		expect(area().value).toContain('"id": "w1"');
+		// YAML (read-only) then back to JSON.
+		fireEvent.click(screen.getByText('YAML'));
+		expect(screen.getByLabelText('Node YAML (read-only)')).toBeTruthy();
+		fireEvent.click(screen.getByText('JSON'));
+		expect(screen.getByLabelText('Node JSON')).toBeTruthy();
+		// Back to the form via the Fields tab.
+		fireEvent.click(screen.getByRole('tab', { name: 'Fields' }));
+		expect(screen.getByRole('tabpanel', { name: /Fields/i })).toBeTruthy();
+	});
+
+	it('ignores non-arrow keys on the tablist', () => {
+		render(<Inspector widget={widget} placement="floating" node={node} onOp={vi.fn()} />);
+		const tablist = screen.getByRole('tablist');
+		fireEvent.keyDown(tablist, { key: 'ArrowDown' });
+		expect(within(tablist).getByRole('tab', { name: 'Fields' }).getAttribute('aria-selected')).toBe(
+			'true'
+		);
+	});
+});
+
+// ---------------------------------------------------------------------------------------------------
+describe('Inspector config JSON resync + docked chrome', () => {
+	it('resyncs the raw config box on a widget switch and drops it when a container is selected', () => {
+		const { rerender } = render(
+			<Inspector
+				widget={gaugeWidget({ label: 'A' })}
+				placement="floating"
+				configFields={[]}
+				onOp={vi.fn()}
+			/>
+		);
+		const box = () =>
+			within(panel()).getByRole('textbox', { name: /config \(JSON\)/i }) as HTMLTextAreaElement;
+		expect(box().value).toContain('"label": "A"');
+		rerender(
+			<Inspector
+				widget={gaugeWidget({ label: 'B' })}
+				placement="floating"
+				configFields={[]}
+				onOp={vi.fn()}
+			/>
+		);
+		expect(box().value).toContain('"label": "B"');
+		// Selecting a container clears the widget branch (and its config box) without crashing.
+		rerender(<Inspector container={container('root', 'col', [])} onOp={vi.fn()} />);
+		expect(within(panel()).queryByRole('textbox', { name: /config \(JSON\)/i })).toBeNull();
+	});
+
+	it('adds the docked modifier class to the rail', () => {
+		const { container: root } = render(<Inspector docked onOp={vi.fn()} />);
+		expect(root.querySelector('.inspector')!.className).toContain('docked');
+	});
+});
+
+// ---------------------------------------------------------------------------------------------------
+describe('Inspector nodeIsNew for containers and groups', () => {
+	it('reads every container field as dirty when the node is new, despite an identical baseline', () => {
+		const c = container('root', 'col', []);
+		render(
+			<Inspector
+				container={c}
+				baseContainer={container('root', 'col', [])}
+				nodeIsNew
+				onOp={vi.fn()}
+			/>
+		);
+		expect(within(panel()).getByText('kind').closest('label')!.className).toContain('dirty');
+	});
+
+	it('reads every group field as dirty when the node is new, despite an identical baseline', () => {
+		const child = leaf(w({ id: 'c', type: 'clock' }));
+		const g = group('g1', { w: 1, h: 1 }, child, { name: 'Same' });
+		const base = group('g1', { w: 1, h: 1 }, child, { name: 'Same' });
+		render(<Inspector groupUnit={g} baseGroup={base} nodeIsNew placement="flow" onOp={vi.fn()} />);
+		expect(screen.getByText('name').closest('label')!.className).toContain('dirty');
+	});
+});
+
+// ---------------------------------------------------------------------------------------------------
+describe('Inspector text-template expr field', () => {
+	it('uses the template placeholder, lists {refs} via templateRefs, and clears to undefined', () => {
+		const onOp = vi.fn<(op: LayoutOp) => void>();
+		const fields: ConfigField[] = [{ key: 'tpl', label: 'template', kind: 'expr', result: 'text' }];
+		render(
+			<Inspector
+				widget={gaugeWidget({ tpl: 'CPU {cpu.total}%' })}
+				placement="floating"
+				configFields={fields}
+				sensors={['cpu.total']}
+				onOp={onOp}
+			/>
+		);
+		// A text-result formula gets the template placeholder and its refs come from templateRefs.
+		const area = within(panel()).getByPlaceholderText('text + {expression}');
+		const hint = document.querySelector('.cfg-expr-refs') as HTMLElement;
+		expect(within(hint).getByText(/cpu\.total/)).toBeTruthy();
+		expect(hint.querySelector('.unknown')).toBeNull(); // the ref is a known sensor
+		// Clearing the textarea stores undefined (drop the key), not an empty string.
+		fireEvent.input(area, { target: { value: '' } });
+		expect(configPatch(onOp)).toEqual({ tpl: undefined });
+	});
+});
+
+// ---------------------------------------------------------------------------------------------------
+describe('Inspector template options form — unlabeled param', () => {
+	it('falls back to the param key for the row label and aria-label', () => {
+		registerTemplates('KeyOnly', [
+			{
+				id: 'keyonly-1',
+				name: 'Key Only',
+				description: 'param without a label',
+				size: { w: 10, h: 10 },
+				params: [
+					{
+						key: 'lang',
+						default: 'a',
+						target: 'unit.config.lang',
+						choices: [
+							{ value: 'a', label: 'A' },
+							{ value: 'b', label: 'B' }
+						]
+					}
+				],
+				tree: () => leaf(w({ id: 'p', type: 'text' }))
+			}
+		]);
+		try {
+			render(<Inspector onOp={vi.fn()} />);
+			// No `label` on the spec → the key names both the visible row and the select's aria-label.
+			expect(within(palette()).getByLabelText('Key Only — lang')).toBeTruthy();
+			expect(within(palette()).getByText('lang', { selector: 'label' })).toBeTruthy();
+		} finally {
+			unregisterTemplates('KeyOnly');
+		}
+	});
+});
+
+// ---------------------------------------------------------------------------------------------------
+describe('Inspector remaining branch wiring', () => {
+	it('clears group css to undefined on an empty blur', () => {
+		const onOp = vi.fn<(op: LayoutOp) => void>();
+		const g = group('g1', { w: 1, h: 1 }, leaf(w({ id: 'c', type: 'clock' })), {
+			name: 'G',
+			css: 'x'
+		});
+		render(<Inspector groupUnit={g} placement="flow" onOp={onOp} />);
+		const groupCss = screen.getByLabelText('group css');
+		fireEvent.change(groupCss, { target: { value: '' } });
+		fireEvent.blur(groupCss);
+		expect(lastOp(onOp, 'patchGroup')).toMatchObject({ patch: { css: undefined } });
+	});
+
+	it('defaults the untouched leaf-align axis to "fill" when emitting setLeafAlign', () => {
+		const onOp = vi.fn<(op: LayoutOp) => void>();
+		// Neither halign nor valign supplied: changing one axis defaults the other to 'fill'.
+		render(<Inspector widget={w()} placement="flow" onOp={onOp} />);
+		fireEvent.click(within(panel()).getByLabelText('horizontal align'));
+		fireEvent.click(screen.getByText('center', { selector: '.np-select-opt-label' }));
+		expect(lastOp(onOp, 'setLeafAlign')).toEqual({
+			op: 'setLeafAlign',
+			id: 'w1',
+			halign: 'center',
+			valign: 'fill'
+		});
+		fireEvent.click(within(panel()).getByLabelText('vertical align'));
+		fireEvent.click(screen.getByText('middle', { selector: '.np-select-opt-label' }));
+		expect(lastOp(onOp, 'setLeafAlign')).toEqual({
+			op: 'setLeafAlign',
+			id: 'w1',
+			halign: 'fill',
+			valign: 'middle'
+		});
+	});
+
+	it('coerces an emptied group fixed-px input to a 0 basis', () => {
+		const onOp = vi.fn<(op: LayoutOp) => void>();
+		const g = group('g1', { w: 100, h: 40 }, leaf(w({ id: 'c', type: 'clock' })), { name: 'G' });
+		render(
+			<Inspector groupUnit={g} placement="flow" widgetBasis={120} node={leaf(g)} onOp={onOp} />
+		);
+		fireEvent.input(screen.getByRole('spinbutton', { name: 'size (px)' }), {
+			target: { value: '' }
+		});
+		expect(lastOp(onOp, 'setBasis')).toEqual({ op: 'setBasis', id: 'g1', basis: 0 });
+	});
+
+	it('emits an fr basis when a container picks "fill — grow to share"', () => {
+		const onOp = vi.fn<(op: LayoutOp) => void>();
+		render(<Inspector container={container('root', 'col', [])} onOp={onOp} />);
+		fireEvent.click(within(panel()).getByLabelText('container size in parent'));
+		fireEvent.click(screen.getByText('fill — grow to share', { selector: '.np-select-opt-label' }));
+		expect(lastOp(onOp, 'patchContainer')).toEqual({
+			op: 'patchContainer',
+			id: 'root',
+			patch: { basis: { fr: 1 } }
+		});
+	});
+
+	it('copies the JSON representation from the Data tab', () => {
+		const onCopy = vi.fn<(t: string) => void>();
+		const widget = w();
+		render(<Inspector widget={widget} placement="floating" node={leaf(widget)} onCopy={onCopy} />);
+		fireEvent.click(screen.getByText('Data'));
+		fireEvent.click(screen.getByText('⧉ Copy')); // JSON is the initial format
+		expect(onCopy).toHaveBeenCalledWith(expect.stringContaining('"id": "w1"'));
+	});
+
+	it('shows neither Dock nor Float when the placement is unknown', () => {
+		render(<Inspector widget={w()} onOp={vi.fn()} />);
+		expect(within(panel()).queryByRole('button', { name: 'Dock →flow' })).toBeNull();
+		expect(within(panel()).queryByRole('button', { name: 'Float' })).toBeNull();
+	});
+
+	it('defaults grid cols/rows inputs to 1 and flags dirty grid + gap + cell fields', () => {
+		const onOp = vi.fn<(op: LayoutOp) => void>();
+		// cols/rows unset (→ the ?? 1 display default); baseline differs in cols/rows/gap/cellW/cellH.
+		const c = container('g', 'grid', [], { gap: 4, cellW: 5, cellH: 6 });
+		const base = container('g', 'grid', [], { cols: 2, rows: 3, gap: 0, cellW: 1, cellH: 2 });
+		render(<Inspector container={c} baseContainer={base} isGridCell onOp={onOp} />);
+		const cols = within(panel()).getByRole('spinbutton', { name: 'cols' }) as HTMLInputElement;
+		expect(cols.value).toBe('1');
+		expect(cols.closest('label')!.className).toContain('dirty');
+		const rows = within(panel()).getByRole('spinbutton', { name: 'rows' }) as HTMLInputElement;
+		expect(rows.value).toBe('1');
+		expect(rows.closest('label')!.className).toContain('dirty');
+		expect(
+			within(panel()).getByRole('spinbutton', { name: 'gap' }).closest('label')!.className
+		).toContain('dirty');
+		const cellW = within(panel()).getByRole('spinbutton', { name: 'width (px)' });
+		expect(cellW.closest('label')!.className).toContain('dirty');
+		expect(
+			within(panel()).getByRole('spinbutton', { name: 'height (px)' }).closest('label')!.className
+		).toContain('dirty');
+		// Emptying a cell size clears it back to flex (undefined).
+		fireEvent.input(cellW, { target: { value: '' } });
+		expect(lastOp(onOp, 'patchContainer')).toEqual({
+			op: 'patchContainer',
+			id: 'g',
+			patch: { cellW: undefined }
+		});
+	});
+
+	it('flags a dirty flow w/h field against the baseline', () => {
+		const widget = w({ rect: { x: 0, y: 0, w: 160, h: 40 } });
+		const base = w({ rect: { x: 0, y: 0, w: 100, h: 40 } });
+		render(<Inspector widget={widget} baseWidget={base} placement="flow" onOp={vi.fn()} />);
+		expect(
+			within(panel()).getByRole('spinbutton', { name: 'w (fixed)' }).closest('label')!.className
+		).toContain('dirty');
+		expect(
+			within(panel()).getByRole('spinbutton', { name: 'h (fixed)' }).closest('label')!.className
+		).not.toContain('dirty');
+	});
+
+	it('renders the help line for macro / monitorSources / toggle / generic fields', async () => {
+		const fields: ConfigField[] = [
+			{ key: 'actions', label: 'actions', kind: 'macro', help: 'macro help' },
+			{ key: 'sources', label: 'sources', kind: 'monitorSources', help: 'sources help' },
+			{ key: 'fill', label: 'fill', kind: 'toggle', help: 'toggle help' },
+			{ key: 'label', label: 'label', kind: 'text', help: 'text help' }
+		];
+		render(
+			<Inspector
+				widget={{ ...gaugeWidget(), type: 'button', config: { actions: [] } }}
+				placement="floating"
+				configFields={fields}
+				onOp={vi.fn()}
+			/>
+		);
+		expect(within(panel()).getByText('macro help')).toBeTruthy();
+		expect(within(panel()).getByText('sources help')).toBeTruthy();
+		expect(within(panel()).getByText('toggle help')).toBeTruthy();
+		expect(within(panel()).getByText('text help')).toBeTruthy();
+		// Let the (mocked) monitor-inputs detect effect settle inside the test.
+		await screen.findByPlaceholderText('0x11=Desktop, 0x12=Switch');
+	});
+
+	it('clears the sources spec to undefined when the last monitor input is unchecked', async () => {
+		const onOp = vi.fn<(op: LayoutOp) => void>();
+		const fields: ConfigField[] = [{ key: 'sources', label: 'sources', kind: 'monitorSources' }];
+		render(
+			<Inspector
+				widget={{ ...gaugeWidget(), type: 'monitorswitch', config: { sources: '0x11=A' } }}
+				placement="floating"
+				configFields={fields}
+				onOp={onOp}
+			/>
+		);
+		// The manual 0x11 entry appears as one checked row once detection resolves; unchecking it
+		// empties the spec, which the Inspector stores as undefined.
+		await screen.findByText('1 input');
+		fireEvent.click(within(panel()).getByRole('checkbox'));
+		expect(configPatch(onOp)).toEqual({ sources: undefined });
+	});
+
+	it('renders unlabeled def params with key fallbacks and empty unset values', () => {
+		const child = leaf(w({ id: 'c', type: 'clock' }));
+		// No params override on the group; specs carry no label and no default.
+		const g = group('g1', { w: 1, h: 1 }, child, { name: 'G', def: 'd1' });
+		const def: WidgetDef = {
+			id: 'd1',
+			name: 'Def',
+			size: { w: 1, h: 1 },
+			child,
+			params: [
+				{ key: 'plain' },
+				{
+					key: 'pick',
+					choices: [
+						{ value: 'x', label: 'X' },
+						{ value: 'y', label: 'Y' }
+					]
+				}
+			]
+		};
+		render(<Inspector groupUnit={g} def={def} placement="flow" onOp={vi.fn()} />);
+		// The text param: key as the label, an empty input (no override, no default, no target hint).
+		const plainLabel = screen.getByText('plain', { selector: 'label' });
+		expect((within(plainLabel).getByRole('textbox') as HTMLInputElement).value).toBe('');
+		// The choices param: key drives the aria-label; unset value falls to '' (no default).
+		expect(screen.getByLabelText('param pick')).toBeTruthy();
+	});
+
+	it('leaves grid + cell fields clean against an identical baseline and clears cellH to flex', () => {
+		const onOp = vi.fn<(op: LayoutOp) => void>();
+		// Identical baseline → the not-dirty (no class) arm of every grid/cell field label.
+		const opts = { cols: 2, rows: 2, gap: 4, cellW: 5, cellH: 6 } as const;
+		const c = container('g', 'grid', [], { ...opts });
+		const base = container('g', 'grid', [], { ...opts });
+		render(<Inspector container={c} baseContainer={base} isGridCell onOp={onOp} />);
+		for (const name of ['cols', 'rows', 'gap', 'width (px)', 'height (px)']) {
+			expect(
+				within(panel()).getByRole('spinbutton', { name }).closest('label')!.className
+			).not.toContain('dirty');
+		}
+		// Emptying the cell height clears it back to flex (undefined), like the width.
+		fireEvent.input(within(panel()).getByRole('spinbutton', { name: 'height (px)' }), {
+			target: { value: '' }
+		});
+		expect(lastOp(onOp, 'patchContainer')).toEqual({
+			op: 'patchContainer',
+			id: 'g',
+			patch: { cellH: undefined }
+		});
+	});
+
+	it('clears a GROUP token override set via the clear-all button', () => {
+		const onOp = vi.fn<(op: LayoutOp) => void>();
+		const g = group('g1', { w: 1, h: 1 }, leaf(w({ id: 'c', type: 'clock' })), {
+			name: 'G',
+			tokens: { '--np-fg': 'red' }
+		});
+		render(<Inspector groupUnit={g} placement="flow" onOp={onOp} />);
+		fireEvent.click(screen.getByRole('button', { name: 'Clear 1 override' }));
+		expect(lastOp(onOp, 'clearWidgetTokens')).toEqual({ op: 'clearWidgetTokens', id: 'g1' });
+	});
+});

--- a/client/src/lib/widgets/MonitorSwitchHost.test.tsx
+++ b/client/src/lib/widgets/MonitorSwitchHost.test.tsx
@@ -168,6 +168,35 @@ describe('MonitorSwitchHost (container wiring)', () => {
 		}
 	});
 
+	it('a stray interval tick after teardown is swallowed by the alive guard', async () => {
+		const setIntervalSpy = vi.spyOn(window, 'setInterval');
+		const { unmount } = render(<MonitorSwitchHost />);
+		await act(async () => undefined); // settle the mount refresh
+		const tick = setIntervalSpy.mock.calls.at(-1)?.[0] as () => void;
+		unmount();
+		listMonitorInputs.mockClear();
+		// clearInterval normally prevents this; if a queued tick slips through it must not refresh.
+		tick();
+		expect(listMonitorInputs).not.toHaveBeenCalled();
+		setIntervalSpy.mockRestore();
+	});
+
+	it('keeps the optimistic updater null-safe when picking before the target resolves', async () => {
+		// The lookup never resolves: with a configured target the default input rows still render
+		// (missing only flips after a resolved lookup), so a click reaches pick() while selected is
+		// null — gdi falls back to the target and the optimistic setSelected updater keeps the null.
+		listMonitorInputs.mockReturnValue(new Promise(() => {}));
+		const { container } = render(<MonitorSwitchHost monitor={'\\\\.\\DISPLAY7'} />);
+		const rows = container.querySelectorAll('.ms-row');
+		expect(rows.length).toBe(4); // DEFAULT_INPUTS while the lookup is pending
+		await act(async () => {
+			fireEvent.click(rows[0]);
+		});
+		expect(setMonitorInput).toHaveBeenCalledWith('\\\\.\\DISPLAY7', expect.any(Number));
+		// no monitor resolved → nothing to highlight optimistically
+		expect(container.querySelector('.ms-row[data-active="true"]')).toBeNull();
+	});
+
 	it('refreshes the active input on window focus', async () => {
 		listMonitorInputs
 			.mockResolvedValueOnce([mon()]) // initial: HDMI 1

--- a/client/src/lib/widgets/MultiInspector.test.tsx
+++ b/client/src/lib/widgets/MultiInspector.test.tsx
@@ -113,6 +113,24 @@ describe('MultiInspector text / number fields', () => {
 		expect(input.value).toBe('');
 		expect(input.placeholder).toBe('mixed');
 	});
+
+	it('renders an UNSET (non-mixed) shared value as empty — never the string "undefined"', () => {
+		// A field every selected widget leaves unset is shared (mixed=false) with value undefined.
+		const { getByLabelText } = render(
+			<MultiInspector {...baseProps} fields={[field(textField, undefined)]} />
+		);
+		const input = getByLabelText('Label') as HTMLInputElement;
+		expect(input.value).toBe('');
+		expect(input.placeholder).toBe(''); // not the mixed placeholder — the value is just unset
+	});
+
+	it('renders a shared null value as empty — never the string "null"', () => {
+		const { getByLabelText } = render(
+			<MultiInspector {...baseProps} fields={[field(textField, null)]} />
+		);
+		const input = getByLabelText('Label') as HTMLInputElement;
+		expect(input.value).toBe('');
+	});
 });
 
 describe('MultiInspector toggle field', () => {

--- a/client/src/lib/widgets/NowPlayingHost.test.tsx
+++ b/client/src/lib/widgets/NowPlayingHost.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, waitFor } from '@testing-library/react';
+import { act, render, waitFor } from '@testing-library/react';
 
 // Stub the Tauri-backed media adapter (no backend in tests): the host must still boot the feed and
 // fetch capabilities through it. Caps hide everything but play/pause so the wiring is observable.
@@ -79,5 +79,45 @@ describe('NowPlayingHost (container wiring)', () => {
 			expect(container.querySelector('[data-part="playpause"]')).not.toBeNull();
 			expect(container.querySelector('[data-part="next"]')).toBeNull(); // caps.next === false
 		});
+	});
+
+	it('renders the empty meter and queries default caps when no session is active', async () => {
+		mediaStore.set({ ...defaultState, sourcePriority: '', sessions: {} });
+		const { container } = render(<NowPlayingHost />);
+		expect(getMediaCapabilities).toHaveBeenCalledWith(undefined); // no session → no source
+		// the meter renders its bare, not-playing root — no track parts at all
+		await waitFor(() => {
+			expect(container.querySelector('[data-part="root"]')?.getAttribute('data-playing')).toBe(
+				'false'
+			);
+			expect(container.querySelector('[data-part="title"]')).toBeNull();
+		});
+	});
+
+	it('ignores a capabilities result that resolves only after unmount (alive guard)', async () => {
+		const caps = {
+			play: true,
+			pause: true,
+			playpause: true,
+			stop: false,
+			next: false,
+			previous: false,
+			shuffle: false,
+			repeat: false,
+			seek: false
+		};
+		let resolveCaps!: (c: typeof caps) => void;
+		getMediaCapabilities.mockReturnValueOnce(
+			new Promise<typeof caps>((r) => {
+				resolveCaps = r;
+			})
+		);
+		const { unmount } = render(<NowPlayingHost />);
+		unmount();
+		// The late resolution must be dropped (alive === false) — no setState on the unmounted host.
+		await act(async () => {
+			resolveCaps(caps);
+		});
+		expect(getMediaCapabilities).toHaveBeenCalledTimes(1);
 	});
 });

--- a/client/src/lib/widgets/Outline.test.tsx
+++ b/client/src/lib/widgets/Outline.test.tsx
@@ -150,6 +150,21 @@ describe('Outline row labels + hints', () => {
 		expect(getByText('My Widget')).toBeTruthy();
 	});
 
+	it('falls back to the def id, then the node id, when a group has no name', () => {
+		// No name → surface the backing def id as the recognisable hint.
+		const withDef = group('g-def', { w: 50, h: 50 }, leaf(prim('inner', 'text')), {
+			def: 'clockDef'
+		});
+		const r1 = container('root', 'col', [leaf(withDef)]);
+		const { getByText, unmount } = render(<Outline root={r1} />);
+		expect(getByText('clockDef')).toBeTruthy();
+		unmount();
+		// No name AND no def → the node id is the last-resort hint.
+		const bare = group('g-bare', { w: 50, h: 50 }, leaf(prim('inner', 'text')));
+		const r2 = container('root', 'col', [leaf(bare)]);
+		expect(render(<Outline root={r2} />).getByText('g-bare')).toBeTruthy();
+	});
+
 	it('appends the scopeLabel to the header when given', () => {
 		const { getByText } = render(<Outline root={labelledRoot()} scopeLabel="MyDef" />);
 		expect(getByText('Outline · MyDef')).toBeTruthy();
@@ -291,6 +306,19 @@ describe('Outline drag-and-drop into containers', () => {
 		fireEvent.dragLeave(containerRow, { dataTransfer: dt });
 		expect(containerRow.className).not.toContain('dropok');
 	});
+
+	it('tolerates drag events that carry no dataTransfer (synthetic drags)', () => {
+		const { getByText } = render(<Outline root={labelledRoot()} />);
+		const leafRow = getByText('• clock').closest('.row')!;
+		const containerRow = getByText('▦ row').closest('.row')!;
+		// No dataTransfer on any of these — the handlers must skip the payload/effect writes without
+		// crashing, and the visual target feedback still applies (it doesn't depend on the payload).
+		fireEvent.dragStart(leafRow);
+		fireEvent.dragOver(leafRow);
+		expect(leafRow.className).toContain('dropno');
+		fireEvent.dragOver(containerRow);
+		expect(containerRow.className).toContain('dropok');
+	});
 });
 
 describe('Outline floating layer', () => {
@@ -310,5 +338,73 @@ describe('Outline floating layer', () => {
 	it('omits the Floating section when there are no floating leaves', () => {
 		const { queryByText } = render(<Outline root={labelledRoot()} />);
 		expect(queryByText('Floating')).toBeNull();
+	});
+
+	it('marks a floating row selected / hovered, drags it, and selects it on click', () => {
+		const onOp = vi.fn();
+		const onHover = vi.fn();
+		const { getByText } = render(
+			<Outline
+				root={labelledRoot()}
+				floating={floating}
+				selectedId="fl-1"
+				hoverId="fl-1"
+				onHover={onHover}
+				onOp={onOp}
+			/>
+		);
+		const flRow = getByText('Floater').closest('.row') as HTMLElement;
+		expect(flRow.className).toContain('sel');
+		expect(flRow.className).toContain('hover');
+		// Dragging a floating row writes its node id as the drag payload.
+		const store: Record<string, string> = {};
+		const dt = {
+			effectAllowed: '',
+			setData: (k: string, v: string) => {
+				store[k] = v;
+			},
+			getData: (k: string) => store[k] ?? ''
+		};
+		fireEvent.dragStart(flRow, { dataTransfer: dt });
+		expect(store['text/x-node-id']).toBe('fl-1');
+		// Clicking the floating row's label selects it.
+		fireEvent.click(getByText('Floater'));
+		expect(onOp).toHaveBeenCalledWith({ op: 'select', id: 'fl-1' });
+	});
+});
+
+describe('Outline root row', () => {
+	it('adds a "docked" class to the panel when docked', () => {
+		const { container: root } = render(<Outline root={labelledRoot()} docked />);
+		expect(root.querySelector('.outline')!.className).toContain('docked');
+	});
+
+	it('marks the root row selected / hovered from the props', () => {
+		const { getByText } = render(
+			<Outline root={labelledRoot()} selectedId="root" hoverId="root" />
+		);
+		const rootRow = getByText('▦ root (col)').closest('.row') as HTMLElement;
+		expect(rootRow.className).toContain('sel');
+		expect(rootRow.className).toContain('root');
+		expect(rootRow.className).toContain('hover');
+	});
+
+	it('accepts a drop onto the root row (highlight + reparent into root)', () => {
+		const onOp = vi.fn();
+		const { getByText } = render(<Outline root={labelledRoot()} onOp={onOp} />);
+		const rootRow = getByText('▦ root (col)').closest('.row') as HTMLElement;
+		const store: Record<string, string> = { 'text/x-node-id': 'b-clock' };
+		const dt = {
+			dropEffect: '',
+			effectAllowed: '',
+			setData: (k: string, v: string) => {
+				store[k] = v;
+			},
+			getData: (k: string) => store[k] ?? ''
+		};
+		fireEvent.dragOver(rootRow, { dataTransfer: dt });
+		expect(rootRow.className).toContain('dropok'); // root is a container → a valid drop target
+		fireEvent.drop(rootRow, { dataTransfer: dt });
+		expect(onOp).toHaveBeenCalledWith({ op: 'reparent', id: 'b-clock', containerId: 'root' });
 	});
 });

--- a/client/src/lib/widgets/Select.test.tsx
+++ b/client/src/lib/widgets/Select.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
 import Select from './Select';
 import type { SelectOption } from './selectOptions';
@@ -73,5 +73,125 @@ describe('Select (combobox variant: typeahead)', () => {
 		// an option row renders both its label and its dim hint (the raw id)
 		expect(screen.getByText('Sensor 3')).toBeInTheDocument();
 		expect(screen.getByText('s.3', { selector: '.np-select-opt-hint' })).toBeInTheDocument();
+	});
+});
+
+describe('Select (listbox: controlled value changes, keyboard, positioning, swatches)', () => {
+	afterEach(() => vi.restoreAllMocks());
+
+	it('reflects an external value change and empties the trigger when nothing matches', () => {
+		const { rerender } = render(<Select value="a" options={SMALL} onChange={vi.fn()} />);
+		const value = () => screen.getByRole('combobox').querySelector('.np-select-value')?.textContent;
+		expect(value()).toBe('Apple');
+		rerender(<Select value="b" options={SMALL} onChange={vi.fn()} />);
+		expect(value()).toBe('Banana');
+		// a stale/unknown stored value matches no option; with no placeholder the trigger is empty
+		rerender(<Select value="zzz" options={SMALL} onChange={vi.fn()} />);
+		expect(value()).toBe('');
+	});
+
+	it('typeahead: pressing a character key highlights the matching option', () => {
+		render(<Select value="" options={SMALL} onChange={vi.fn()} />);
+		const trigger = screen.getByRole('combobox');
+		fireEvent.click(trigger); // open
+		fireEvent.keyDown(trigger, { key: 'c' });
+		const cherry = screen.getByText('Cherry').closest('li') as HTMLElement;
+		expect(cherry.getAttribute('data-highlighted')).toBe('true');
+	});
+
+	it('flips the menu above the trigger when there is little room below', () => {
+		// Anchor the trigger near the bottom of the viewport: below < 200 and top > below → flip up.
+		const h = window.innerHeight;
+		vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({
+			x: 8,
+			y: h - 68,
+			top: h - 68,
+			left: 8,
+			right: 208,
+			bottom: h - 44,
+			width: 200,
+			height: 24,
+			toJSON: () => ({})
+		} as DOMRect);
+		render(<Select value="a" options={SMALL} onChange={vi.fn()} />);
+		fireEvent.click(screen.getByRole('combobox'));
+		const menu = document.querySelector('.np-select-menu') as HTMLElement;
+		expect(menu.style.bottom).toBe('70px'); // innerHeight - top + 2
+		expect(menu.style.top).toBe('');
+	});
+
+	it('renders swatches in the trigger and swatch + hint in the open menu rows', () => {
+		const themed: SelectOption[] = [
+			{
+				value: 'day',
+				label: 'Day',
+				hint: 'light',
+				swatch: { bg: '#fff', accent: '#09f', fg: '#111' }
+			},
+			{ value: 'night', label: 'Night', swatch: { bg: '#000', accent: '#f90', fg: '#eee' } },
+			{ value: 'mono', label: 'Mono' }
+		];
+		render(<Select value="day" options={themed} onChange={vi.fn()} />);
+		const trigger = screen.getByRole('combobox');
+		expect(trigger.querySelector('.np-swatch')).not.toBeNull();
+		fireEvent.click(trigger);
+		const rows = document.querySelectorAll('.np-select-menu .np-select-option');
+		expect(rows[0].querySelector('.np-swatch')).not.toBeNull();
+		expect(rows[0].querySelector('.np-select-opt-hint')?.textContent).toBe('light');
+		expect(rows[2].querySelector('.np-swatch')).toBeNull(); // no swatch on Mono
+	});
+});
+
+describe('Select (combobox: external value + selection behaviours)', () => {
+	it('re-syncs the input when the value changes from outside, clearing it for an unknown value', () => {
+		const { rerender } = render(
+			<Select value="s.1" options={SENSORS} onChange={vi.fn()} searchable />
+		);
+		const input = screen.getByRole('combobox') as HTMLInputElement;
+		expect(input.value).toBe('Sensor 1');
+		rerender(<Select value="s.2" options={SENSORS} onChange={vi.fn()} searchable />);
+		expect(input.value).toBe('Sensor 2');
+		rerender(<Select value="nope" options={SENSORS} onChange={vi.fn()} searchable />);
+		expect(input.value).toBe('');
+	});
+
+	it('Escape with the menu closed clears the filter text without committing a value', () => {
+		const onChange = vi.fn();
+		render(<Select value="s.1" options={SENSORS} onChange={onChange} searchable />);
+		const input = screen.getByRole('combobox') as HTMLInputElement;
+		fireEvent.keyDown(input, { key: 'Escape' });
+		expect(input.value).toBe('');
+		expect(onChange).not.toHaveBeenCalled();
+	});
+
+	it('selecting a listed option in free-text mode commits and shows its raw id', () => {
+		const onChange = vi.fn();
+		render(<Select value="" options={SENSORS} onChange={onChange} allowCustom />);
+		const input = screen.getByRole('combobox') as HTMLInputElement;
+		fireEvent.click(input); // open
+		fireEvent.click(screen.getByText('Sensor 4'));
+		expect(onChange).toHaveBeenCalledWith('s.4');
+		expect(input.value).toBe('s.4');
+	});
+
+	it('shows the full list when the free-text value exactly matches an option id', () => {
+		render(<Select value="s.3" options={SENSORS} onChange={vi.fn()} allowCustom />);
+		fireEvent.click(screen.getByRole('combobox'));
+		expect(document.querySelectorAll('.np-select-option').length).toBe(SENSORS.length);
+	});
+
+	it('shows the selected option swatch in the trigger and per-row swatches in the menu', () => {
+		const themed: SelectOption[] = [
+			{ value: 't1', label: 'Theme One', swatch: { bg: '#123', accent: '#456', fg: '#789' } },
+			{ value: 't2', label: 'Theme Two', swatch: { bg: '#abc', accent: '#def', fg: '#012' } }
+		];
+		render(<Select value="t1" options={themed} onChange={vi.fn()} searchable />);
+		expect(document.querySelector('.np-select-trigger .np-swatch')).not.toBeNull();
+		fireEvent.click(screen.getByLabelText('Toggle options'));
+		const rows = document.querySelectorAll('.np-select-menu .np-select-option');
+		expect(rows.length).toBe(2);
+		expect(rows[0].querySelector('.np-swatch')).not.toBeNull();
+		// these options carry no hint — the hint span is simply absent
+		expect(rows[0].querySelector('.np-select-opt-hint')).toBeNull();
 	});
 });

--- a/client/src/lib/widgets/SensorList.test.tsx
+++ b/client/src/lib/widgets/SensorList.test.tsx
@@ -108,6 +108,20 @@ describe('SensorList — grouped', () => {
 		expect(getByTitle('cpu.total.pct')).toBeTruthy();
 	});
 
+	it('re-expands a collapsed group on a second header click (toggle both ways)', () => {
+		const hub = createTelemetryHub();
+		const { container, getByText, getByTitle } = render(
+			<SensorList hub={hub} ids={['mqtt.alpha']} filter groupFor={groupFor} />
+		);
+		const header = getByText('MQTT').closest('button') as HTMLButtonElement;
+		fireEvent.click(header); // collapse
+		expect(header.getAttribute('aria-expanded')).toBe('false');
+		expect(container.querySelector('[title="mqtt.alpha"]')).toBeNull();
+		fireEvent.click(header); // expand again — the toggle's delete arm
+		expect(header.getAttribute('aria-expanded')).toBe('true');
+		expect(getByTitle('mqtt.alpha')).toBeTruthy();
+	});
+
 	it('suppresses per-row badges in grouped mode (the header carries the source)', () => {
 		const hub = createTelemetryHub();
 		const { queryByText } = render(

--- a/client/src/lib/widgets/WidgetErrorBoundary.test.tsx
+++ b/client/src/lib/widgets/WidgetErrorBoundary.test.tsx
@@ -1,11 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from '@testing-library/react';
+import type { ReactNode } from 'react';
 import WidgetErrorBoundary from './WidgetErrorBoundary';
 
 // A child that throws during render (what an error boundary catches) when `explode` is set.
 function Boom({ explode, text }: { explode: boolean; text?: string }) {
 	if (explode) throw new Error('kaboom');
 	return <div>{text ?? 'ok'}</div>;
+}
+
+// A child that rethrows an arbitrary value — JS lets code throw non-Errors, which have no `.message`.
+function BoomValue({ thrown }: { thrown: unknown }): ReactNode {
+	throw thrown;
 }
 
 describe('WidgetErrorBoundary', () => {
@@ -65,5 +71,42 @@ describe('WidgetErrorBoundary', () => {
 		// Same resetKey → no retry → fallback persists even though children would now render fine.
 		expect(() => getByText(/clock/)).not.toThrow();
 		expect(queryByText('should-not-show')).toBeNull();
+	});
+
+	it('falls back to the "widget" label (and "?" in the warning) when no label is given', () => {
+		const { getByText } = render(
+			<WidgetErrorBoundary resetKey="a">
+				<Boom explode={true} />
+			</WidgetErrorBoundary>
+		);
+		expect(() => getByText(/widget/)).not.toThrow();
+		expect(vi.mocked(console.warn).mock.calls[0][0]).toBe('widget "?" crashed; showing fallback');
+	});
+
+	it('warns only once when a resetKey retry rethrows the same message (dedupe)', () => {
+		const { rerender, getByText } = render(
+			<WidgetErrorBoundary label="clock" resetKey="a">
+				<Boom explode={true} />
+			</WidgetErrorBoundary>
+		);
+		expect(console.warn).toHaveBeenCalledTimes(1);
+		rerender(
+			<WidgetErrorBoundary label="clock" resetKey="b">
+				<Boom explode={true} />
+			</WidgetErrorBoundary>
+		);
+		// The retry re-threw the identical message: the fallback is back but there is no second warning.
+		expect(() => getByText(/clock/)).not.toThrow();
+		expect(console.warn).toHaveBeenCalledTimes(1);
+	});
+
+	it('stringifies a non-Error throw (no .message) for the dedupe key and still shows the fallback', () => {
+		const { container } = render(
+			<WidgetErrorBoundary label="clock" resetKey="a">
+				<BoomValue thrown="string-crash" />
+			</WidgetErrorBoundary>
+		);
+		expect(container.querySelector('.widget-error')).not.toBeNull();
+		expect(console.warn).toHaveBeenCalledTimes(1);
 	});
 });

--- a/client/src/lib/widgets/WidgetHost.test.tsx
+++ b/client/src/lib/widgets/WidgetHost.test.tsx
@@ -456,6 +456,74 @@ describe('WidgetHost drag interactions', () => {
 		expect(onSelect).toHaveBeenCalledWith({ id: 'w' });
 	});
 
+	it('keeps reporting rect changes on later moves once past the slop (no re-gating)', () => {
+		const onChange = vi.fn();
+		const { container } = render(
+			<WidgetHost hub={hub} instance={inst} editMode onChange={onChange} />
+		);
+		const overlay = overlayOf(container);
+		fireEvent.pointerDown(overlay, { button: 0, pointerId: 1, clientX: 10, clientY: 10 });
+		fireEvent.pointerMove(overlay, { pointerId: 1, clientX: 40, clientY: 10 }); // crosses the slop
+		fireEvent.pointerMove(overlay, { pointerId: 1, clientX: 60, clientY: 10 }); // already moved
+		expect(onChange).toHaveBeenCalledTimes(2);
+	});
+
+	it('a click (no movement) on an UNSELECTED in-flow widget selects on press only, never drops', () => {
+		const onSelect = vi.fn();
+		const onDrop = vi.fn();
+		const { container } = render(
+			<WidgetHost
+				hub={hub}
+				instance={inst}
+				editMode
+				movable={false}
+				flow
+				onSelect={onSelect}
+				onDrop={onDrop}
+			/>
+		);
+		const overlay = overlayOf(container);
+		fireEvent.pointerDown(overlay, { button: 0, pointerId: 1, clientX: 10, clientY: 10 });
+		expect(onSelect).toHaveBeenCalledTimes(1); // it was unselected → selected on press
+		fireEvent.pointerUp(overlay, { pointerId: 1, clientX: 10, clientY: 10 }); // no movement
+		expect(onDrop).not.toHaveBeenCalled();
+		expect(onSelect).toHaveBeenCalledTimes(1); // and NOT re-selected on release
+	});
+
+	it('a press-release without movement on a selected widget’s resize handle does not re-select', () => {
+		const onSelect = vi.fn();
+		const onCommit = vi.fn();
+		const { container } = render(
+			<WidgetHost
+				hub={hub}
+				instance={inst}
+				editMode
+				selected
+				onSelect={onSelect}
+				onCommit={onCommit}
+			/>
+		);
+		const handle = container.querySelector('.handle.se') as HTMLElement;
+		fireEvent.pointerDown(handle, { button: 0, pointerId: 1, clientX: 10, clientY: 10 });
+		expect(onSelect).toHaveBeenCalledTimes(1); // a resize collapses the selection on press
+		fireEvent.pointerUp(handle, { pointerId: 1, clientX: 10, clientY: 10 }); // no movement
+		expect(onCommit).not.toHaveBeenCalled();
+		expect(onSelect).toHaveBeenCalledTimes(1); // not a move → end() adds no collapse-select
+	});
+
+	it('a click (no movement) on an UNSELECTED floating widget selects on press only', () => {
+		const onSelect = vi.fn();
+		const onCommit = vi.fn();
+		const { container } = render(
+			<WidgetHost hub={hub} instance={inst} editMode onSelect={onSelect} onCommit={onCommit} />
+		);
+		const overlay = overlayOf(container);
+		fireEvent.pointerDown(overlay, { button: 0, pointerId: 1, clientX: 10, clientY: 10 });
+		fireEvent.pointerUp(overlay, { pointerId: 1, clientX: 10, clientY: 10 }); // no movement
+		expect(onCommit).not.toHaveBeenCalled();
+		expect(onSelect).toHaveBeenCalledTimes(1); // press-select only; nothing more on release
+	});
+
 	it('does not move below the drag slop (click-to-select only)', () => {
 		const onChange = vi.fn();
 		const { container } = render(

--- a/client/src/lib/widgets/canvas/alignControls.test.ts
+++ b/client/src/lib/widgets/canvas/alignControls.test.ts
@@ -37,4 +37,10 @@ describe('containerAlignControls', () => {
 		expect(h.value).toBe('start'); // justify default
 		expect(v.value).toBe('stretch'); // align default
 	});
+
+	it('col defaults mirror the row ones on swapped axes', () => {
+		const [h, v] = containerAlignControls(container('c', 'col', []));
+		expect(h.value).toBe('stretch'); // align default (cross axis)
+		expect(v.value).toBe('start'); // justify default (main axis)
+	});
 });

--- a/client/src/lib/widgets/canvas/containerAt.test.ts
+++ b/client/src/lib/widgets/canvas/containerAt.test.ts
@@ -28,6 +28,13 @@ describe('innermostContainerAt', () => {
 		expect(innermostContainerAt(boxes, { x: 90, y: 50 }, 'root')).toBe('right');
 	});
 
+	it('rejects a LATER but strictly-larger box containing the point (keeps the smaller)', () => {
+		// Not pre-order here on purpose: the small box comes first, so the later, larger container
+		// must lose to the current best instead of stealing the hit.
+		const boxes = [box('inner', 0, 0, 50, 50), box('outer', 0, 0, 100, 100)];
+		expect(innermostContainerAt(boxes, { x: 10, y: 10 }, 'root')).toBe('inner');
+	});
+
 	it('falls back to the root id when the point is outside every box', () => {
 		const boxes = [box('a', 0, 0, 10, 10)];
 		expect(innermostContainerAt(boxes, { x: 50, y: 50 }, 'root')).toBe('root');

--- a/client/src/lib/widgets/canvas/debugInfo.test.ts
+++ b/client/src/lib/widgets/canvas/debugInfo.test.ts
@@ -127,6 +127,18 @@ describe('buildDebugInfo', () => {
 		expect(out).toContain('selected: (none)');
 	});
 
+	it('skips the selected-node summary for a malformed node (neither container nor leaf)', () => {
+		// The report is a diagnostic for BROKEN layouts, so a corrupt node (no kind, no unit) must not
+		// crash it — the found node matches neither summary branch and simply gets no `selected:` line.
+		const mon: MonitorLayout = {
+			root: container('root', 'col', [], { pad: 8 }),
+			floating: [{ id: 'weird' } as never]
+		};
+		const out = buildDebugInfo(leafArgs(mon, 'weird'));
+		expect(out).toContain('=== WidgetSack debug ===');
+		expect(out).not.toContain('selected:');
+	});
+
 	it('reports "(none)" when the selected id matches no node anywhere', () => {
 		// findNode → null AND floating.find → null exercises the final `?? null` fallback.
 		const out = buildDebugInfo(leafArgs(withLeaf(leaf(createWidget('gauge', 'w1'))), 'ghost'));

--- a/client/src/lib/widgets/canvas/editorOps.bulk.test.ts
+++ b/client/src/lib/widgets/canvas/editorOps.bulk.test.ts
@@ -15,6 +15,9 @@ import { createWidget, getMeta } from '../../core/widget';
 import {
 	container,
 	emptyMonitorLayout,
+	group,
+	isContainer,
+	isGroup,
 	leaf,
 	type Leaf,
 	type WidgetInstance
@@ -76,6 +79,32 @@ describe('bulkPatchConfig', () => {
 	it('is a no-op with no selection', () => {
 		expect(bulkPatchConfig(stateWith(null, []), 'x', 1)).toEqual({});
 	});
+
+	it('falls back to the single primary when the marquee set is empty', () => {
+		const patch = bulkPatchConfig(stateWith('w1', []), 'probe', 'X');
+		expect(unitAt(patch as never, 0).config.probe).toBe('X'); // the primary was patched
+		expect(unitAt(patch as never, 1).config.probe).toBeUndefined(); // w2 untouched
+	});
+
+	it('skips floating leaves outside the selection and floating groups', () => {
+		const s = stateWith('w1', ['w1', 'grpF']);
+		const bystander = leaf(gauge('bystander'));
+		const grpLeaf = leaf(group('grpF', { w: 10, h: 10 }, leaf(gauge('gi'))));
+		s.monitor.floating = [bystander, grpLeaf];
+		const patch = bulkPatchConfig(s, 'probe', 'X');
+		expect(patch.monitor!.floating[0]).toBe(bystander); // not selected → pass-through
+		expect(patch.monitor!.floating[1]).toBe(grpLeaf); // a selected GROUP is skipped too
+	});
+
+	it('leaves selected containers and flow groups untouched (primitives only)', () => {
+		const s = stateWith('root', ['root', 'w1', 'grpT']);
+		const grpLeaf = leaf(group('grpT', { w: 10, h: 10 }, leaf(gauge('gi'))));
+		s.monitor.root.children.push(grpLeaf);
+		const patch = bulkPatchConfig(s, 'probe', 'X');
+		expect(unitAt(patch as never, 0).config.probe).toBe('X'); // the primitive was patched
+		expect(isContainer(patch.monitor!.root)).toBe(true); // the container passed through
+		expect(patch.monitor!.root.children[2]).toBe(grpLeaf); // the flow group passed through
+	});
 });
 
 describe('bulkSetBasis', () => {
@@ -129,6 +158,20 @@ describe('setWidgetToken / clearWidgetTokens', () => {
 		expect(clearWidgetTokens(stateWith(null, []), 'w1')).toEqual({}); // no tokens
 		expect(clearWidgetTokens(stateWith(null, []), 'missing')).toEqual({});
 	});
+
+	it('setWidgetToken is a no-op on a missing id or a container id', () => {
+		expect(setWidgetToken(stateWith(null, []), 'missing', '--a', '1')).toEqual({});
+		expect(setWidgetToken(stateWith(null, []), 'root', '--a', '1')).toEqual({});
+	});
+
+	it('setWidgetToken routes a GROUP leaf through the patchGroup path', () => {
+		const s = stateWith(null, []);
+		s.monitor.root.children.push(leaf(group('grpT', { w: 10, h: 10 }, leaf(gauge('gi')))));
+		const patch = setWidgetToken(s, 'grpT', '--accent', '#0f0');
+		const grp = patch.monitor!.root.children[2] as Leaf;
+		expect(isGroup(grp.unit)).toBe(true);
+		expect(grp.unit.tokens).toEqual({ '--accent': '#0f0' });
+	});
 });
 
 describe('patchFloating / patchUnit', () => {
@@ -145,5 +188,12 @@ describe('patchFloating / patchUnit', () => {
 		expect(unitAt(flow as never, 0).sensor).toBe('mem.used');
 		const noop = patchUnit(s, 'root', { sensor: 'x' }); // container id → tree unchanged
 		expect(noop.monitor!.root.children).toHaveLength(2);
+	});
+
+	it('patchUnit routes a floating id to the floating layer', () => {
+		const s = stateWith(null, []);
+		s.monitor.floating = [leaf(gauge('f1'))];
+		const patch = patchUnit(s, 'f1', { sensor: 'cpu.total' });
+		expect((patch.monitor!.floating[0].unit as WidgetInstance).sensor).toBe('cpu.total');
 	});
 });

--- a/client/src/lib/widgets/canvas/editorOps.place.test.ts
+++ b/client/src/lib/widgets/canvas/editorOps.place.test.ts
@@ -321,6 +321,17 @@ describe('replaceNodeOp', () => {
 		expect(next.monitor.floating[0]).toBe(replacement);
 		expect(patch.selectedId).toBe('fl');
 	});
+
+	it('leaves other floating leaves untouched when swapping one', () => {
+		const state = minimalState();
+		const bystander = leaf(gauge('other'));
+		state.monitor.floating = [leaf(gauge('fl')), bystander];
+		const replacement = leaf(gauge('fl'));
+		const next = { ...state, ...replaceNodeOp(state, 'fl', replacement) };
+
+		expect(next.monitor.floating[0]).toBe(replacement);
+		expect(next.monitor.floating[1]).toBe(bystander); // passed through by reference
+	});
 });
 
 // =============================================================================================

--- a/client/src/lib/widgets/canvas/editorOps.rest.test.ts
+++ b/client/src/lib/widgets/canvas/editorOps.rest.test.ts
@@ -229,6 +229,17 @@ describe('patchGroup', () => {
 		expect((patch.monitor!.floating[0].unit as Group).css).toBe('.x{}');
 	});
 
+	it('leaves other floating leaves untouched when patching a floating group', () => {
+		const s = minimalState();
+		const g = group('grpF', { w: 50, h: 50 }, leaf(gauge('inner')));
+		const bystander = leaf(gauge('bystander'));
+		s.monitor.floating = [leaf(g), bystander];
+
+		const patch = patchGroup(s, 'grpF', { name: 'renamed' });
+		expect((patch.monitor!.floating[0].unit as Group).name).toBe('renamed');
+		expect(patch.monitor!.floating[1]).toBe(bystander); // pass-through by reference
+	});
+
 	it('leaves the tree unchanged when the id is a non-group leaf', () => {
 		const s = minimalState();
 		s.monitor.root = container('root', 'col', [leaf(gauge('w1'))]);
@@ -276,6 +287,13 @@ describe('setDefCss', () => {
 		const s = stateWithLib([def]);
 		const defs = (setDefCss(s, 'def-1', '').library as Library).defs;
 		expect(defs[0].css).toBeUndefined();
+	});
+
+	it('only patches the matching def, leaving siblings untouched', () => {
+		const s = stateWithLib([gaugeDef('def-1'), { ...gaugeDef('def-2'), css: '.keep{}' }]);
+		const defs = (setDefCss(s, 'def-1', '.new{}').library as Library).defs;
+		expect(defs[0].css).toBe('.new{}');
+		expect(defs[1].css).toBe('.keep{}'); // the non-matching def passes through
 	});
 
 	it('is a no-op when there is no library', () => {

--- a/client/src/lib/widgets/canvas/editorOps.sizing.test.ts
+++ b/client/src/lib/widgets/canvas/editorOps.sizing.test.ts
@@ -148,6 +148,29 @@ describe('patchContainerOp', () => {
 		const col1 = find(find(rootOf(patch), 'container1'), col1Id);
 		expect(col1.children).toHaveLength(2);
 	});
+
+	it('safely ignores cols on a missing id or a leaf id (nothing to trim)', () => {
+		const { state } = stateWithLayout();
+		const missing = patchContainerOp(state, 'ghost', { cols: 1 });
+		expect(rootOf(missing).children).toHaveLength(1); // tree unchanged
+		const onLeaf = patchContainerOp(state, 'w1', { cols: 1 });
+		const col1 = find(find(rootOf(onLeaf), 'container1'), 'col1');
+		expect(col1.children).toHaveLength(2); // a leaf is not a grid; nothing trimmed
+	});
+
+	it('defaults an undeclared cols/rows to 1 when computing the trim capacity', () => {
+		const cells = ['x0', 'x1', 'x2'].map((id) => container(id, 'col', []));
+		const state = minimalState();
+		state.monitor.root = container('root', 'col', [container('g3', 'grid', cells)], {
+			align: 'stretch'
+		});
+		// rows patched, cols still undefined → cap = (cols ?? 1) × 1 = 1 → trim to one cell.
+		const byRows = patchContainerOp(state, 'g3', { rows: 1 });
+		expect(find(rootOf(byRows), 'g3').children.map((c) => c.id)).toEqual(['x0']);
+		// cols patched, rows still undefined → cap = 1 × (rows ?? 1) = 1.
+		const byCols = patchContainerOp(state, 'g3', { cols: 1 });
+		expect(find(rootOf(byCols), 'g3').children.map((c) => c.id)).toEqual(['x0']);
+	});
 });
 
 // =============================================================================================
@@ -314,6 +337,26 @@ describe('setGridTracks', () => {
 		const patch = setGridTracks(s2, 'g', 'col', [{ index: 1, fr: 2 }]);
 		const grid = find(rootOf(patch), 'g');
 		expect(grid.colFr).toEqual([3, 2]); // index 0's prior weight kept
+	});
+
+	it('defaults the track-count hint to 1 when the grid has no cols/rows', () => {
+		const state = minimalState();
+		state.monitor.root = container('root', 'col', [container('g2', 'grid', [])], {
+			align: 'stretch'
+		});
+		const colPatch = setGridTracks(state, 'g2', 'col', [{ index: 0, fr: 2 }]);
+		expect(find(rootOf(colPatch), 'g2').colFr).toEqual([2]);
+		const rowPatch = setGridTracks(state, 'g2', 'row', [{ index: 0, fr: 3 }]);
+		expect(find(rootOf(rowPatch), 'g2').rowFr).toEqual([3]);
+	});
+
+	it('ignores entries with a negative (out-of-range) index', () => {
+		const { state } = stateWithGrid();
+		const patch = setGridTracks(state, 'g', 'col', [
+			{ index: -1, fr: 9 },
+			{ index: 0, fr: 2 }
+		]);
+		expect(find(rootOf(patch), 'g').colFr).toEqual([2, 1]); // -1 skipped, 0 applied
 	});
 
 	it('is a no-op when the id is not a grid', () => {

--- a/client/src/lib/widgets/canvas/editorOps.structure.test.ts
+++ b/client/src/lib/widgets/canvas/editorOps.structure.test.ts
@@ -104,6 +104,17 @@ describe('splitNode', () => {
 		expect(root.children).toHaveLength(4);
 	});
 
+	it('"grid" on a populated node wraps the content into cell 0 and selects the last cell', () => {
+		const s = minimalState(container('root', 'col', [leaf(gauge('w1'))]));
+		const patch = splitNode(s, 'root', 'grid');
+		const root = patch.monitor!.root;
+		expect(root.kind).toBe('grid');
+		expect(root.children).toHaveLength(4);
+		const keep = root.children[0] as Container;
+		expect(keep.children.map((c) => c.id)).toEqual(['w1']); // existing content kept in cell 0
+		expect(patch.selectedId).toBe(root.children[3].id); // with content kept, the LAST cell is selected
+	});
+
 	it('is a no-op ({}) when the id is missing or is a leaf', () => {
 		const s = minimalState(container('root', 'col', [leaf(gauge('w1'))]));
 		expect(splitNode(s, 'nope', 'rows')).toEqual({});
@@ -207,6 +218,12 @@ describe('indent', () => {
 		);
 		expect(indent(s, 'a')).toEqual({});
 	});
+
+	it('is a no-op for the root or an unknown id (no parent to indent within)', () => {
+		const s = minimalState(container('root', 'col', [leaf(gauge('a'))]));
+		expect(indent(s, 'root')).toEqual({});
+		expect(indent(s, 'missing')).toEqual({});
+	});
 });
 
 describe('outdent', () => {
@@ -271,6 +288,40 @@ describe('ungroupSelected', () => {
 		expect(patch.selectedId).toBe(u.id);
 	});
 
+	it('ungroups a floating def-backed group from the DEF child, leaving other floaters alone', () => {
+		const s = minimalState(container('root', 'col', []));
+		s.library = {
+			version: 1,
+			defs: [{ id: 'def-1', name: 'g', size: { w: 10, h: 10 }, child: leaf(gauge('def-inner')) }]
+		};
+		const g = group('grpF', { w: 10, h: 10 }, leaf(gauge('inline-inner')), {
+			def: 'def-1',
+			config: { x: 5, y: 6 }
+		});
+		const bystander = leaf(gauge('bystander'));
+		s.monitor.floating = [leaf(g), bystander];
+		const patch = ungroupSelected(s, 'grpF');
+		const u = patch.monitor!.floating[0].unit as ReturnType<typeof gauge>;
+		expect(u.id).toBe('def-inner'); // the def child wins over the inline child
+		expect(u.rect.x).toBe(5);
+		expect(u.rect.y).toBe(6);
+		expect(patch.monitor!.floating[1]).toBe(bystander); // pass-through by reference
+		expect(patch.selectedId).toBe('def-inner');
+	});
+
+	it('falls back to the inline child when the group names a def but no library is loaded', () => {
+		const s = minimalState(container('root', 'col', []));
+		const g = group('grpF', { w: 10, h: 10 }, leaf(gauge('inline-inner')), {
+			def: 'def-gone',
+			config: { x: 1, y: 2 }
+		});
+		s.monitor.floating = [leaf(g)];
+		const patch = ungroupSelected(s, 'grpF');
+		const u = patch.monitor!.floating[0].unit as ReturnType<typeof gauge>;
+		expect(u.id).toBe('inline-inner');
+		expect(u.rect.x).toBe(1);
+	});
+
 	it('is a no-op on a non-group floating leaf', () => {
 		const s = minimalState(container('root', 'col', []));
 		s.monitor.floating = [leaf(gauge('plain'))];
@@ -333,6 +384,24 @@ describe('makeWidget', () => {
 		// the group keeps the floating anchor in its config
 		expect(unit.config).toEqual({ x: 55, y: 66 });
 		expect(patch.selectedId).toBe(unit.id);
+	});
+
+	it('promotes an empty CONTAINER with the fallback def size and a widget-<kind> name', () => {
+		const s = minimalState(container('root', 'col', [container('band', 'row', [])]));
+		const patch = makeWidget(s, 'band');
+		const def = patch.library!.defs[0];
+		expect(def.name).toBe('widget-row'); // containers are named after their kind
+		expect(def.size).toEqual({ w: 120, h: 80 }); // intrinsic 0 → the || size fallbacks
+		const unit = (patch.monitor!.root.children[0] as ReturnType<typeof leaf>).unit;
+		expect(isGroup(unit)).toBe(true);
+	});
+
+	it('leaves other floaters untouched when promoting a floating primitive', () => {
+		const s = minimalState(container('root', 'col', []));
+		const bystander = leaf(gauge('bystander'));
+		s.monitor.floating = [leaf(gauge('f1')), bystander];
+		const patch = makeWidget(s, 'f1');
+		expect(patch.monitor!.floating[1]).toBe(bystander); // pass-through by reference
 	});
 
 	it('is a no-op ({}) on a missing id', () => {

--- a/client/src/lib/widgets/canvas/menuPreview.test.ts
+++ b/client/src/lib/widgets/canvas/menuPreview.test.ts
@@ -76,6 +76,23 @@ describe('buildMenuPreview — split', () => {
 		expect(shapes[0].rect).toEqual({ x: 10, y: 10, w: 20, h: 20 });
 	});
 
+	it('a cell-scoped split whose placeholder is missing falls back to the node box', () => {
+		// The op carries a cellIndex but the placeholder list has no matching cell (stale menu after a
+		// re-measure) — boxFor falls through to the grid's own measured box, still keeping nothing.
+		const op: LayoutOp = { op: 'split', id: 'b', dir: 'cols', cellIndex: 2 };
+		const shapes = buildMenuPreview(
+			op,
+			monitor(),
+			boxes({ b: { x: 0, y: 0, w: 80, h: 80 } }),
+			[],
+			WORK
+		);
+		expect(shapes).toEqual([
+			{ kind: 'zone', rect: { x: 0, y: 0, w: 40, h: 80 } },
+			{ kind: 'zone', rect: { x: 40, y: 0, w: 40, h: 80 } }
+		]);
+	});
+
 	it('falls back to the work area for the (unmeasured) root container', () => {
 		const op: LayoutOp = { op: 'split', id: 'root', dir: 'cols' };
 		const shapes = buildMenuPreview(op, monitor(), boxes({}), [], WORK);
@@ -135,6 +152,18 @@ describe('buildMenuPreview — add inside', () => {
 		expect(shapes).toEqual([{ kind: 'zone', rect: { x: 5, y: 5, w: 30, h: 30 } }]);
 	});
 
+	it('returns nothing when the op carries no containerId (Outline’s +Row/+Col)', () => {
+		const op: LayoutOp = { op: 'addContainer', kind: 'row' };
+		expect(
+			buildMenuPreview(op, monitor(), boxes({ a: { x: 0, y: 0, w: 10, h: 10 } }), [], WORK)
+		).toEqual([]);
+	});
+
+	it('returns nothing when the target container box is unmeasured', () => {
+		const op: LayoutOp = { op: 'addContainer', kind: 'row', containerId: 'a' };
+		expect(buildMenuPreview(op, monitor(), boxes({}), [], WORK)).toEqual([]);
+	});
+
 	it('an OVERLAP (stacking) container shows only the zone — no trailing bar (the child stacks)', () => {
 		const m: MonitorLayout = {
 			root: cont('root', 'col', [
@@ -158,6 +187,16 @@ describe('buildMenuPreview — add beside', () => {
 		expect(shapes[0]).toMatchObject({ kind: 'bar', axis: 'col' });
 		expect(shapes[0].rect.y).toBeCloseTo(78);
 		expect(shapes[0].rect.w).toBe(100);
+	});
+
+	it('in a row parent: a vertical bar after the node', () => {
+		const op: LayoutOp = { op: 'addBeside', kind: 'col', id: 'a1' }; // a1's parent `a` is a row
+		const a1Box: Rect = { x: 0, y: 0, w: 60, h: 80 };
+		const shapes = buildMenuPreview(op, monitor(), boxes({ a1: a1Box }), [], WORK);
+		expect(shapes).toHaveLength(1);
+		expect(shapes[0]).toMatchObject({ kind: 'bar', axis: 'row' });
+		expect(shapes[0].rect.x).toBeCloseTo(58); // right edge minus half the bar width
+		expect(shapes[0].rect.h).toBe(80);
 	});
 
 	it('returns nothing when the node box is unmeasured', () => {

--- a/client/src/lib/widgets/canvas/multiSelect.test.ts
+++ b/client/src/lib/widgets/canvas/multiSelect.test.ts
@@ -39,6 +39,10 @@ describe('commonConfigFields', () => {
 	it('is empty for an empty selection', () => {
 		expect(commonConfigFields([])).toEqual([]);
 	});
+
+	it('shares nothing with a widget of an unregistered type (no meta → no fields)', () => {
+		expect(commonConfigFields([w('mystery'), w('clock')])).toEqual([]);
+	});
 });
 
 describe('commonBasisMode', () => {
@@ -51,5 +55,9 @@ describe('commonBasisMode', () => {
 	it('reports "mixed" when the bases disagree', () => {
 		expect(commonBasisMode([{ fr: 1 }, undefined])).toBe('mixed');
 		expect(commonBasisMode(['content', { fr: 1 }])).toBe('mixed');
+	});
+
+	it('defaults to "fixed" for an empty selection', () => {
+		expect(commonBasisMode([])).toBe('fixed');
 	});
 });

--- a/client/src/lib/widgets/canvas/previewTemplate.test.ts
+++ b/client/src/lib/widgets/canvas/previewTemplate.test.ts
@@ -36,6 +36,41 @@ describe('template preview lifecycle', () => {
 		expect(s.library?.defs ?? []).toHaveLength(0);
 	});
 
+	it('previewTemplate is refused while a def is already open (the UI folds it first)', () => {
+		const { result } = renderHook(() => useEditorModel(true, []));
+		act(() => result.current.dispatch({ type: 'newWidget' }));
+		const before = result.current.state;
+		act(() => result.current.dispatch({ type: 'previewTemplate', templateId: CLOCK }));
+		expect(result.current.state).toBe(before);
+	});
+
+	it('previewTemplate is a no-op for an unknown template id', () => {
+		const { result } = renderHook(() => useEditorModel(true, []));
+		const before = result.current.state;
+		act(() => result.current.dispatch({ type: 'previewTemplate', templateId: 'nope' }));
+		expect(result.current.state).toBe(before);
+	});
+
+	it('endPreview and clonePreview are no-ops when nothing is previewing', () => {
+		const { result } = renderHook(() => useEditorModel(true, []));
+		const before = result.current.state;
+		act(() => result.current.dispatch({ type: 'endPreview' }));
+		expect(result.current.state).toBe(before);
+		act(() => result.current.dispatch({ type: 'clonePreview' }));
+		expect(result.current.state).toBe(before);
+	});
+
+	it('endDefEdit during a preview (no library yet) restores the real monitor without materialising one', () => {
+		const { result } = renderHook(() => useEditorModel(true, []));
+		const realMonitor = result.current.state.monitor;
+		act(() => result.current.dispatch({ type: 'previewTemplate', templateId: CLOCK }));
+		act(() => result.current.dispatch({ type: 'endDefEdit' }));
+		const s = result.current.state;
+		expect(s.editingDefId).toBeNull();
+		expect(s.monitor).toBe(realMonitor);
+		expect(s.library).toBeUndefined(); // no def write-back — there is no library to write to
+	});
+
 	it('clonePreview promotes the previewed template into the library and keeps editing it', () => {
 		const { result } = renderHook(() => useEditorModel(true, []));
 		act(() => result.current.dispatch({ type: 'previewTemplate', templateId: CLOCK }));

--- a/client/src/lib/widgets/canvas/useBackground.test.ts
+++ b/client/src/lib/widgets/canvas/useBackground.test.ts
@@ -45,6 +45,33 @@ describe('useBackground', () => {
 		expect(wallpaperAssetUrl).toHaveBeenCalledTimes(1); // resolved once, then cached
 	});
 
+	it('does not cache a falsy resolved URL (asset lookup failed)', async () => {
+		wallpaperAssetUrl.mockResolvedValue('');
+		const m = monitor({ background: { kind: 'image', src: 'gone.png' } });
+		const { result } = renderHook(() =>
+			useBackground({ studio: true, navSection: 'layouts', monitor: m, handleOp: vi.fn() })
+		);
+		await act(async () => {
+			await Promise.resolve();
+		});
+		expect(wallpaperAssetUrl).toHaveBeenCalledWith('gone.png');
+		expect(result.current.resolveWallpaper('gone.png')).toBe(''); // no entry was written
+	});
+
+	it('drops an asset URL that resolves after unmount (cancelled)', async () => {
+		let resolveUrl!: (url: string) => void;
+		wallpaperAssetUrl.mockReturnValue(new Promise<string>((r) => (resolveUrl = r)));
+		const m = monitor({ background: { kind: 'image', src: 'late.png' } });
+		const { unmount } = renderHook(() =>
+			useBackground({ studio: true, navSection: 'layouts', monitor: m, handleOp: vi.fn() })
+		);
+		unmount(); // cleanup flips the cancel guard before the URL arrives
+		await act(async () => {
+			resolveUrl('asset://localhost/late.png');
+		});
+		expect(wallpaperAssetUrl).toHaveBeenCalledTimes(1); // resolved, but the state write was skipped
+	});
+
 	it('does not resolve a color/web background (src used verbatim)', () => {
 		const m = monitor({ background: { kind: 'web', src: 'https://x.test' } });
 		renderHook(() =>

--- a/client/src/lib/widgets/canvas/useCanvasPointer.test.ts
+++ b/client/src/lib/widgets/canvas/useCanvasPointer.test.ts
@@ -184,4 +184,67 @@ describe('useCanvasPointer registry-driven gestures', () => {
 		// toCanvas with no element returns the raw coords → marquee origin at (7, 9).
 		expect(result.current.marquee).toEqual({ x: 7, y: 9, w: 0, h: 0 });
 	});
+
+	it('a widget-target press that remaps onto the marquee control is refused off-canvas', () => {
+		// Disable move-widget via an override so a left-drag whose target is 'any' (a widget press)
+		// resolves to studio.marquee — the guard must still refuse to rubber-band off the canvas.
+		const { result } = renderHook(() =>
+			useCanvasPointer({ ...deps, overrides: () => ({ 'studio.moveWidget': { disabled: true } }) })
+		);
+		act(() => result.current.onCanvasMouseDown(ev({ button: 0, target: widgetEl })));
+		expect(result.current.marquee).toBeNull();
+		expect(clearSelection).not.toHaveBeenCalled();
+	});
+
+	it('a stray marquee move from a superseded listener generation is ignored (ref-null guard)', () => {
+		// Two marquee listener generations can briefly coexist (mousedown, re-render with fresh deps,
+		// mousedown again). Generation A's mouseup handler nulls marqueeStart and only THEN reads
+		// renderables() — while generation B's mousemove listener is still attached — so a mousemove
+		// dispatched from renderables() drives onMarqueeMove with no start point, which must no-op.
+		const trap = (): Renderable[] => {
+			window.dispatchEvent(new MouseEvent('mousemove', { clientX: 60, clientY: 60 }));
+			return [];
+		};
+		const mk = (): CanvasPointerDeps => ({
+			...deps,
+			canvasRef: { current: null },
+			renderables: trap
+		});
+		const { result, rerender } = renderHook((p: CanvasPointerDeps) => useCanvasPointer(p), {
+			initialProps: mk()
+		});
+		act(() => result.current.onCanvasMouseDown(ev({ button: 0, clientX: 0, clientY: 0 })));
+		rerender(mk()); // a fresh deps object → new handler identities (generation B)
+		act(() => result.current.onCanvasMouseDown(ev({ button: 0, clientX: 0, clientY: 0 })));
+		act(() => window.dispatchEvent(new MouseEvent('mousemove', { clientX: 40, clientY: 40 })));
+		act(() => window.dispatchEvent(new MouseEvent('mouseup')));
+		expect(result.current.marquee).toBeNull(); // the stale move did not restart a marquee
+		expect(setSelection).toHaveBeenCalledTimes(1); // generation A's selection still committed
+	});
+
+	it('a stray pan move from a superseded listener generation is ignored (ref-null guard)', () => {
+		// Same shape as the marquee case: pan generation A + a live marquee + pan generation B. On
+		// mouseup A's pan handler nulls panStart first; the marquee handler then reads pan() while
+		// generation B's pan-move listener is still attached — a mousemove dispatched there drives
+		// onPanMove with no pan origin, which must no-op instead of deriving a delta from null.
+		let armed = false;
+		const trapPan = (): Pan => {
+			if (armed) window.dispatchEvent(new MouseEvent('mousemove', { clientX: 70, clientY: 70 }));
+			return { panX: 0, panY: 0, zoom: 1 };
+		};
+		const mk = (): CanvasPointerDeps => ({ ...deps, canvasRef: { current: null }, pan: trapPan });
+		const { result, rerender } = renderHook((p: CanvasPointerDeps) => useCanvasPointer(p), {
+			initialProps: mk()
+		});
+		act(() => result.current.onCanvasMouseDown(ev({ button: 1, clientX: 0, clientY: 0 }))); // pan A
+		act(() => result.current.onCanvasMouseDown(ev({ button: 0, clientX: 0, clientY: 0 }))); // marquee
+		act(() => window.dispatchEvent(new MouseEvent('mousemove', { clientX: 40, clientY: 40 })));
+		rerender(mk()); // a fresh deps object → new pan handler identities (generation B)
+		act(() => result.current.onCanvasMouseDown(ev({ button: 1, clientX: 10, clientY: 10 }))); // pan B
+		setPan.mockClear();
+		armed = true;
+		act(() => window.dispatchEvent(new MouseEvent('mouseup')));
+		expect(setPan).not.toHaveBeenCalled(); // the stale move produced no pan update
+		expect(result.current.panning).toBe(false);
+	});
 });

--- a/client/src/lib/widgets/canvas/useEditorModel.test.ts
+++ b/client/src/lib/widgets/canvas/useEditorModel.test.ts
@@ -121,6 +121,18 @@ describe('op-apply path (commit chokepoint)', () => {
 		expect(result.current.state.undoStack).toEqual([]);
 	});
 
+	it('a commit with history enabled but no anchor snapshot self-anchors (lastSnap ?? snap)', () => {
+		const { result } = renderHook(() => useEditorModel(true, []));
+		// A load patch can enable history without carrying a baseline snapshot; the first commit then
+		// anchors undo to its own result instead of reading a null lastSnap.
+		act(() => result.current.dispatch({ type: 'load', patch: { historyReady: true } }));
+		act(() => result.current.commitOp((s) => ({ monitor: { ...s.monitor } })));
+		const s = result.current.state;
+		expect(s.undoStack).toHaveLength(1);
+		expect(s.undoStack[0].monitor).toBe(s.monitor); // self-anchored: the pushed snap IS the new state
+		expect(s.lastSnap?.monitor).toBe(s.monitor);
+	});
+
 	it('mutateNoSave applies the patch WITHOUT recording undo or bumping saveSeq', () => {
 		const { result } = renderHook(() => useEditorModel(true, []));
 		const seq0 = result.current.state.saveSeq;
@@ -285,10 +297,47 @@ describe('def-edit sub-reducer', () => {
 		expect(s.editingDefId).toBe(copy.id);
 	});
 
+	it('cloneDef copies the source css + params by value onto the copy', () => {
+		const { result } = renderHook(() => useEditorModel(true, []));
+		// Seed a def carrying css + params (the optional fields cloneDef must carry over).
+		act(() => result.current.dispatch({ type: 'newWidget' }));
+		const srcId = result.current.state.editingDefId!;
+		act(() => result.current.dispatch({ type: 'endDefEdit' }));
+		act(() => result.current.handleOp({ op: 'setDefCss', defId: srcId, css: '.a{}' }));
+		act(() =>
+			result.current.handleOp({ op: 'addDefParam', defId: srcId, key: 'core', target: 'unit.s' })
+		);
+
+		act(() => result.current.dispatch({ type: 'cloneDef', defId: srcId }));
+		const s = result.current.state;
+		const copy = s.library!.defs.find((d) => d.id !== srcId)!;
+		expect(copy.css).toBe('.a{}');
+		expect(copy.params).toEqual([{ key: 'core', target: 'unit.s' }]);
+		// params are cloned per-entry, not shared with the source def.
+		const src = s.library!.defs.find((d) => d.id === srcId)!;
+		expect(copy.params![0]).not.toBe(src.params![0]);
+	});
+
 	it('cloneDef is a no-op for an unknown def id', () => {
 		const { result } = renderHook(() => useEditorModel(true, []));
 		const before = result.current.state;
 		act(() => result.current.dispatch({ type: 'cloneDef', defId: 'nope' }));
+		expect(result.current.state).toBe(before);
+	});
+
+	it('cloneDef is refused while already editing a def', () => {
+		const { result } = renderHook(() => useEditorModel(true, []));
+		act(() => result.current.dispatch({ type: 'newWidget' }));
+		const before = result.current.state;
+		act(() => result.current.dispatch({ type: 'cloneDef', defId: before.editingDefId! }));
+		expect(result.current.state).toBe(before);
+	});
+
+	it('newFromTemplate is refused while already editing a def', () => {
+		const { result } = renderHook(() => useEditorModel(true, []));
+		act(() => result.current.dispatch({ type: 'newWidget' }));
+		const before = result.current.state;
+		act(() => result.current.dispatch({ type: 'newFromTemplate', templateId: 'clock-jp' }));
 		expect(result.current.state).toBe(before);
 	});
 
@@ -314,6 +363,26 @@ describe('def-edit sub-reducer', () => {
 		act(() => result.current.dispatch({ type: 'enterDefEdit', defId: 'whatever' }));
 		expect(result.current.state).toBe(before);
 		expect(result.current.state.editingDefId).toBe(open);
+	});
+
+	it('enterDefEdit is a no-op for an unknown def id', () => {
+		const { result } = renderHook(() => useEditorModel(true, []));
+		const before = result.current.state;
+		act(() => result.current.dispatch({ type: 'enterDefEdit', defId: 'nope' }));
+		expect(result.current.state).toBe(before);
+	});
+
+	it('endDefEdit writes back only the edited def; other library defs pass through untouched', () => {
+		const { result } = renderHook(() => useEditorModel(true, []));
+		act(() => result.current.dispatch({ type: 'newWidget' }));
+		const firstId = result.current.state.editingDefId!;
+		act(() => result.current.dispatch({ type: 'endDefEdit' }));
+		const firstDef = result.current.state.library!.defs.find((d) => d.id === firstId)!;
+		act(() => result.current.dispatch({ type: 'newWidget' })); // a second def, now being edited
+		act(() => result.current.dispatch({ type: 'endDefEdit' }));
+		const s = result.current.state;
+		expect(s.library?.defs).toHaveLength(2);
+		expect(s.library?.defs.find((d) => d.id === firstId)).toBe(firstDef); // same object: untouched
 	});
 
 	it('endDefEdit writes the scoped tree back onto the def, restores the monitor, and commits', () => {
@@ -679,6 +748,15 @@ describe('handleOp switch (Inspector / Outline / menu funnel)', () => {
 		expect(result.current.state.editingDefId).not.toBeNull();
 		act(() => result.current.handleOp({ op: 'endDefEdit' }));
 		expect(result.current.state.editingDefId).toBeNull();
+	});
+});
+
+describe('reducer fallback', () => {
+	it('an unknown action type returns the state unchanged (same reference)', () => {
+		const { result } = renderHook(() => useEditorModel(true, []));
+		const before = result.current.state;
+		act(() => result.current.dispatch({ type: 'nope' } as never));
+		expect(result.current.state).toBe(before);
 	});
 });
 

--- a/client/src/lib/widgets/canvas/useKeyboard.test.ts
+++ b/client/src/lib/widgets/canvas/useKeyboard.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, renderHook } from '@testing-library/react';
+import { registerControl } from '../../core/controls';
 import { useKeyboard, type KeyboardDeps } from './useKeyboard';
 
 // Mutable context the deps read, so a test can flip dirty/hasSelection/menuOpen between keystrokes.
@@ -118,6 +119,20 @@ describe('useKeyboard registry dispatch', () => {
 		expect(result.current.spaceDown).toBe(true);
 	});
 
+	it('a nudge chord remapped to a non-arrow key matches but nudges nothing', () => {
+		// A user remap can bind studio.nudge to any key; only the arrows have a NUDGE delta, so a
+		// non-arrow hit resolves no delta and the nudge callback is never invoked.
+		state.hasSelection = true;
+		renderHook(() =>
+			useKeyboard({
+				...deps,
+				overrides: () => ({ 'studio.nudge': { triggers: [{ type: 'key', key: 'j' }] } })
+			})
+		);
+		press({ key: 'j', code: 'KeyJ' });
+		expect(nudge).not.toHaveBeenCalled();
+	});
+
 	it('Ctrl+1..8 jumps to the matching section (0-based index)', () => {
 		renderHook(() => useKeyboard(deps));
 		press({ key: '1', code: 'Digit1', ctrlKey: true });
@@ -125,6 +140,29 @@ describe('useKeyboard registry dispatch', () => {
 		press({ key: '8', code: 'Digit8', ctrlKey: true });
 		expect(gotoSection).toHaveBeenLastCalledWith(7);
 		expect(gotoSection).toHaveBeenCalledTimes(2);
+	});
+
+	it('a section chord with a digit outside 1..8 (remapped trigger) does not jump', () => {
+		// The built-in triggers only bind Ctrl+1..8; a remap can still hit studio.section with an
+		// out-of-range digit (or no digit at all) — the guard must skip gotoSection for those.
+		renderHook(() =>
+			useKeyboard({
+				...deps,
+				overrides: () => ({
+					'studio.section': {
+						triggers: [
+							{ type: 'key', key: '9', ctrl: true },
+							{ type: 'key', key: '0', ctrl: true },
+							{ type: 'key', key: 'x', ctrl: true }
+						]
+					}
+				})
+			})
+		);
+		press({ key: '9', code: 'Digit9', ctrlKey: true }); // an integer, but > 8
+		press({ key: '0', code: 'Digit0', ctrlKey: true }); // an integer, but < 1
+		press({ key: 'x', code: 'KeyX', ctrlKey: true }); // not a number at all
+		expect(gotoSection).not.toHaveBeenCalled();
 	});
 
 	it('a section chord with no gotoSection handler is a harmless no-op', () => {
@@ -168,6 +206,31 @@ describe('useKeyboard registry dispatch', () => {
 		press({ key: 'e', code: 'KeyE', ctrlKey: true });
 		expect(handlers['global.toggleEdit']).toHaveBeenCalledTimes(1);
 		unmount();
+	});
+
+	it('honors preventDefault: false on a matched control (the browser default is kept)', () => {
+		// No built-in sets preventDefault: false — register a synthetic control to drive the skip arm.
+		registerControl({
+			id: 'test.noPrevent',
+			scope: 'studio',
+			group: 'edit',
+			label: 'test control',
+			triggers: [{ type: 'key', key: 'f9' }],
+			preventDefault: false
+		});
+		const fired = vi.fn();
+		renderHook(() => useKeyboard({ ...deps, handlers: { ...handlers, 'test.noPrevent': fired } }));
+		const event = new KeyboardEvent('keydown', {
+			key: 'F9',
+			code: 'F9',
+			bubbles: true,
+			cancelable: true
+		});
+		act(() => {
+			window.dispatchEvent(event);
+		});
+		expect(fired).toHaveBeenCalledTimes(1); // the control matched and ran…
+		expect(event.defaultPrevented).toBe(false); // …without suppressing the default
 	});
 
 	it('does not steal Space pan-mode from a focused button', () => {

--- a/client/src/lib/widgets/canvas/usePersistence.test.ts
+++ b/client/src/lib/widgets/canvas/usePersistence.test.ts
@@ -276,7 +276,9 @@ describe('persistToDisk — widgets.json assembly', () => {
 	});
 
 	it('appends an extra onto an on-disk monitor that has no `floating` field', async () => {
-		// The on-disk mon-B record omits `floating` → the `?? []` guard must synthesize the array.
+		// The on-disk mon-B record omits `floating`, but parseLayoutAny's parseMonitor normalises it
+		// to [] before the extras loop ever sees the record — the `t.floating ?? []` arm in the loop
+		// itself stays defensive-only (no real input reaches it).
 		loadLayoutRaw = JSON.stringify({
 			version: 2,
 			monitors: { 'mon-B': { root: container('root', 'col', []) } }

--- a/client/src/lib/widgets/canvas/useSacks.test.ts
+++ b/client/src/lib/widgets/canvas/useSacks.test.ts
@@ -154,6 +154,37 @@ describe('refreshSacks (section-open peek)', () => {
 		setup({ navSection: 'settings' });
 		expect(listSacks).not.toHaveBeenCalled();
 	});
+
+	it('drops a stale section-open load once the section closes mid-flight', async () => {
+		// listSacks resolves only AFTER the section flips away — the effect's cancel guard must drop
+		// the late result instead of clobbering state for a section that is no longer open.
+		let resolveNames!: (names: string[]) => void;
+		listSacks.mockReturnValue(new Promise<string[]>((r) => (resolveNames = r)));
+		const commitOp = vi.fn<(run: (s: EditorState) => Partial<EditorState>) => void>();
+		const { result, rerender } = renderHook(
+			(p: { navSection: 'sacks' | 'settings' }) =>
+				useSacks({
+					studio: true,
+					navSection: p.navSection,
+					editingDefId: null,
+					selectedTheme: '',
+					library: undefined,
+					tokenOverrides: {},
+					commitOp,
+					themes: { themeLabel, setThemeList, adoptTheme }
+				}),
+			{ initialProps: { navSection: 'sacks' as 'sacks' | 'settings' } }
+		);
+		rerender({ navSection: 'settings' }); // cleanup flips the cancel guard
+		await act(async () => {
+			resolveNames(['late']);
+			await Promise.resolve();
+			await Promise.resolve();
+			await Promise.resolve();
+		});
+		expect(readSack).toHaveBeenCalledWith('late'); // the load DID finish…
+		expect(result.current.sackInfos).toEqual([]); // …but the stale result never landed
+	});
 });
 
 describe('exportSack', () => {
@@ -322,6 +353,40 @@ describe('importSack', () => {
 		});
 		expect(saveThemeCss).toHaveBeenCalledWith('Risky', expect.any(String));
 		expect(commitOp).toHaveBeenCalledTimes(1);
+	});
+
+	it('imports a theme-ONLY sack: the commit patch carries just the selection', async () => {
+		// No library defs and no tokens → the commit patch must leave both untouched (the false arms
+		// of the library/tokens guards), carrying only the newly-adopted theme name.
+		const sack = packSack({ name: 's', theme: { name: 'Solo', css: ':root{}' } });
+		readSack.mockResolvedValue(JSON.stringify(sack));
+		listThemes.mockResolvedValue([]);
+		const { result, commitOp } = setup({ navSection: 'settings' });
+		await act(async () => {
+			await result.current.importSack('s');
+		});
+		const patch = commitOp.mock.calls[0][0]({
+			library: undefined,
+			tokenOverrides: {}
+		} as EditorState);
+		expect(patch).toEqual({ selectedTheme: 'Solo' });
+		expect(adoptTheme).toHaveBeenCalledWith('Solo');
+	});
+
+	it('an empty tokens object imports as a no-op patch (tokens present but zero keys)', async () => {
+		// unpackSack passes the JSON through verbatim, so a hand-edited sack can carry `tokens: {}` —
+		// the Object.keys length guard must not spread an empty override set into the state.
+		readSack.mockResolvedValue(JSON.stringify({ kind: 'widgetsack/sack', version: 1, tokens: {} }));
+		const { result, commitOp } = setup({ navSection: 'settings' });
+		await act(async () => {
+			await result.current.importSack('s');
+		});
+		const patch = commitOp.mock.calls[0][0]({
+			library: undefined,
+			tokenOverrides: {}
+		} as EditorState);
+		expect(patch).toEqual({});
+		expect(adoptTheme).not.toHaveBeenCalled();
 	});
 
 	it('imports a themeless sack: commit applies only library/tokens, no theme adopt', async () => {

--- a/client/src/lib/widgets/canvas/useThemes.test.ts
+++ b/client/src/lib/widgets/canvas/useThemes.test.ts
@@ -24,7 +24,11 @@ vi.mock('../../overlay', () => ({
 
 function setup(opts: { studio?: boolean; selectedTheme?: string } = {}) {
 	const dispatch = vi.fn() as unknown as EditorModel['dispatch'];
-	const commitOp = vi.fn() as unknown as EditorModel['commitOp'];
+	// Invoke the run callback like the real reducer does, so the `() => ({})` history-no-op patch
+	// arrows execute (they ignore the state arg, so passing none is safe).
+	const commitOp = vi.fn((run: (s: never) => unknown) =>
+		run(undefined as never)
+	) as unknown as EditorModel['commitOp'];
 	const hook = renderHook(
 		(p: { studio: boolean; selectedTheme: string }) =>
 			useThemes({ studio: p.studio, selectedTheme: p.selectedTheme, dispatch, commitOp }),

--- a/client/src/lib/widgets/canvas/useZoomFit.test.ts
+++ b/client/src/lib/widgets/canvas/useZoomFit.test.ts
@@ -119,6 +119,15 @@ describe('initial pan + auto-fit effect', () => {
 		expect(result.current).toMatchObject({ zoom: 2, panX: 11, panY: 22 });
 	});
 
+	it('does not re-fit when the effect re-runs on a stage resize with the SAME key', () => {
+		const opts = baseOpts();
+		const { result, rerender } = renderHook((p: Opts) => useZoomFit(p), { initialProps: opts });
+		act(() => result.current.setPan({ zoom: 2, panX: 11, panY: 22 }));
+		// stageW is an effect dep but NOT part of the fit key — the effect re-runs and must bail.
+		rerender({ ...opts, stageW: 900 });
+		expect(result.current).toMatchObject({ zoom: 2, panX: 11, panY: 22 });
+	});
+
 	it('auto-fits AGAIN when the monitor key changes (different monitor)', () => {
 		const opts = baseOpts();
 		const { result, rerender } = renderHook((p: Opts) => useZoomFit(p), { initialProps: opts });

--- a/client/src/lib/widgets/canvas/widgetProfile.test.ts
+++ b/client/src/lib/widgets/canvas/widgetProfile.test.ts
@@ -33,4 +33,20 @@ describe('widgetCosts', () => {
 		render('text-cc', 0.2, 5000);
 		expect(widgetCosts()[0]).toMatchObject({ id: 'text-cc', commits: 1, perSec: 0 });
 	});
+
+	it('falls back to the full id as the type when the prefix is empty (id starts with "-")', () => {
+		render('-orphan', 1, 1000);
+		expect(widgetCosts()[0]).toMatchObject({ id: '-orphan', type: '-orphan' });
+	});
+
+	it('reports 0/s for repeat commits with no elapsed span and tie-breaks by avg ms', () => {
+		// Both widgets read 0/s (same-timestamp commits → zero span; single commit → no interval), so
+		// the sort falls through to the slowest-average tie-break.
+		render('slow-x', 5, 1000);
+		render('slow-x', 5, 1000); // 2 commits, zero span → still 0/s
+		render('fast-y', 1, 1000);
+		const costs = widgetCosts();
+		expect(costs.map((c) => c.id)).toEqual(['slow-x', 'fast-y']); // avg 5ms before avg 1ms
+		expect(costs[0].perSec).toBe(0);
+	});
 });

--- a/client/src/lib/widgets/cssEditorLint.test.ts
+++ b/client/src/lib/widgets/cssEditorLint.test.ts
@@ -47,6 +47,14 @@ describe('cssDiagnostics', () => {
 		expect(cssDiagnostics('color:', { supports: () => false })).toEqual([]);
 	});
 
+	it('de-dupes identical diagnostics (two zero-width parse errors at the same clamped spot)', () => {
+		// '~ ~' parses (balanced, so no short-circuit) into TWO zero-width error nodes at the same
+		// position; both clamp to the same (from, to, message), so exactly one survives the de-dupe.
+		const d = cssDiagnostics('~ ~', { supports: ok });
+		expect(d).toHaveLength(1);
+		expect(d[0]).toMatchObject({ from: 3, to: 4, severity: 'error', message: 'Syntax error' });
+	});
+
 	it('caps the diagnostic count on a very broken doc', () => {
 		// A flood of distinct unknown props — the gutter is capped at 50 entries.
 		const lines = Array.from({ length: 80 }, (_, i) => `bad-prop-${i}: x`).join(';\n');

--- a/client/src/lib/widgets/meters/Agenda.test.tsx
+++ b/client/src/lib/widgets/meters/Agenda.test.tsx
@@ -88,4 +88,37 @@ describe('Agenda meter', () => {
 		const c = await renderWith(null);
 		expect(c.querySelector('.ag-empty')?.textContent).toBe('No upcoming events');
 	});
+
+	it('skips the re-render when a re-ingest produces an identical event list', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date(2027, 0, 1, 13, 0, 0));
+		const hub = createTelemetryHub();
+		const rows = [{ summary: 'Design review', start: new Date(2027, 0, 1, 15, 0).toISOString() }];
+		hub.ingestBatch([list(rows)]);
+		const c = await renderWith(hub);
+		expect(c.querySelectorAll('.ag-row')).toHaveLength(1);
+		// Re-ingest the exact same batch: the subscriber fires, read() re-runs, but the parsed list's
+		// JSON matches the previous signature so `setEvents` (and a re-render) is skipped.
+		await act(async () => {
+			hub.ingestBatch([list(rows)]);
+		});
+		expect(c.querySelectorAll('.ag-row')).toHaveLength(1);
+	});
+
+	it('re-evaluates the relative "when" labels on the minute tick', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date(2027, 0, 1, 13, 0, 0));
+		const hub = createTelemetryHub();
+		hub.ingestBatch([
+			list([{ summary: 'Design review', start: new Date(2027, 0, 1, 15, 0).toISOString() }])
+		]);
+		const c = await renderWith(hub);
+		expect(c.querySelector('.ag-when')?.textContent).toBe('Today 15:00');
+		// Jump a day forward and let the minute tick fire — "when" should re-derive relative to `now`.
+		vi.setSystemTime(new Date(2027, 0, 2, 13, 0, 0));
+		await act(async () => {
+			vi.advanceTimersByTime(60_000);
+		});
+		expect(c.querySelector('.ag-empty')?.textContent).toBe('No upcoming events'); // now in the past
+	});
 });

--- a/client/src/lib/widgets/meters/AirQuality.test.tsx
+++ b/client/src/lib/widgets/meters/AirQuality.test.tsx
@@ -29,4 +29,30 @@ describe('AirQuality meter', () => {
 		const { container } = render(<AirQuality sensors={{}} />);
 		expect(container.querySelector('.aq-value')?.textContent).toBe('—');
 	});
+
+	it('applies a per-instance color as the --aq-accent CSS variable', () => {
+		const { container } = render(<AirQuality sensors={{}} color="rgb(8,8,8)" />);
+		const root = container.querySelector('.np-airquality') as HTMLElement;
+		expect(root.style.getPropertyValue('--aq-accent')).toBe('rgb(8,8,8)');
+	});
+
+	it('hides the detail row entirely when both PM2.5 and UV are disabled', () => {
+		const { container } = render(
+			<AirQuality
+				sensors={{ aqi: sc(34), pm25: sc(8.2), uv: sc(6) }}
+				showPm={false}
+				showUv={false}
+			/>
+		);
+		expect(container.querySelector('.aq-detail')).toBeNull();
+	});
+
+	it('omits just the PM2.5 or UV line when that toggle is off, keeping the other', () => {
+		const { container } = render(
+			<AirQuality sensors={{ aqi: sc(34), pm25: sc(8.2), uv: sc(6) }} showPm={false} />
+		);
+		const detail = container.querySelector('.aq-detail')?.textContent ?? '';
+		expect(detail).not.toContain('PM2.5');
+		expect(detail).toContain('UV');
+	});
 });

--- a/client/src/lib/widgets/meters/AnalogClock.test.tsx
+++ b/client/src/lib/widgets/meters/AnalogClock.test.tsx
@@ -1,6 +1,8 @@
-import { describe, expect, it } from 'vitest';
-import { render } from '@testing-library/react';
+import { describe, expect, it, afterEach, vi } from 'vitest';
+import { render, act } from '@testing-library/react';
 import AnalogClock from './AnalogClock';
+
+afterEach(() => vi.useRealTimers());
 
 describe('AnalogClock (DOM)', () => {
 	it('renders a DOM dial with three hands (no SVG)', () => {
@@ -35,5 +37,26 @@ describe('AnalogClock (DOM)', () => {
 		const { container } = render(<AnalogClock accent="rgb(1,2,3)" />);
 		const root = container.querySelector('.np-analog-clock') as HTMLElement;
 		expect(root.style.getPropertyValue('--clock-accent')).toBe('rgb(1,2,3)');
+	});
+
+	it('maps color and face config to their own CSS variables', () => {
+		const { container } = render(<AnalogClock color="#fff" face="#000" />);
+		const root = container.querySelector('.np-analog-clock') as HTMLElement;
+		expect(root.style.getPropertyValue('--clock-fg')).toBe('#fff');
+		expect(root.style.getPropertyValue('--clock-face')).toBe('#000');
+	});
+
+	it('sweeps the second hand forward on the redraw tick', () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date(2027, 0, 1, 12, 0, 0));
+		const { container } = render(<AnalogClock />);
+		const hand = () =>
+			(container.querySelector('.np-clock-second')!.parentElement as HTMLElement).style.transform;
+		const before = hand();
+		vi.setSystemTime(new Date(2027, 0, 1, 12, 0, 5));
+		act(() => {
+			vi.advanceTimersByTime(1000);
+		});
+		expect(hand()).not.toBe(before);
 	});
 });

--- a/client/src/lib/widgets/meters/AudioSwitcher.test.tsx
+++ b/client/src/lib/widgets/meters/AudioSwitcher.test.tsx
@@ -45,4 +45,12 @@ describe('AudioSwitcher meter', () => {
 		);
 		expect(container.querySelector('.as-empty')?.textContent).toBe('—');
 	});
+
+	it('applies a per-instance color as the --as-accent CSS variable', () => {
+		const { container } = render(
+			<AudioSwitcher devices={devices} currentId="a" onPick={() => undefined} color="rgb(9,1,2)" />
+		);
+		const root = container.querySelector('.np-audioswitch') as HTMLElement;
+		expect(root.style.getPropertyValue('--as-accent')).toBe('rgb(9,1,2)');
+	});
 });

--- a/client/src/lib/widgets/meters/Battery.test.tsx
+++ b/client/src/lib/widgets/meters/Battery.test.tsx
@@ -35,4 +35,10 @@ describe('Battery meter', () => {
 		const { container: empty } = render(<Battery sensors={{}} />);
 		expect(empty.querySelector('.bat-pct')?.textContent).toBe('—');
 	});
+
+	it('applies a per-instance color as the --bat-accent CSS variable', () => {
+		const { container } = render(<Battery sensors={{}} color="rgb(6,6,6)" />);
+		const root = container.querySelector('.np-battery') as HTMLElement;
+		expect(root.style.getPropertyValue('--bat-accent')).toBe('rgb(6,6,6)');
+	});
 });

--- a/client/src/lib/widgets/meters/Calendar.test.tsx
+++ b/client/src/lib/widgets/meters/Calendar.test.tsx
@@ -1,8 +1,11 @@
-import { describe, it, expect, afterEach } from 'vitest';
-import { render, cleanup } from '@testing-library/react';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup, act } from '@testing-library/react';
 import Calendar from './Calendar';
 
-afterEach(cleanup);
+afterEach(() => {
+	cleanup();
+	vi.useRealTimers();
+});
 
 // The meter self-sources the real date, so these assert STRUCTURE (the grid math is exhaustively
 // covered in core/calendar.test.ts) — which holds whatever today happens to be.
@@ -38,5 +41,24 @@ describe('Calendar meter', () => {
 			'.cal-row:not(.cal-head)'
 		).length;
 		expect(contRows).toBeGreaterThan(monthRows);
+	});
+
+	it('applies a per-instance color as the --cal-accent CSS variable', () => {
+		const { container } = render(<Calendar color="rgb(4,2,0)" />);
+		const root = container.querySelector('.np-calendar') as HTMLElement;
+		expect(root.style.getPropertyValue('--cal-accent')).toBe('rgb(4,2,0)');
+	});
+
+	it('re-reads the date on the slow minute tick (so "today" flips past midnight)', () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date(2027, 0, 31, 23, 59, 30));
+		const { container } = render(<Calendar />);
+		expect(container.querySelectorAll('.cal-today')).toHaveLength(1);
+		const beforeTitle = container.querySelector('.cal-title')?.textContent;
+		vi.setSystemTime(new Date(2027, 1, 1, 0, 0, 30));
+		act(() => {
+			vi.advanceTimersByTime(60_000);
+		});
+		expect(container.querySelector('.cal-title')?.textContent).not.toBe(beforeTitle);
 	});
 });

--- a/client/src/lib/widgets/meters/Disks.test.tsx
+++ b/client/src/lib/widgets/meters/Disks.test.tsx
@@ -148,6 +148,26 @@ describe('Disks meter', () => {
 		expect(container.querySelector('.disk-meta')?.textContent).toBe(before);
 	});
 
+	it('does not crash if the demand-probe sensor unexpectedly receives a sample', async () => {
+		// disk._probe is a pure demand sentinel (subscribing gates backend sampling on); the widget
+		// itself never reads a value off it. Its subscribe callback is a no-op — this just proves that
+		// holds even if something upstream ever did emit on it.
+		const hub = createTelemetryHub();
+		hub.ingestBatch([s('disk.C.used.pct', 40)]);
+		let container!: HTMLElement;
+		await act(async () => {
+			container = render(
+				<TelemetryHubContext.Provider value={hub}>
+					<Disks />
+				</TelemetryHubContext.Provider>
+			).container;
+		});
+		expect(() =>
+			hub.ingest({ sensor: 'disk._probe', ts_ms: 0, value: { kind: 'scalar', value: 1 } })
+		).not.toThrow();
+		expect(container.querySelector('.disk-meta')?.textContent).toBe('40%');
+	});
+
 	it('updates rows on the 5s re-read when a volume capacity changes', async () => {
 		vi.useFakeTimers();
 		const hub = createTelemetryHub();

--- a/client/src/lib/widgets/meters/GpuPanel.test.tsx
+++ b/client/src/lib/widgets/meters/GpuPanel.test.tsx
@@ -34,4 +34,17 @@ describe('GpuPanel meter', () => {
 		expect(container.querySelector('.gpu-util-val')?.textContent).toBe('—');
 		expect(container.querySelector('.gpu-stats')).toBeNull();
 	});
+
+	it('applies a per-instance color as the --gpu-accent CSS variable', () => {
+		const { container } = render(<GpuPanel sensors={{}} color="rgb(7,7,7)" />);
+		const root = container.querySelector('.np-gpu') as HTMLElement;
+		expect(root.style.getPropertyValue('--gpu-accent')).toBe('rgb(7,7,7)');
+	});
+
+	it('hides the name row when showName is off', () => {
+		const { container } = render(
+			<GpuPanel sensors={{ name: txt('NVIDIA RTX 4080') }} showName={false} />
+		);
+		expect(container.querySelector('.gpu-name')).toBeNull();
+	});
 });

--- a/client/src/lib/widgets/meters/MonitorSourcesEditor.test.tsx
+++ b/client/src/lib/widgets/meters/MonitorSourcesEditor.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, waitFor, fireEvent, cleanup } from '@testing-library/react';
+import { render, waitFor, fireEvent, cleanup, act } from '@testing-library/react';
 
 // Stub the Tauri-backed DDC adapter: the editor must still scan the chosen monitor's inputs and round-
 // trip include/rename edits through the same `code=label` spec the widget consumes.
@@ -134,11 +134,59 @@ describe('MonitorSourcesEditor (config form)', () => {
 		expect(container.querySelector('.ms-src-row')).toBeNull();
 	});
 
+	it('re-shows the detecting state and re-scans when the monitor prop changes on a live instance', async () => {
+		listMonitorInputs.mockResolvedValueOnce([mon({ supported: [0x0f, 0x11] })]);
+		const { container, rerender } = render(
+			<MonitorSourcesEditor value="" monitor="" onChange={() => undefined} />
+		);
+		await waitFor(() => expect(container.querySelectorAll('.ms-src-row')).toHaveLength(2));
+		listMonitorInputs.mockResolvedValueOnce([
+			mon({ gdi: '\\\\.\\DISPLAY2', primary: false, supported: [0x12] })
+		]);
+		rerender(
+			<MonitorSourcesEditor value="" monitor={'\\\\.\\DISPLAY2'} onChange={() => undefined} />
+		);
+		await waitFor(() => expect(listMonitorInputs).toHaveBeenCalledWith('\\\\.\\DISPLAY2'));
+		await waitFor(() => expect(container.querySelectorAll('.ms-src-row')).toHaveLength(1));
+		expect(container.querySelector('.ms-src-name')?.textContent).toBe('HDMI 2');
+	});
+
+	it('discards a stale in-flight probe result when the monitor changes before it resolves', async () => {
+		let resolveFirst!: (v: MonitorInputs[]) => void;
+		const first = new Promise<MonitorInputs[]>((res) => {
+			resolveFirst = res;
+		});
+		listMonitorInputs.mockReturnValueOnce(first); // the '' (primary) probe never resolves during this test
+		listMonitorInputs.mockResolvedValueOnce([
+			mon({ gdi: '\\\\.\\DISPLAY2', primary: false, supported: [0x12] })
+		]);
+		const { container, rerender } = render(
+			<MonitorSourcesEditor value="" monitor="" onChange={() => undefined} />
+		);
+		// Switch monitors before the first probe settles — the effect's cleanup marks it cancelled.
+		rerender(
+			<MonitorSourcesEditor value="" monitor={'\\\\.\\DISPLAY2'} onChange={() => undefined} />
+		);
+		await waitFor(() => expect(container.querySelectorAll('.ms-src-row')).toHaveLength(1));
+		expect(container.querySelector('.ms-src-name')?.textContent).toBe('HDMI 2');
+		// Now let the stale first probe resolve — its `cancelled` guard must discard the result instead
+		// of clobbering the DISPLAY2 data that's already showing.
+		await act(async () => {
+			resolveFirst([mon({ supported: [0x0f, 0x11] })]);
+		});
+		expect(container.querySelectorAll('.ms-src-row')).toHaveLength(1);
+		expect(container.querySelector('.ms-src-name')?.textContent).toBe('HDMI 2');
+	});
+
 	it('rescans on demand', async () => {
 		const { container } = render(
 			<MonitorSourcesEditor value="" monitor="" onChange={() => undefined} />
 		);
-		await waitFor(() => expect(container.querySelector('.ms-src-scan')).not.toBeNull());
+		// Wait for the initial probe to finish (the button is DISABLED while detecting): clicking a
+		// still-disabled button would silently no-op and flake the call-count assertion below.
+		await waitFor(() =>
+			expect((container.querySelector('.ms-src-scan') as HTMLButtonElement).disabled).toBe(false)
+		);
 		expect(listMonitorInputs).toHaveBeenCalledTimes(1);
 		fireEvent.click(container.querySelector('.ms-src-scan')!);
 		await waitFor(() => expect(listMonitorInputs).toHaveBeenCalledTimes(2));

--- a/client/src/lib/widgets/meters/NetConnections.test.tsx
+++ b/client/src/lib/widgets/meters/NetConnections.test.tsx
@@ -76,4 +76,56 @@ describe('NetConnections meter', () => {
 		const c = await renderWith(hub);
 		expect(c.querySelector('.nc-empty')?.textContent).toBe('—');
 	});
+
+	it('renders nothing sensor-driven without a telemetry hub in context', async () => {
+		let container!: HTMLElement;
+		await act(async () => {
+			container = render(<NetConnections />).container;
+		});
+		// The early `if (!hub) return` bails the effect — the dash-empty state still renders.
+		expect(container.querySelector('.nc-empty')?.textContent).toBe('—');
+	});
+
+	it('skips the re-render when a re-ingest produces an identical snapshot', async () => {
+		const hub = createTelemetryHub();
+		const rows = [
+			{ proc: 'chrome.exe', pid: 100, established: 4, public: 3, remotes: ['8.8.8.8:443'] }
+		];
+		hub.ingestBatch([
+			scalar('net.conn.established', 5),
+			scalar('net.conn.public', 3),
+			scalar('net.conn.listening', 0),
+			list(rows)
+		]);
+		const c = await renderWith(hub);
+		expect(c.querySelectorAll('.nc-row')).toHaveLength(1);
+		// Re-ingest the exact same batch: the subscriber fires, read() re-runs, but the computed
+		// snapshot's JSON matches the previous signature so `setSnap` (and a re-render) is skipped.
+		await act(async () => {
+			hub.ingestBatch([
+				scalar('net.conn.established', 5),
+				scalar('net.conn.public', 3),
+				scalar('net.conn.listening', 0),
+				list(rows)
+			]);
+		});
+		expect(c.querySelectorAll('.nc-row')).toHaveLength(1);
+	});
+
+	it('applies a per-instance color as the --nc-accent CSS variable', async () => {
+		const hub = createTelemetryHub();
+		const c = await renderWith(hub, { color: 'rgb(3,1,4)' });
+		const root = c.querySelector('.np-netconn') as HTMLElement;
+		expect(root.style.getPropertyValue('--nc-accent')).toBe('rgb(3,1,4)');
+	});
+
+	it('hides the established badge when it does not exceed the public count, and labels a public row without remotes', async () => {
+		const hub = createTelemetryHub();
+		hub.ingestBatch([list([{ proc: 'app.exe', pid: 42, established: 2, public: 2, remotes: [] }])]);
+		const c = await renderWith(hub);
+		const row = c.querySelector('.nc-row')!;
+		expect(row.querySelector('.nc-est')).toBeNull();
+		const pub = row.querySelector('.nc-pub')!;
+		expect(pub.getAttribute('title')).toBe('public Internet');
+	});
 });

--- a/client/src/lib/widgets/meters/NowPlaying.test.tsx
+++ b/client/src/lib/widgets/meters/NowPlaying.test.tsx
@@ -511,6 +511,15 @@ describe('NowPlaying — crossfade layer lifecycle (transitionend)', () => {
 // Art-clearing paths: the player vanishing drops every layer immediately; an art-less track keeps the
 // stale cover for a grace window then fades it out, unless new art arrives first.
 describe('NowPlaying — art clearing', () => {
+	it('mounting straight into a track with no art at all schedules nothing (no layers to fade)', () => {
+		// A fresh mount (never had a cover) whose track also has no art: the no-art guard's
+		// `layersRef.current.length > 0` check is false from the very first effect run — there is
+		// nothing to hold onto or fade, so it just returns without scheduling a teardown timer.
+		const { container } = render(<NowPlaying session={session('Song A', null)} />);
+		expect(container.querySelectorAll('.np-thumb').length).toBe(0);
+		expect(container.querySelector('[data-part="title"]')?.textContent).toBe('Song A');
+	});
+
 	it('drops every cover layer immediately when the player goes away', async () => {
 		const { container, rerender } = await renderWithLoadedCover();
 		expect(container.querySelectorAll('.np-thumb').length).toBe(1);
@@ -561,6 +570,30 @@ describe('NowPlaying — art clearing', () => {
 		});
 		// The old cover was not torn down by the cancelled timer; the new art layer is present.
 		expect(container.querySelector('.np-thumb[src="http://art.localhost/789"]')).not.toBeNull();
+	});
+
+	it('does not clear any layers when a track/cover first appears (showsArt flips false → true)', async () => {
+		// Mount with nothing playing at all, then a session with a track + art appears. The
+		// adjust-during-render guard fires (showsArt !== prevShowsArt) but must NOT clear layers on the
+		// way IN — only the away/track-loss direction (`!showsArt`) does that.
+		const { container, rerender } = render(<NowPlaying session={null} />);
+		expect(container.querySelectorAll('.np-thumb').length).toBe(0);
+		rerender(<NowPlaying session={session('Song A', ART)} />);
+		await waitFor(() => expect(container.querySelectorAll('.np-thumb').length).toBe(1));
+	});
+
+	it('drops the whole stack with no crossfade anchor when a third cover arrives before anything loaded', async () => {
+		// Start from a loaded cover, then push two MORE distinct-art changes back to back without ever
+		// firing `load` on the intermediate layer. By the time the second push's effect runs, every
+		// layer in `prev` is loaded:false — the outgoing-anchor loop finds nothing to carry forward.
+		const { container, rerender } = await renderWithLoadedCover();
+		rerender(<NowPlaying session={session('Song B', 'http://art.localhost/456')} />);
+		await waitFor(() => expect(container.querySelectorAll('.np-thumb').length).toBe(2));
+		rerender(<NowPlaying session={session('Song C', 'http://art.localhost/789')} />);
+		await waitFor(() => {
+			const srcs = [...container.querySelectorAll('.np-thumb')].map((el) => el.getAttribute('src'));
+			expect(srcs).toEqual(['http://art.localhost/789']);
+		});
 	});
 
 	it('clears a pending no-art teardown timer on unmount (no late state update)', async () => {

--- a/client/src/lib/widgets/meters/ProcessWatch.test.tsx
+++ b/client/src/lib/widgets/meters/ProcessWatch.test.tsx
@@ -32,4 +32,28 @@ describe('ProcessWatch meter', () => {
 		expect(container.querySelector('.procwatch')?.getAttribute('data-state')).toBe('unknown');
 		expect(container.querySelector('.pw-status')?.textContent).toBe('—');
 	});
+
+	it('falls back to a bare "running" when no cpu/mem/count sample has arrived yet', () => {
+		const { container } = render(<ProcessWatch sensors={{ running: sc(1) }} />);
+		expect(container.querySelector('.pw-status')?.textContent).toBe('running');
+	});
+
+	it('omits the ×count suffix when the count is 1', () => {
+		const { container } = render(
+			<ProcessWatch sensors={{ running: sc(1), cpu: sc(2), mem: sc(1024), count: sc(1) }} />
+		);
+		const status = container.querySelector('.pw-status')?.textContent ?? '';
+		expect(status).not.toContain('×');
+	});
+
+	it('applies a per-instance color as the --pw-accent CSS variable', () => {
+		const { container } = render(<ProcessWatch sensors={{}} color="rgb(9,8,7)" />);
+		const root = container.querySelector('.np-procwatch') as HTMLElement;
+		expect(root.style.getPropertyValue('--pw-accent')).toBe('rgb(9,8,7)');
+	});
+
+	it('prefers a custom label over the raw process name', () => {
+		const { container } = render(<ProcessWatch name="chrome.exe" label="Browser" sensors={{}} />);
+		expect(container.querySelector('.pw-name')?.textContent).toBe('Browser');
+	});
 });

--- a/client/src/lib/widgets/meters/Recyclebin.test.tsx
+++ b/client/src/lib/widgets/meters/Recyclebin.test.tsx
@@ -33,4 +33,23 @@ describe('Recyclebin meter', () => {
 		);
 		expect(container.querySelector('.recyclebin')?.getAttribute('data-level')).toBe('full');
 	});
+
+	it('treats a missing byte sample as 0 bytes while still counting items', () => {
+		const { container } = render(<Recyclebin sensors={{ items: sc(4) }} />);
+		expect(container.querySelector('.rb-count')?.textContent).toBe('4 items');
+		expect(container.querySelector('.rb-size')?.textContent).toBe('0 B');
+	});
+
+	it('ignores a non-scalar items sample (treated as no reading yet → empty)', () => {
+		const { container } = render(
+			<Recyclebin sensors={{ items: { value: { kind: 'text', value: 'n/a' }, history: [] } }} />
+		);
+		expect(container.querySelector('.rb-empty')?.textContent).toBe('Empty');
+	});
+
+	it('applies a per-instance color as the --rb-accent CSS variable', () => {
+		const { container } = render(<Recyclebin sensors={{}} color="rgb(1,1,1)" />);
+		const root = container.querySelector('.np-recyclebin') as HTMLElement;
+		expect(root.style.getPropertyValue('--rb-accent')).toBe('rgb(1,1,1)');
+	});
 });

--- a/client/src/lib/widgets/meters/StickyNote.test.tsx
+++ b/client/src/lib/widgets/meters/StickyNote.test.tsx
@@ -114,6 +114,27 @@ describe('StickyNote', () => {
 		expect(stopWheel).not.toHaveBeenCalled();
 	});
 
+	it('keeps showing whatever text is up when the widget id changes to empty on a live instance', () => {
+		localStorage.setItem('scratch:w11', 'kept note');
+		const { container, rerender } = render(<StickyNote widgetId="w11" />);
+		const ta = () => container.querySelector('textarea') as HTMLTextAreaElement;
+		expect(ta().value).toBe('kept note');
+		// widgetId flips to '' — the adjust-during-render guard fires but the `if (widgetId)` reload is
+		// skipped (comment: "an empty id keeps whatever is shown").
+		rerender(<StickyNote widgetId="" />);
+		expect(ta().value).toBe('kept note');
+	});
+
+	it('reloads text from storage when the widget id changes on a live instance', () => {
+		localStorage.setItem('scratch:w10a', 'first note');
+		localStorage.setItem('scratch:w10b', 'second note');
+		const { container, rerender } = render(<StickyNote widgetId="w10a" />);
+		const ta = () => container.querySelector('textarea') as HTMLTextAreaElement;
+		expect(ta().value).toBe('first note');
+		rerender(<StickyNote widgetId="w10b" />);
+		expect(ta().value).toBe('second note');
+	});
+
 	it('passes a per-instance color as the --note-accent CSS variable', () => {
 		const { container } = render(<StickyNote widgetId="w9" color="rgb(4, 5, 6)" />);
 		const root = container.querySelector('.np-stickynote') as HTMLElement;

--- a/client/src/lib/widgets/meters/SunMoon.test.tsx
+++ b/client/src/lib/widgets/meters/SunMoon.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
-import { render, cleanup } from '@testing-library/react';
+import { render, cleanup, act } from '@testing-library/react';
 import SunMoon from './SunMoon';
 import type { SensorState } from '../../core/telemetry';
 
@@ -32,5 +32,30 @@ describe('SunMoon meter', () => {
 		const { container } = render(<SunMoon sensors={{}} />);
 		const times = [...container.querySelectorAll('.sm-time')].map((e) => e.textContent);
 		expect(times).toEqual(['—', '—']);
+	});
+
+	it('applies the accent color as a CSS variable when set', () => {
+		const { container } = render(<SunMoon sensors={{}} color="#abc123" />);
+		const root = container.querySelector('.np-sunmoon') as HTMLElement;
+		expect(root.style.getPropertyValue('--sm-accent')).toBe('#abc123');
+	});
+
+	it('omits the sun and moon sections when disabled', () => {
+		const { container } = render(<SunMoon sensors={{}} showSun={false} showMoon={false} />);
+		expect(container.querySelector('[data-part="sun"]')).toBeNull();
+		expect(container.querySelector('[data-part="moon"]')).toBeNull();
+	});
+
+	it('re-renders the moon phase on the slow minute tick', () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date(Date.UTC(2000, 0, 6, 18, 14)));
+		const { container } = render(<SunMoon sensors={{}} />);
+		const before = container.querySelector('.sm-moon-illum')?.textContent;
+		vi.setSystemTime(new Date(Date.UTC(2000, 0, 6, 18, 14) + 14.77 * 86_400_000));
+		act(() => {
+			vi.advanceTimersByTime(60_000);
+		});
+		const after = container.querySelector('.sm-moon-illum')?.textContent;
+		expect(after).not.toBe(before);
 	});
 });

--- a/client/src/lib/widgets/meters/TopProcess.test.tsx
+++ b/client/src/lib/widgets/meters/TopProcess.test.tsx
@@ -36,4 +36,10 @@ describe('TopProcess meter', () => {
 		expect(container.querySelector('.tp-name')?.textContent).toBe('—');
 		expect(container.querySelector('.tp-value')?.textContent).toBe('—');
 	});
+
+	it('applies a per-instance color as the --tp-accent CSS variable', () => {
+		const { container } = render(<TopProcess sensors={{}} color="rgb(3,3,3)" />);
+		const root = container.querySelector('.np-topproc') as HTMLElement;
+		expect(root.style.getPropertyValue('--tp-accent')).toBe('rgb(3,3,3)');
+	});
 });

--- a/client/src/lib/widgets/meters/Volume.test.tsx
+++ b/client/src/lib/widgets/meters/Volume.test.tsx
@@ -38,4 +38,10 @@ describe('Volume meter', () => {
 		const { container } = render(<Volume level={null} />);
 		expect(container.querySelector('.vol-pct')?.textContent).toBe('—');
 	});
+
+	it('applies a per-instance color as the --vol-accent CSS variable', () => {
+		const { container } = render(<Volume level={0.5} color="rgb(2,9,1)" />);
+		const root = container.querySelector('.np-volume') as HTMLElement;
+		expect(root.style.getPropertyValue('--vol-accent')).toBe('rgb(2,9,1)');
+	});
 });

--- a/client/src/lib/widgets/meters/Weather.test.tsx
+++ b/client/src/lib/widgets/meters/Weather.test.tsx
@@ -86,4 +86,63 @@ describe('Weather meter', () => {
 		const { container } = render(<Weather sensors={{ temp: scalar(12), code: scalar(3) }} />);
 		expect(container.querySelector('.wx-forecast')).toBeNull();
 	});
+
+	it('dashes a missing high or low while still showing the other', () => {
+		const { container } = render(
+			<Weather sensors={{ temp: scalar(12), code: scalar(3), high: scalar(15) }} />
+		);
+		expect(container.querySelector('.wx-hi')?.textContent).toBe('↑ 15°');
+		expect(container.querySelector('.wx-lo')?.textContent).toBe('↓ —');
+	});
+
+	it('defaults to daytime icons when is_day is not reported', () => {
+		const { container } = render(<Weather sensors={{ temp: scalar(12), code: scalar(0) }} />);
+		expect(container.querySelector('.wx-icon')?.textContent).toBe('☀️');
+	});
+
+	it('applies a per-instance color as the --wx-accent CSS variable', () => {
+		const { container } = render(<Weather sensors={{}} color="rgb(2,4,6)" />);
+		const root = container.querySelector('.np-weather') as HTMLElement;
+		expect(root.style.getPropertyValue('--wx-accent')).toBe('rgb(2,4,6)');
+	});
+
+	it('clamps forecastDays outside 0..7 (negative and > 7)', () => {
+		const negative = render(
+			<Weather
+				forecastDays={-2}
+				sensors={{ temp: scalar(12), code: scalar(3), d0high: scalar(5) }}
+			/>
+		);
+		expect(negative.container.querySelector('.wx-forecast')).toBeNull();
+		negative.unmount();
+
+		const clamped = render(
+			<Weather
+				forecastDays={10}
+				sensors={{
+					temp: scalar(12),
+					code: scalar(3),
+					d0high: scalar(5),
+					d1high: scalar(6),
+					d2high: scalar(7),
+					d3high: scalar(8),
+					d4high: scalar(9),
+					d5high: scalar(10),
+					d6high: scalar(11)
+				}}
+			/>
+		);
+		expect(clamped.container.querySelectorAll('.wx-day')).toHaveLength(7); // clamped to 7, not 10
+	});
+
+	it('drops forecast days with no data at all, keeping only days that have some', () => {
+		const { container } = render(
+			<Weather
+				forecastDays={3}
+				sensors={{ temp: scalar(12), code: scalar(3), d0high: scalar(5) }}
+				// d1* / d2* deliberately absent → those cells are all-null and filtered out
+			/>
+		);
+		expect(container.querySelectorAll('.wx-day')).toHaveLength(1);
+	});
 });

--- a/client/src/lib/widgets/meters/Wifi.test.tsx
+++ b/client/src/lib/widgets/meters/Wifi.test.tsx
@@ -45,4 +45,10 @@ describe('Wifi meter', () => {
 		expect(container.querySelector('.wifi')?.getAttribute('data-level')).toBe('weak');
 		expect(container.querySelectorAll('.wf-bar[data-on]')).toHaveLength(1);
 	});
+
+	it('applies a per-instance color as the --wf-accent CSS variable', () => {
+		const { container } = render(<Wifi sensors={{}} color="rgb(5,5,5)" />);
+		const root = container.querySelector('.np-wifi') as HTMLElement;
+		expect(root.style.getPropertyValue('--wf-accent')).toBe('rgb(5,5,5)');
+	});
 });

--- a/client/src/lib/widgets/meters/gaugeMath.test.ts
+++ b/client/src/lib/widgets/meters/gaugeMath.test.ts
@@ -150,4 +150,13 @@ describe('dialTicks', () => {
 		expect(ticks[0].x2).toBeCloseTo(outer.x);
 		expect(ticks[0].y2).toBeCloseTo(outer.y);
 	});
+	it('a single tick sits mid-arc (avoids a divide-by-zero at count - 1)', () => {
+		const [tick] = dialTicks(270, 1, 50, 50, R - 7, R);
+		const inner = polar(50, 50, R - 7, 270);
+		const outer = polar(50, 50, R, 270);
+		expect(tick.x1).toBeCloseTo(inner.x);
+		expect(tick.y1).toBeCloseTo(inner.y);
+		expect(tick.x2).toBeCloseTo(outer.x);
+		expect(tick.y2).toBeCloseTo(outer.y);
+	});
 });

--- a/client/src/lib/widgets/meters/sparklineMath.test.ts
+++ b/client/src/lib/widgets/meters/sparklineMath.test.ts
@@ -38,6 +38,17 @@ describe('sparklinePoints', () => {
 			[87.5, 0] // slot 3 centre, 20/20 → top
 		]);
 	});
+
+	it('centres a flat series within a fixed window (pinned min === max → span 0)', () => {
+		expect(sparklinePoints([5, 5], 100, 10, 5, 5, 4)).toEqual([
+			[62.5, 5],
+			[87.5, 5]
+		]);
+	});
+
+	it('places a single point at x=0 with no window (stepX 0, one sample)', () => {
+		expect(sparklinePoints([5], 100, 10, 0, 10)).toEqual([[0, 5]]);
+	});
 });
 
 describe('sparklineBars', () => {
@@ -67,5 +78,18 @@ describe('sparklineBars', () => {
 		expect(bars).toHaveLength(1);
 		expect(bars[0].x).toBeCloseTo(77.5); // slot 3 of 4: 3*25 + (25-20)/2
 		expect(bars[0].h).toBe(10);
+	});
+
+	it('floors a zero span (pinned min === max) to a divide-by-zero-safe 1', () => {
+		const bars = sparklineBars([5, 5], 100, 10, 5, 5);
+		expect(bars[0].h).toBe(0);
+		expect(bars[1].h).toBe(0);
+	});
+
+	it('defaults an unpinned min to 0 (baseline) with no min/max args at all', () => {
+		// min/max both default to null → lo falls back to 0, hi falls back to the data max.
+		const bars = sparklineBars([5, 10], 100, 20);
+		expect(bars[0].h).toBe(10); // 5 / (data max 10) of 20
+		expect(bars[1].h).toBe(20);
 	});
 });

--- a/client/src/lib/widgets/meters/tickerFormat.test.ts
+++ b/client/src/lib/widgets/meters/tickerFormat.test.ts
@@ -52,6 +52,7 @@ describe('formatChangePct / formatChangeAbs', () => {
 	it('signs the absolute change', () => {
 		expect(formatChangeAbs(1.2, 2)).toBe('+1.20');
 		expect(formatChangeAbs(-1234.5, 2)).toBe('-1,234.50');
+		expect(formatChangeAbs(0)).toBe('0.00'); // neither gain nor loss → no sign
 		expect(formatChangeAbs(null)).toBe('');
 	});
 });
@@ -70,8 +71,14 @@ describe('marketLabel', () => {
 		expect(marketLabel('REGULAR')).toBe('');
 		expect(marketLabel('')).toBe('');
 		expect(marketLabel('PRE')).toBe('pre-market');
+		expect(marketLabel('PREPRE')).toBe('pre-market');
+		expect(marketLabel('POST')).toBe('after hours');
 		expect(marketLabel('POSTPOST')).toBe('after hours');
 		expect(marketLabel('CLOSED')).toBe('closed');
 		expect(marketLabel('weird')).toBe('weird');
+	});
+	it('blanks a missing state (null/undefined) same as an open session', () => {
+		expect(marketLabel(null)).toBe('');
+		expect(marketLabel(undefined)).toBe('');
 	});
 });

--- a/client/src/lib/widgets/plugin.test.tsx
+++ b/client/src/lib/widgets/plugin.test.tsx
@@ -166,6 +166,14 @@ describe('pluginSensorNamesFrom', () => {
 		expect(names.has('mem.used')).toBe(false);
 	});
 
+	it('keeps the FIRST plugin’s name when two plugins claim the same sensor id', () => {
+		const names = pluginSensorNamesFrom([
+			{ id: 'one', name: 'First', sources: [src('one', ['dup.sensor'])] },
+			{ id: 'two', name: 'Second', sources: [src('two', ['dup.sensor'])] }
+		]);
+		expect(names.get('dup.sensor')).toBe('First');
+	});
+
 	it('tolerates a source with no catalog() (no ids contributed)', () => {
 		const names = pluginSensorNamesFrom([
 			{

--- a/client/src/lib/widgets/plugins/AgendaSettings.test.tsx
+++ b/client/src/lib/widgets/plugins/AgendaSettings.test.tsx
@@ -144,6 +144,70 @@ describe('AgendaSettings', () => {
 		expect(await findByText('Saved ✓')).toBeTruthy();
 	});
 
+	it('auto-dismisses the "Saved ✓" tick after 2.5s', async () => {
+		vi.useFakeTimers();
+		try {
+			const { getByRole, getByText, queryByText } = renderPanel();
+			await act(async () => {}); // flush the prefill promises
+			fireEvent.click(getByRole('button', { name: /Save & fetch/ }));
+			await act(async () => {}); // flush the save → disconnect → connect chain
+			expect(getByText('Saved ✓')).toBeTruthy();
+			act(() => {
+				vi.advanceTimersByTime(2500);
+			});
+			expect(queryByText('Saved ✓')).toBeNull();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it('renders with defaults when the connect kick and the status fetch both reject', async () => {
+		vi.mocked(agendaConnect).mockRejectedValue(new Error('no backend'));
+		vi.mocked(agendaConfigStatus).mockRejectedValue(new Error('no backend'));
+		const { container, findByText } = renderPanel();
+		// Both rejections are swallowed; the panel stays usable with its default (empty) form.
+		expect(await findByText('not configured')).toBeTruthy();
+		const url = container.querySelector('input[inputmode="url"]') as HTMLInputElement;
+		expect(url.value).toBe('');
+	});
+
+	it('ignores a status result that resolves after unmount (no setState on a dead panel)', async () => {
+		let resolveStatus: (s: {
+			configured: boolean;
+			url: string;
+			title: string;
+			pollSeconds: number;
+		}) => void = () => undefined;
+		vi.mocked(agendaConfigStatus).mockImplementation(
+			() => new Promise((res) => (resolveStatus = res))
+		);
+		const { container, unmount } = renderPanel();
+		const url = container.querySelector('input[inputmode="url"]') as HTMLInputElement;
+		expect(url.value).toBe('');
+		unmount();
+		// Resolving late must hit the `alive` guard, not a state setter on the unmounted panel.
+		await act(async () => {
+			resolveStatus({
+				configured: true,
+				url: 'https://x.example/a.ics',
+				title: 't',
+				pollSeconds: 60
+			});
+		});
+	});
+
+	it('falls back to a 30-minute poll when the saved status has no pollSeconds', async () => {
+		vi.mocked(agendaConfigStatus).mockResolvedValue({
+			configured: true,
+			url: 'https://calendar.example.com/basic.ics',
+			title: '',
+			pollSeconds: 0 // unset/zero → the || 1800 fallback → 30 minutes
+		});
+		const { container } = renderPanel();
+		const poll = container.querySelector('input[type="number"]') as HTMLInputElement;
+		await waitFor(() => expect(poll.value).toBe('30'));
+	});
+
 	it('reflects the live agenda.status sample in the badge', async () => {
 		const { getByText } = renderPanel();
 		await waitFor(() => expect(agendaConfigStatus).toHaveBeenCalled());

--- a/client/src/lib/widgets/plugins/HaSettings.test.tsx
+++ b/client/src/lib/widgets/plugins/HaSettings.test.tsx
@@ -368,4 +368,73 @@ describe('HaSettings', () => {
 		const url = container.querySelector('input[type="text"]') as HTMLInputElement;
 		expect(url.value).toBe('');
 	});
+
+	it('auto-dismisses the "Saved ✓" tick after 2.5s', async () => {
+		vi.useFakeTimers();
+		try {
+			const { container, getByText, queryByText } = renderPanel();
+			await act(async () => {}); // flush the prefill promises (url must be set for canSubmit)
+			const url = container.querySelector('input[type="text"]') as HTMLInputElement;
+			expect(url.value).toBe('http://ha:8123');
+			fireEvent.click(getByText('Save & connect'));
+			await act(async () => {}); // flush the save → disconnect → connect chain
+			expect(getByText('Saved ✓')).toBeTruthy();
+			act(() => {
+				vi.advanceTimersByTime(2500);
+			});
+			expect(queryByText('Saved ✓')).toBeNull();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it('renders with defaults when the connect kick and the status fetch both reject', async () => {
+		vi.mocked(haConnect).mockRejectedValue(new Error('no backend'));
+		vi.mocked(haConfigStatus).mockRejectedValue(new Error('no backend'));
+		const { container, findByText } = renderPanel();
+		// Both rejections are swallowed; the panel stays usable with its default (empty) form.
+		expect(await findByText('not configured')).toBeTruthy();
+		const url = container.querySelector('input[type="text"]') as HTMLInputElement;
+		expect(url.value).toBe('');
+	});
+
+	it('ignores a status result that resolves after unmount (no setState on a dead panel)', async () => {
+		type Status = Awaited<ReturnType<typeof haConfigStatus>>;
+		let resolveStatus: (s: Status) => void = () => undefined;
+		vi.mocked(haConfigStatus).mockImplementation(() => new Promise((res) => (resolveStatus = res)));
+		const { container, unmount } = renderPanel();
+		const url = container.querySelector('input[type="text"]') as HTMLInputElement;
+		expect(url.value).toBe('');
+		unmount();
+		// Resolving late must hit the `alive` guard, not a state setter on the unmounted panel.
+		await act(async () => {
+			resolveStatus({ configured: true, url: 'http://late:8123', insecure: false, base_path: '' });
+		});
+	});
+
+	it('stays on the flat list when the registry snapshot fetch rejects', async () => {
+		vi.mocked(haRegistrySnapshot).mockRejectedValueOnce(new Error('ws down'));
+		const { findByText, getByLabelText, queryByText } = renderPanel();
+		await findByText('Kitchen Light');
+		fireEvent.click(getByLabelText('Group by area'));
+		// The rejection is swallowed: no grouped headers appear, and the panel doesn't crash.
+		await waitFor(() => expect(haRegistrySnapshot).toHaveBeenCalled());
+		expect(queryByText('Living Room')).toBeNull();
+	});
+
+	it('ignores a registry snapshot that resolves after unmount', async () => {
+		type Registry = Awaited<ReturnType<typeof haRegistrySnapshot>>;
+		let resolveRegistry: (r: Registry) => void = () => undefined;
+		vi.mocked(haRegistrySnapshot).mockImplementation(
+			() => new Promise((res) => (resolveRegistry = res))
+		);
+		const { findByText, getByLabelText, unmount } = renderPanel();
+		await findByText('Kitchen Light');
+		fireEvent.click(getByLabelText('Group by area')); // kicks the (deferred) registry fetch
+		unmount();
+		// Resolving late must hit the `alive` guard, not a state setter on the unmounted panel.
+		await act(async () => {
+			resolveRegistry({ areas: [], devices: [], entities: [] });
+		});
+	});
 });

--- a/client/src/lib/widgets/plugins/LlmSettings.test.tsx
+++ b/client/src/lib/widgets/plugins/LlmSettings.test.tsx
@@ -655,4 +655,107 @@ describe('LlmSettings', () => {
 		act(() => handleDelta({ requestId, token: '', done: true, error: 'rate limited' }));
 		expect(await findByText(/⚠ rate limited/)).toBeTruthy();
 	});
+
+	it('renders a finished assistant turn with no content as an empty line (no ellipsis, no 🔊)', async () => {
+		const { container, findByPlaceholderText, queryByText } = renderPanel();
+		const input = (await findByPlaceholderText('Ask anything…')) as HTMLInputElement;
+		fireEvent.change(input, { target: { value: 'hi' } });
+		fireEvent.keyDown(input, { key: 'Enter' });
+		await waitFor(() => expect(llmStream).toHaveBeenCalled());
+		const requestId = vi.mocked(llmStream).mock.calls[0][0] as string;
+		// The stream finishes without ever producing a token (e.g. an immediately-cancelled request).
+		act(() => handleDelta({ requestId, token: '', done: true }));
+		const rows = container.querySelectorAll('.has-entity');
+		expect(rows.length).toBe(2); // the user turn + the (empty) assistant turn
+		const ai = rows[1] as HTMLElement;
+		expect(ai.textContent).toContain('ai');
+		expect(ai.textContent).not.toContain('…'); // finished — not the streaming ellipsis
+		expect(queryByText('🔊')).toBeNull(); // no content → no read-aloud button
+	});
+
+	it('does not generate on a plain keypress in the assistant prompt (Ctrl/⌘+Enter only)', async () => {
+		setLlmStudioApi({
+			monitor: () => emptyMonitorLayout(),
+			apply: () => ({ applied: 0, addedIds: [], errors: [] })
+		});
+		const { container } = renderPanel();
+		await waitFor(() => expect(baseUrlInput(container).value).toBe('https://my-proxy.test/v1'));
+		const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+		fireEvent.change(textarea, { target: { value: 'add a clock' } });
+		fireEvent.keyDown(textarea, { key: 'Enter' }); // no modifier → newline, not generate
+		fireEvent.keyDown(textarea, { key: 'a', ctrlKey: true }); // modifier without Enter
+		expect(llmComplete).not.toHaveBeenCalled();
+	});
+
+	it('does not send the chat on a non-Enter key', async () => {
+		const { findByPlaceholderText } = renderPanel();
+		const input = (await findByPlaceholderText('Ask anything…')) as HTMLInputElement;
+		fireEvent.change(input, { target: { value: 'hi' } });
+		fireEvent.keyDown(input, { key: 'a' });
+		expect(llmStream).not.toHaveBeenCalled();
+	});
+
+	// --- init edge cases ---------------------------------------------------------------------
+
+	it('auto-dismisses the "Saved ✓" tick after 2.5s', async () => {
+		vi.useFakeTimers();
+		try {
+			const { container, getByText, queryByText } = renderPanel();
+			await act(async () => {}); // flush the status prefill (saved key → canSubmit)
+			expect(baseUrlInput(container).value).toBe('https://my-proxy.test/v1');
+			fireEvent.click(button(container, 'Save'));
+			await act(async () => {}); // flush the save → status-refresh chain
+			expect(getByText('Saved ✓')).toBeTruthy();
+			act(() => {
+				vi.advanceTimersByTime(2500);
+			});
+			expect(queryByText('Saved ✓')).toBeNull();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it('renders with catalog defaults when the status fetch rejects', async () => {
+		vi.mocked(llmConfigStatus).mockRejectedValue(new Error('no backend'));
+		const { container, findByText } = renderPanel();
+		// The rejection is swallowed; the panel stays on the openai defaults, unconfigured.
+		expect(await findByText(/not configured/)).toBeTruthy();
+		expect(providerSelect(container).value).toBe('openai');
+		expect(baseUrlInput(container).value).toBe('');
+	});
+
+	it('ignores a status result that resolves after unmount (no setState on a dead panel)', async () => {
+		let resolveStatus: (s: LlmStatus) => void = () => undefined;
+		vi.mocked(llmConfigStatus).mockImplementation(
+			() => new Promise((res) => (resolveStatus = res))
+		);
+		const { container, unmount } = renderPanel();
+		expect(baseUrlInput(container).value).toBe('');
+		unmount();
+		// Resolving late must hit the `alive` guard, not a state setter on the unmounted panel.
+		await act(async () => {
+			resolveStatus(configuredStatus());
+		});
+	});
+
+	it('ignores a second mic click while getUserMedia is still pending (no double recorder)', async () => {
+		// Defer startRecording so the second click lands while the first is still starting.
+		let resolveRec: (r: Recorder) => void = () => undefined;
+		vi.mocked(startRecording).mockImplementation(
+			() => new Promise<Recorder>((res) => (resolveRec = res))
+		);
+		const { container, getByText, findByText } = renderPanel();
+		await waitFor(() => expect(baseUrlInput(container).value).toBe('https://my-proxy.test/v1'));
+		const mic = getByText('🎤 Speak');
+		fireEvent.click(mic); // starts (pending) — startingRef guards…
+		fireEvent.click(mic); // …this rapid second click from starting another recorder
+		expect(startRecording).toHaveBeenCalledTimes(1);
+		await act(async () => {
+			resolveRec({
+				stop: () => Promise.resolve({ bytes: new Uint8Array([1]), mime: 'audio/webm' }),
+				cancel: vi.fn()
+			});
+		});
+		expect(await findByText(/Listening/)).toBeTruthy();
+	});
 });

--- a/client/src/lib/widgets/plugins/MqttSettings.test.tsx
+++ b/client/src/lib/widgets/plugins/MqttSettings.test.tsx
@@ -27,7 +27,13 @@ vi.mock('./mqtt-commands', () => ({
 vi.mock('../../overlay', () => ({ copyToClipboard: vi.fn(() => Promise.resolve(true)) }));
 
 import MqttSettings from './MqttSettings';
-import { mqttCatalog, mqttConfigStatus, mqttDisconnect, saveMqttConfig } from './mqtt-commands';
+import {
+	mqttCatalog,
+	mqttConfigStatus,
+	mqttConnect,
+	mqttDisconnect,
+	saveMqttConfig
+} from './mqtt-commands';
 import { copyToClipboard } from '../../overlay';
 import { createTelemetryHub, type TelemetryHub } from '../../core/telemetry';
 import { TelemetryHubContext } from '../telemetryContext';
@@ -180,5 +186,59 @@ describe('MqttSettings', () => {
 		// The label-less entry renders its topic as the name (e.label ?? e.topic).
 		const name = await findByText('tasmota/x', { selector: '.has-entity-name' });
 		expect(name).toBeTruthy();
+	});
+
+	it('auto-dismisses the "Saved ✓" tick after 2.5s', async () => {
+		vi.useFakeTimers();
+		try {
+			const { container, getByText, queryByText } = renderPanel();
+			await act(async () => {}); // flush the prefill promises (host must be set for canSubmit)
+			const host = container.querySelector('input[type="text"]') as HTMLInputElement;
+			expect(host.value).toBe('broker.local');
+			fireEvent.click(getByText('Save & connect'));
+			await act(async () => {}); // flush the save → disconnect → connect → catalog chain
+			expect(getByText('Saved ✓')).toBeTruthy();
+			act(() => {
+				vi.advanceTimersByTime(2500);
+			});
+			expect(queryByText('Saved ✓')).toBeNull();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it('renders with defaults when the connect kick and the status fetch both reject', async () => {
+		vi.mocked(mqttConnect).mockRejectedValue(new Error('no backend'));
+		vi.mocked(mqttConfigStatus).mockRejectedValue(new Error('no backend'));
+		const { container, findByText } = renderPanel();
+		// Both rejections are swallowed; the panel stays usable with its default (empty) form.
+		expect(await findByText('not configured')).toBeTruthy();
+		const host = container.querySelector('input[type="text"]') as HTMLInputElement;
+		expect(host.value).toBe('');
+	});
+
+	it('ignores a status result that resolves after unmount (no setState on a dead panel)', async () => {
+		type Status = Awaited<ReturnType<typeof mqttConfigStatus>>;
+		let resolveStatus: (s: Status) => void = () => undefined;
+		vi.mocked(mqttConfigStatus).mockImplementation(
+			() => new Promise((res) => (resolveStatus = res))
+		);
+		const { container, unmount } = renderPanel();
+		const host = container.querySelector('input[type="text"]') as HTMLInputElement;
+		expect(host.value).toBe('');
+		unmount();
+		// Resolving late must hit the `alive` guard, not a state setter on the unmounted panel.
+		await act(async () => {
+			resolveStatus({
+				configured: true,
+				host: 'late.local',
+				port: 1883,
+				username: '',
+				topics: [],
+				tls: false,
+				insecure: false,
+				discovery: false
+			});
+		});
 	});
 });

--- a/client/src/lib/widgets/plugins/NowPlayingSettings.test.tsx
+++ b/client/src/lib/widgets/plugins/NowPlayingSettings.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { fireEvent, render } from '@testing-library/react';
+import { act, fireEvent, render } from '@testing-library/react';
 
 // Stub the Tauri-backed media source; resolve a known MediaCaps for an active source so the
 // capabilities grid renders, and null for no source (mirrors the off-Windows / no-session case).
@@ -228,5 +228,41 @@ describe('NowPlayingSettings', () => {
 		const { getByText } = render(<NowPlayingSettings />);
 		// No session → getMediaCapabilities is still pending/empty in the no-session branch.
 		expect(getByText('No active session.')).toBeTruthy();
+	});
+
+	it('auto-disarms the two-step reset after 3s (an abandoned first click does not linger)', () => {
+		vi.useFakeTimers();
+		try {
+			mediaStore.set({ ...mediaStore.getSnapshot(), sourcePriority: 'zzz' });
+			const { container } = render(<NowPlayingSettings />);
+			const reset = container.querySelector('.rp-danger') as HTMLButtonElement;
+			fireEvent.click(reset);
+			expect(reset.textContent).toContain('Click again to confirm');
+			act(() => {
+				vi.advanceTimersByTime(3000); // the arm window lapses
+			});
+			expect(reset.textContent).toContain('Reset settings');
+			// A click after the lapse only re-arms — it must NOT reset.
+			fireEvent.click(reset);
+			expect(mediaStore.getSnapshot().sourcePriority).toBe('zzz');
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it('tolerates a session record with no source field (treated as sourceless)', () => {
+		// A malformed/legacy record whose `source` is missing entirely — the detected-source
+		// derivations must fall back to '' and skip it rather than crash.
+		const { source: _drop, ...noSource } = session('x.exe', 'T');
+		void _drop;
+		mediaStore.set({
+			...defaultState,
+			sourcePriority: 'x',
+			ignoreList: '',
+			sessions: { 1: noSource as SessionRecord }
+		});
+		const { getByText } = render(<NowPlayingSettings />);
+		// Nothing detected (the record has no source) → the empty-state hint renders.
+		expect(getByText(/No media sources detected yet/)).toBeTruthy();
 	});
 });

--- a/client/src/lib/widgets/plugins/RssSettings.test.tsx
+++ b/client/src/lib/widgets/plugins/RssSettings.test.tsx
@@ -175,4 +175,31 @@ describe('RssSettings', () => {
 		});
 		expect(getByText(/Connected/)).toBeTruthy();
 	});
+
+	it('auto-dismisses the "Saved ✓" tick after 2.5s', async () => {
+		vi.useFakeTimers();
+		try {
+			const { getByRole, getByText, queryByText } = renderPanel();
+			await act(async () => {}); // flush the prefill promises
+			fireEvent.click(getByRole('button', { name: /Save & fetch/ }));
+			await act(async () => {}); // flush the save → disconnect → connect chain
+			expect(getByText('Saved ✓')).toBeTruthy();
+			act(() => {
+				vi.advanceTimersByTime(2500);
+			});
+			expect(queryByText('Saved ✓')).toBeNull();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it('renders with defaults when the connect kick and the status fetch both reject', async () => {
+		vi.mocked(rssConnect).mockRejectedValue(new Error('no backend'));
+		vi.mocked(rssConfigStatus).mockRejectedValue(new Error('no backend'));
+		const { container, findByText } = renderPanel();
+		// Both rejections are swallowed; the panel stays usable with its default (empty) form.
+		expect(await findByText('not configured')).toBeTruthy();
+		const url = container.querySelector('input[type="text"]') as HTMLInputElement;
+		expect(url.value).toBe('');
+	});
 });

--- a/client/src/lib/widgets/plugins/StocksSettings.test.tsx
+++ b/client/src/lib/widgets/plugins/StocksSettings.test.tsx
@@ -35,7 +35,7 @@ import {
 	stocksConnect,
 	stocksDisconnect
 } from './stocks-commands';
-import { refreshStocksCatalog } from './stocks-source';
+import { refreshStocksCatalog, stocksSource } from './stocks-source';
 import { copyToClipboard } from '../../overlay';
 import { createTelemetryHub, type TelemetryHub } from '../../core/telemetry';
 import { TelemetryHubContext } from '../telemetryContext';
@@ -166,5 +166,89 @@ describe('StocksSettings', () => {
 			});
 		});
 		expect(getByText(/Connected/)).toBeTruthy();
+	});
+
+	it('auto-dismisses the "Saved ✓" tick after 2.5s', async () => {
+		vi.useFakeTimers();
+		try {
+			const { getByText, queryByText } = renderPanel();
+			await act(async () => {}); // flush the prefill promises
+			fireEvent.click(getByText('Save & refresh'));
+			await act(async () => {}); // flush the save → disconnect → connect → refresh chain
+			expect(getByText('Saved ✓')).toBeTruthy();
+			act(() => {
+				vi.advanceTimersByTime(2500);
+			});
+			expect(queryByText('Saved ✓')).toBeNull();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it('stringifies a non-Error save failure', async () => {
+		vi.mocked(saveStocksConfig).mockRejectedValueOnce('quota exceeded');
+		const { getByText, findByText } = renderPanel();
+		await findByText('AAPL price'); // wait for prefill (sensor list is unambiguous)
+		fireEvent.click(getByText('Save & refresh'));
+		expect(await findByText(/Couldn.t save: quota exceeded/)).toBeTruthy();
+	});
+
+	it('renders with defaults when the connect kick and the status fetch both reject', async () => {
+		vi.mocked(stocksConnect).mockRejectedValue(new Error('no backend'));
+		vi.mocked(stocksConfigStatus).mockRejectedValue(new Error('no backend'));
+		const { findByText, container } = renderPanel();
+		// Both rejections are swallowed; the panel stays usable with its defaults.
+		expect(await findByText('not configured')).toBeTruthy();
+		const poll = container.querySelector('input[type="number"]') as HTMLInputElement;
+		expect(poll.value).toBe('60');
+	});
+
+	it('ignores a status result that resolves after unmount (no setState on a dead panel)', async () => {
+		type Status = Awaited<ReturnType<typeof stocksConfigStatus>>;
+		let resolveStatus: (s: Status) => void = () => undefined;
+		vi.mocked(stocksConfigStatus).mockImplementation(
+			() => new Promise((res) => (resolveStatus = res))
+		);
+		const { unmount, queryByLabelText } = renderPanel();
+		expect(queryByLabelText('Remove AAPL')).toBeNull();
+		unmount();
+		// Resolving late must hit the `alive` guard, not a state setter on the unmounted panel.
+		await act(async () => {
+			resolveStatus({ configured: true, provider: 'yahoo', symbols: ['AAPL'], pollSeconds: 60 });
+		});
+	});
+
+	it('falls back to a 60s poll when the interval field is cleared', async () => {
+		const { container, getByText, findByText } = renderPanel();
+		await findByText('AAPL price'); // wait for prefill
+		const poll = container.querySelector('input[type="number"]') as HTMLInputElement;
+		fireEvent.change(poll, { target: { value: '' } }); // Number('') → 0 → the || 60 fallback
+		fireEvent.click(getByText('Save & refresh'));
+		await waitFor(() =>
+			expect(saveStocksConfig).toHaveBeenCalledWith(expect.objectContaining({ pollSeconds: 60 }))
+		);
+	});
+
+	it('falls back to the id when a catalog entry has no label', async () => {
+		vi.mocked(stocksSource.catalogEntries!).mockReturnValue([{ id: 'stocks.MSFT.price' }]);
+		const { findByText } = renderPanel();
+		// The label-less entry renders its id as the name (e.label ?? e.id).
+		const name = await findByText('stocks.MSFT.price', { selector: '.has-entity-name' });
+		expect(name).toBeTruthy();
+	});
+
+	it('renders an empty sensor list when the source exposes no catalog', async () => {
+		// A source without catalogEntries is legal (the field is optional) — the panel's `?? []`
+		// degrades to an empty id list rather than crashing.
+		const src = stocksSource as { catalogEntries?: () => { id: string; label?: string }[] };
+		const orig = src.catalogEntries;
+		src.catalogEntries = undefined;
+		try {
+			const { findByLabelText, container } = renderPanel();
+			await findByLabelText('Remove AAPL'); // prefill: symbols present but no catalog ids
+			expect(container.querySelectorAll('.has-entity').length).toBe(0);
+		} finally {
+			src.catalogEntries = orig;
+		}
 	});
 });

--- a/client/src/lib/widgets/plugins/TokenListField.test.tsx
+++ b/client/src/lib/widgets/plugins/TokenListField.test.tsx
@@ -84,4 +84,52 @@ describe('TokenListField', () => {
 		);
 		expect(screen.getByText('No tickers yet.')).toBeTruthy();
 	});
+
+	it('ignores Enter on an empty/blank input (nothing to commit)', () => {
+		const { onChange, input } = setup(['AAPL']);
+		fireEvent.keyDown(input, { key: 'Enter' }); // empty pending → parse → [] → early return
+		fireEvent.change(input, { target: { value: '  ,  ' } }); // parses to nothing either
+		fireEvent.keyDown(input, { key: 'Enter' });
+		expect(onChange).not.toHaveBeenCalled();
+		expect(input.value).toBe('  ,  '); // not cleared — nothing was committed
+	});
+
+	it('ignores non-Enter keys (no commit while typing)', () => {
+		const { onChange, input } = setup([]);
+		fireEvent.change(input, { target: { value: 'msft' } });
+		fireEvent.keyDown(input, { key: 'a' });
+		fireEvent.keyDown(input, { key: 'Escape' });
+		expect(onChange).not.toHaveBeenCalled();
+		expect(input.value).toBe('msft');
+	});
+
+	it('lets a single-token paste fall through to the input (no separator → user reviews + Adds)', () => {
+		const { onChange, input } = setup([]);
+		fireEvent.paste(input, { clipboardData: { getData: () => 'MSFT' } });
+		expect(onChange).not.toHaveBeenCalled(); // not intercepted — no chips yet
+	});
+
+	it('clears the input after a paste whose tokens are all duplicates (no onChange)', () => {
+		const { onChange, input } = setup(['AAPL', 'MSFT']);
+		fireEvent.change(input, { target: { value: 'pending' } });
+		fireEvent.paste(input, { clipboardData: { getData: () => 'AAPL, MSFT' } });
+		expect(onChange).not.toHaveBeenCalled(); // list unchanged
+		expect(input.value).toBe(''); // but the pending text is still cleared post-commit
+	});
+
+	it('renders the chip list without an aria-label for a non-string label and no listLabel', () => {
+		const onChange = vi.fn();
+		const { container } = render(
+			<TokenListField
+				label={<em>Topics</em>}
+				values={['a/b']}
+				onChange={onChange}
+				parse={(raw) => [raw]}
+			/>
+		);
+		const ul = container.querySelector('ul.has-tokens') as HTMLUListElement;
+		expect(ul.hasAttribute('aria-label')).toBe(false);
+		// The add input falls back to the generic label too.
+		expect(screen.getByLabelText('Add item')).toBeTruthy();
+	});
 });

--- a/client/src/lib/widgets/plugins/WeatherSettings.test.tsx
+++ b/client/src/lib/widgets/plugins/WeatherSettings.test.tsx
@@ -164,4 +164,74 @@ describe('WeatherSettings', () => {
 		});
 		expect(getByText(/Connected/)).toBeTruthy();
 	});
+
+	it('auto-dismisses the "Saved ✓" tick after 2.5s', async () => {
+		vi.useFakeTimers();
+		try {
+			const { getByRole, getByText, queryByText } = renderPanel();
+			await act(async () => {}); // flush the prefill promises
+			fireEvent.click(getByRole('button', { name: /Save & fetch/ }));
+			await act(async () => {}); // flush the save → disconnect → connect chain
+			expect(getByText('Saved ✓')).toBeTruthy();
+			act(() => {
+				vi.advanceTimersByTime(2500);
+			});
+			expect(queryByText('Saved ✓')).toBeNull();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it('renders with defaults when the connect kick and the status fetch both reject', async () => {
+		vi.mocked(weatherConnect).mockRejectedValue(new Error('no backend'));
+		vi.mocked(weatherConfigStatus).mockRejectedValue(new Error('no backend'));
+		const { container, findByText } = renderPanel();
+		// Both rejections are swallowed; the panel stays usable with its default (empty) form.
+		expect(await findByText('not configured')).toBeTruthy();
+		const lat = container.querySelector('input[placeholder="51.5072"]') as HTMLInputElement;
+		expect(lat.value).toBe('');
+	});
+
+	it('ignores a status result that resolves after unmount (no setState on a dead panel)', async () => {
+		let resolveStatus: (s: {
+			configured: boolean;
+			latitude: number;
+			longitude: number;
+			unit: string;
+			pollSeconds: number;
+		}) => void = () => undefined;
+		vi.mocked(weatherConfigStatus).mockImplementation(
+			() => new Promise((res) => (resolveStatus = res))
+		);
+		const { container, unmount } = renderPanel();
+		const lat = container.querySelector('input[placeholder="51.5072"]') as HTMLInputElement;
+		expect(lat.value).toBe('');
+		unmount();
+		// Resolving late must hit the `alive` guard, not a state setter on the unmounted panel.
+		await act(async () => {
+			resolveStatus({
+				configured: true,
+				latitude: 1,
+				longitude: 2,
+				unit: 'celsius',
+				pollSeconds: 900
+			});
+		});
+	});
+
+	it('falls back to celsius + a 15-minute poll when the saved status has neither', async () => {
+		vi.mocked(weatherConfigStatus).mockResolvedValue({
+			configured: false,
+			latitude: 0,
+			longitude: 0,
+			unit: '', // unset → the || 'celsius' fallback
+			pollSeconds: 0 // unset → the || 900 fallback → 15 minutes
+		});
+		const { container } = renderPanel();
+		await waitFor(() => expect(weatherConfigStatus).toHaveBeenCalled());
+		const poll = container.querySelector('input[type="number"]') as HTMLInputElement;
+		await waitFor(() => expect(poll.value).toBe('15'));
+		const unit = container.querySelector('select') as HTMLSelectElement;
+		expect(unit.value).toBe('celsius');
+	});
 });

--- a/client/src/lib/widgets/plugins/ha-backfill.test.ts
+++ b/client/src/lib/widgets/plugins/ha-backfill.test.ts
@@ -30,6 +30,11 @@ describe('haEntityForHistory', () => {
 		// 'ha.sensor.power_state' is a JSON id (no '.state' suffix) → ignored, not '.state' scalar
 		expect(haEntityForHistory('ha.sensor.power_state')).toBeNull();
 	});
+
+	it('ignores a .state id whose stripped entity has no domain dot', () => {
+		// Passes the ha./.state guard, but 'status' (between them) has no '<domain>.<object_id>' dot.
+		expect(haEntityForHistory('ha.status.state')).toBeNull();
+	});
 });
 
 describe('startHaBackfill', () => {

--- a/client/src/lib/widgets/plugins/llm-tts.test.ts
+++ b/client/src/lib/widgets/plugins/llm-tts.test.ts
@@ -118,6 +118,19 @@ describe('speakSmart', () => {
 		expect(a.paused).toBe(true);
 		expect(revoked).toContain('blob:url-1');
 	});
+
+	it('a stale onended for a superseded clip does not touch the newer clip', async () => {
+		llmSynthesize.mockResolvedValue({ audio: [1], mime: 'audio/mpeg' });
+		await speakSmart('first');
+		const stale = audios[0]!;
+		await speakSmart('second'); // starting the second clip already stopped + revoked the first
+		revoked.length = 0;
+		const current = audios[1]!;
+		current.paused = false;
+		stale.onended!(); // fires late, after `current` no longer points at this clip → no-op
+		expect(current.paused).toBe(false);
+		expect(revoked).toEqual([]);
+	});
 });
 
 describe('stopSpeaking', () => {

--- a/client/src/lib/widgets/plugins/packages.parse.test.ts
+++ b/client/src/lib/widgets/plugins/packages.parse.test.ts
@@ -1,0 +1,70 @@
+// The module-load parse of the three persisted package stores (enabled allowlist / CSS trust /
+// network consent). packages.test.ts covers a RE-imported module via vi.resetModules; this sibling
+// seeds localStorage BEFORE the module's first import so the initial createPersistedStore parse runs
+// against real stored values — including the non-string entries the parsers must drop.
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./packages-commands', () => ({
+	listPluginPackages: vi.fn(() => Promise.resolve([])),
+	readPluginPackageAsset: vi.fn(() => Promise.resolve(null)),
+	installPluginPackage: vi.fn(() => Promise.resolve({ id: 'x', version: '1' })),
+	checkPluginPackageUpdate: vi.fn(() =>
+		Promise.resolve({ current: '1', latest: '1', source: 'o/r' })
+	),
+	removePluginPackage: vi.fn(() => Promise.resolve())
+}));
+vi.mock('./packages-source', () => ({
+	startPackageSource: vi.fn(() => Promise.resolve(() => undefined))
+}));
+
+const KEYS = [
+	'widgetsack.packages.enabled',
+	'widgetsack.packages.cssTrusted',
+	'widgetsack.packages.netConsent'
+];
+
+afterEach(() => {
+	for (const k of KEYS) localStorage.removeItem(k);
+	vi.resetModules();
+});
+
+describe('persisted package stores — module-load parsing', () => {
+	it('keeps only string ids from the stored enabled list and string values from the consent map', async () => {
+		// Corrupt-ish storage: each list carries a non-string entry the parser must drop.
+		localStorage.setItem('widgetsack.packages.enabled', JSON.stringify(['pack-a', 42, 'pack-b']));
+		localStorage.setItem('widgetsack.packages.cssTrusted', JSON.stringify(['pack-a', false]));
+		localStorage.setItem(
+			'widgetsack.packages.netConsent',
+			JSON.stringify({ 'pack-a': 'api.example.com', dropped: 123 })
+		);
+
+		const m = await import('./packages');
+		expect(m.enabledPackages.getSnapshot()).toEqual(['pack-a', 'pack-b']);
+		// The consent map round-trips through the persist-at-creation write: string values only.
+		const consent = JSON.parse(localStorage.getItem('widgetsack.packages.netConsent')!);
+		expect(consent).toEqual({ 'pack-a': 'api.example.com' });
+		m.resetPackagesForTest();
+	});
+
+	it('falls back to empty stores when the stored shapes are wrong (array/object mismatch)', async () => {
+		localStorage.setItem('widgetsack.packages.enabled', JSON.stringify({ not: 'an array' }));
+		localStorage.setItem('widgetsack.packages.netConsent', JSON.stringify(['not', 'a', 'map']));
+
+		const m = await import('./packages');
+		expect(m.enabledPackages.getSnapshot()).toEqual([]);
+		expect(JSON.parse(localStorage.getItem('widgetsack.packages.netConsent')!)).toEqual({});
+		m.resetPackagesForTest();
+	});
+
+	it('drops a consent map whose values are all non-strings (empty map, no consent granted)', async () => {
+		localStorage.setItem(
+			'widgetsack.packages.netConsent',
+			JSON.stringify({ 'pack-a': 123, 'pack-b': { nested: true } })
+		);
+
+		const m = await import('./packages');
+		// Every entry was dropped → the persist-at-creation write stores a clean {}.
+		expect(JSON.parse(localStorage.getItem('widgetsack.packages.netConsent')!)).toEqual({});
+		m.resetPackagesForTest();
+	});
+});

--- a/client/src/lib/widgets/plugins/packages.test.ts
+++ b/client/src/lib/widgets/plugins/packages.test.ts
@@ -350,6 +350,56 @@ describe('togglePackage — theme CSS consent', () => {
 		await togglePackage('pack-a', false);
 		expect(styleTagFor('pack-a')).toBeNull();
 	});
+
+	it('enables without a prompt (and injects nothing) when the theme asset is missing on disk', async () => {
+		// The manifest declares theme.css but the file was deleted: the pre-enable scan reads null
+		// (→ no threats → no prompt) and the injection's own null-check skips the style tag.
+		assets.clear();
+		const confirm = vi.fn(() => true);
+		await togglePackage('pack-a', true, confirm);
+
+		expect(confirm).not.toHaveBeenCalled();
+		expect(enabledPackages.getSnapshot()).toContain('pack-a');
+		expect(styleTagFor('pack-a')).toBeNull();
+	});
+
+	it('never injects a threat-flagged theme applied WITHOUT stored consent (boot-time fail-closed)', async () => {
+		// The allowlist says enabled but no CSS consent was ever stored (e.g. the list was seeded on
+		// another machine, or the theme turned threat-flagged after trust was cleared). The refresh
+		// path applies the package directly — injectPackageTheme must fail closed.
+		enabledPackages.set(['pack-a']);
+		await refreshPackages();
+
+		expect(enabledPackages.getSnapshot()).toContain('pack-a'); // still enabled…
+		expect(styleTagFor('pack-a')).toBeNull(); // …but the flagged CSS never lands
+	});
+
+	it('clears the stored CSS trust when a consented package is removed', async () => {
+		await togglePackage('pack-a', true, () => true); // stores CSS consent for the threat theme
+		expect(styleTagFor('pack-a')).not.toBeNull();
+
+		removeImpl = () => {
+			setFiles([]);
+			return Promise.resolve();
+		};
+		const r = await removePackage('pack-a');
+		expect(r).toEqual({ ok: true });
+		expect(styleTagFor('pack-a')).toBeNull();
+
+		// Re-discovering the same package must RE-PROMPT — trust was cleared with the remove.
+		setFiles([
+			{
+				id: 'pack-a',
+				manifest: manifestJson({ theme: { name: 'T', file: 'theme.css' } }),
+				install: null
+			}
+		]);
+		assets.set('pack-a/theme.css', REMOTE_CSS);
+		await refreshPackages();
+		const confirm = vi.fn(() => true);
+		await togglePackage('pack-a', true, confirm);
+		expect(confirm).toHaveBeenCalledTimes(1);
+	});
 });
 
 // ---- togglePackage: network source consent + lifecycle -------------------------------------------
@@ -421,6 +471,50 @@ describe('togglePackage — network source consent', () => {
 		const stop = await src.start(hub);
 		expect(typeof stop).toBe('function');
 		expect(stop()).toBeUndefined();
+	});
+
+	it('catalogs a label-less sensor bare and carries a declared unit through', async () => {
+		setFiles([
+			{
+				id: 'pack-a',
+				manifest: manifestJson({
+					// No templates key at all — a source-only package registers no palette group.
+					templates: undefined,
+					source: { file: 'src.js', pollSeconds: 30, hosts: ['api.example.com'] },
+					sensors: [{ id: 'raw' }, { id: 'load', label: 'Load', unit: '%' }]
+				}),
+				install: null
+			}
+		]);
+		await refreshPackages();
+		await togglePackage('pack-a', true, () => true);
+
+		const entries = sourceCatalogEntries().filter((e) => e.id.startsWith('pkg.pack-a.'));
+		const raw = entries.find((e) => e.id === 'pkg.pack-a.raw')!;
+		expect(raw.label).toBeUndefined(); // no label declared → none invented
+		expect(raw.unit).toBeUndefined();
+		const load = entries.find((e) => e.id === 'pkg.pack-a.load')!;
+		expect(load.label).toBe('Load');
+		expect(load.unit).toBe('%');
+		// And with no templates, no palette group was registered under the package name.
+		expect(listTemplateGroups().find((g) => g.group === 'Pack A')).toBeUndefined();
+	});
+
+	it('stops an orphaned running loop on reset even after its manifest broke on disk', async () => {
+		await togglePackage('pack-a', true, () => true);
+		expect(sourceStarts).toEqual(['pack-a']);
+
+		// The manifest breaks on disk; the re-scan rows it as an error. The vanish-loop doesn't fire
+		// (the id is still live) and the enable-loop skips the unparsed entry — so the old poll loop
+		// keeps running, tracked only in runningSources.
+		setFiles([{ id: 'pack-a', manifest: '{broken', install: null }]);
+		sourceStops.length = 0;
+		await refreshPackages();
+		expect(sourceStops).toEqual([]); // nothing stopped it yet
+
+		// The reset sweep must catch it via runningSources, not via the (unparsed) discovered entry.
+		resetPackagesForTest();
+		expect(sourceStops).toEqual(['pack-a']);
 	});
 });
 
@@ -648,6 +742,16 @@ describe('removePackage', () => {
 		if (!r.ok) expect(r.error).toContain('locked');
 		// The closing refresh re-discovered the still-present folder.
 		expect(rowFor('pack-a')).toBeDefined();
+	});
+
+	it('deletes a folder that was never discovered (nothing to unregister first)', async () => {
+		// The Plugins panel can race a manual folder delete: the id is gone from `discovered` but the
+		// dir still exists. removePackage must skip the un-apply and still delete + re-scan.
+		await initPackages(hub); // empty disk — nothing discovered
+		const r = await removePackage('ghost');
+
+		expect(r).toEqual({ ok: true });
+		expect(removeCalls).toEqual(['ghost']);
 	});
 });
 

--- a/client/src/lib/widgets/plugins/weather.test.ts
+++ b/client/src/lib/widgets/plugins/weather.test.ts
@@ -22,6 +22,22 @@ describe('weather plugin', () => {
 		expect(listSources().some((s) => s.id === 'weather')).toBe(true);
 	});
 
+	it('the sunmoon sensors resolver binds sunrise + sunset', () => {
+		const sensors = getMeta('sunmoon')?.sensors as () => Record<string, string>;
+		expect(typeof sensors).toBe('function');
+		expect(sensors()).toEqual({ rise: 'weather.sun.rise', set: 'weather.sun.set' });
+	});
+
+	it('the airquality sensors resolver binds aqi/pm25/uv', () => {
+		const sensors = getMeta('airquality')?.sensors as () => Record<string, string>;
+		expect(typeof sensors).toBe('function');
+		expect(sensors()).toEqual({
+			aqi: 'weather.air.aqi',
+			pm25: 'weather.air.pm25',
+			uv: 'weather.uv'
+		});
+	});
+
 	it('the weather sensors resolver expands forecast-day series, clamped to 0..7', () => {
 		const sensors = getMeta('weather')?.sensors as (
 			c: Record<string, unknown>

--- a/client/src/lib/widgets/themeTokens.test.ts
+++ b/client/src/lib/widgets/themeTokens.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { isValidColor, TOKEN_FIELDS } from './themeTokens';
+
+// A handle to swap the global `CSS` object (happy-dom provides one with a working `supports`).
+const g = globalThis as unknown as { CSS?: typeof CSS };
+const originalCSS = g.CSS;
+afterEach(() => {
+	g.CSS = originalCSS;
+});
+
+describe('isValidColor', () => {
+	it('treats an empty value as valid (an empty override is not an error)', () => {
+		expect(isValidColor('')).toBe(true);
+		expect(isValidColor('   ')).toBe(true);
+	});
+
+	it('accepts a CSS-valid colour when CSS.supports is available', () => {
+		expect(isValidColor('rebeccapurple')).toBe(true);
+		expect(isValidColor('#77c4d3')).toBe(true);
+	});
+
+	it('is lenient (returns true) when CSS is unavailable', () => {
+		g.CSS = undefined;
+		// With no CSS API at all it can't validate, so it never false-flags a typo as invalid.
+		expect(isValidColor('definitely-not-a-real-colour')).toBe(true);
+	});
+
+	it('is lenient when CSS.supports is not a function', () => {
+		g.CSS = {} as typeof CSS;
+		expect(isValidColor('whatever')).toBe(true);
+	});
+});
+
+describe('TOKEN_FIELDS', () => {
+	it('surfaces the common theme tokens, each with a --np-* key and a kind', () => {
+		expect(TOKEN_FIELDS.length).toBeGreaterThan(0);
+		for (const t of TOKEN_FIELDS) {
+			expect(t.key.startsWith('--np-')).toBe(true);
+			expect(['color', 'font', 'text']).toContain(t.kind);
+		}
+	});
+});

--- a/client/src/lib/widgets/useAssistant.test.ts
+++ b/client/src/lib/widgets/useAssistant.test.ts
@@ -133,6 +133,17 @@ describe('useAssistant', () => {
 		expect(llmComplete).toHaveBeenCalledTimes(2);
 	});
 
+	it('unmounting before the first delay cancels the pending auto-generation', async () => {
+		// Cleanup clears the first-delay timeout and every interval (which is also why the tick's
+		// `!cancelled` guard can never observe cancelled=true — no timer survives to call it).
+		const { unmount } = renderHook(() => useAssistant(cfg({ schedule: '30s' })), { wrapper });
+		unmount();
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(60_000);
+		});
+		expect(llmComplete).not.toHaveBeenCalled();
+	});
+
 	it('does NOT auto-generate in the studio (manual refresh only)', async () => {
 		isStudioWindow.mockReturnValue(true);
 		const { result } = renderHook(() => useAssistant(cfg({ schedule: '30s' })), { wrapper });

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -93,12 +93,16 @@ export default defineConfig({
 				'src/lib/widgets/plugins/*-commands.ts',
 				'src/mcp/server.ts'
 			],
-			// Principled floors, not literal 100%: the included scope is ~99.4% lines / 96.9% funcs /
-			// 95.6% branches. The residue is genuinely uncoverable with *useful* tests — unreachable
-			// defensive arms (`?? []`, impossible `default:`/guards) and happy-dom-undrivable visual glue
-			// (e.g. the Inspector add-palette hover-preview: 280ms debounce + getBoundingClientRect). Pure
-			// IO/DOM/canvas adapters are excluded above. These thresholds ratchet-guard against regression.
-			thresholds: { statements: 99, lines: 99, functions: 96, branches: 95 }
+			// Principled floors, not literal 100%: the included scope is ~99.6% stmts / 99.0% branches /
+			// 99.9% funcs / 99.9% lines (restored + re-ratcheted 2026-07-10 after the Vitest-4 upgrade
+			// and untested-code drift slid it to 97.7/93.5 unnoticed). The residue is genuinely
+			// uncoverable with *useful* tests — unreachable defensive arms (`?? []`, impossible
+			// `default:`/guards, type-union-impossible branches) and library-internal arms (downshift,
+			// lezer) that no input can drive; each is justified in its cluster's PR notes, none carry
+			// ignore pragmas. Pure IO/DOM/canvas adapters are excluded above. CI runs test:coverage,
+			// so these thresholds now gate every PR; the ~0.4pp slack absorbs v8 remap jitter across
+			// platforms (local Windows vs CI ubuntu).
+			thresholds: { statements: 99.25, lines: 99.5, functions: 99.5, branches: 98.5 }
 		}
 	}
 });


### PR DESCRIPTION
Coverage had slid to **97.69 / 93.45 / 96.39 / 98.89** unnoticed (Vitest 2→4 remap changes in #54 plus untested-code drift) because CI ran \`test:unit\` but never the thresholds. This PR restores it **above the original v0.0.48 baseline** and makes regression impossible to miss.

## What's in it

- **~400 new tests** across 5 parallel clusters — editor panels (Inspector 81.1% → 99.7% stmts, ColorField/themeTokens/Outline → 100%), meters (all listed files → 100%), plugins+llm+formula, lib/core (26/38 files at flat 100), canvas + widgets misc. Suite: 2,769 → **3,151 tests**.
- **All test-only**: zero source changes, zero coverage-ignore pragmas (standing policy). The residue is documented genuinely-unreachable arms — type-union-impossible branches, guards mirrored by \`disabled\` attributes, library-internal arms (downshift, lezer — the latter fuzz-verified over 60k fragments) — each justified in the agents' notes.
- **CI now gates coverage**: the client job runs \`test:coverage\`, so the vite.config ratchet fails any regressing PR.
- **Thresholds re-ratcheted**: statements 99→99.25, lines 99→99.5, functions 96→99.5, branches 95→98.5 (~0.4pp slack for cross-platform v8 remap jitter).
- One pre-existing flaky test hardened (MonitorSourcesEditor rescan raced a disabled button under parallel load).

## Verification

Final tree: \`tsc\` clean, oxfmt+oxlint clean, **3,151 tests / 276 files pass**, build clean, coverage gate exit 0 at the new floors. Global: **99.62 stmts / 98.97 branches / 99.91 funcs / 99.93 lines**.

No product code changed → no release from this PR (per instruction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)