### PR TITLE
fix: harden plugins, themes, sensors, and bridge boundaries (0.0.52)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,6 +258,68 @@ pass with the simplest code, then refactor under green.
   the solver, sensor math, serialization shape) can be exercised without real media,
   hardware, or a window.
 
+### Testing pyramid
+
+Keep the suite bottom-heavy. Choose the lowest layer that can prove the behavior; move upward only
+when the risk depends on framework, bridge, browser, or operating-system integration.
+
+1. **Unit / pure-seam tests (most tests).** Exercise `lib/core/*`, reducers, parsers, schedulers,
+   geometry/math helpers, serialization contracts, and Rust pure seams directly. These should be
+   fast, deterministic, exhaustive around meaningful boundaries, and require no React, Tauri,
+   filesystem, network, clock, or hardware unless that dependency is the subject of the seam.
+2. **Component / integration tests (fewer tests).** Use Testing Library for observable React
+   behavior and focused adapter tests for store, filesystem, event, or command orchestration. Mock
+   at the outer boundary (for example Tauri `invoke`/`listen`), not between internal collaborators,
+   and verify the data or UI that crosses the boundary.
+3. **E2E tests (fewest tests).** Use Playwright for critical studio/overlay journeys whose value
+   comes from real browser layout, focus, pointer/keyboard interaction, persistence wiring, or role
+   behavior. Cover representative happy paths and high-impact regressions; do not duplicate every
+   pure or component-level permutation in E2E.
+4. **Manual / hardware smoke checks (exceptional).** Reserve these for Windows APIs, real media,
+   GPU/audio/display hardware, or destructive/external integrations that cannot be made
+   deterministic. Document the procedure and keep automated pure seams underneath it. Expensive or
+   intrusive Rust smoke tests must stay explicitly `#[ignore]` with a reason.
+
+If a behavior can be tested at two layers, prefer the lower layer and keep at most one higher-level
+test to prove the wiring. A healthy pyramid has many tiny domain tests, a smaller set of component
+and adapter tests, and a compact E2E suite—not the same assertions repeated at every layer.
+
+### Write high-value tests
+
+A test is valuable when it would fail for a plausible user-visible regression and clearly explain
+what contract broke. Optimize for defect detection and confidence, not test count or incidental
+coverage.
+
+- **Assert behavior and contracts, not implementation.** Prefer returned values, persisted JSON,
+  emitted bridge shapes, store snapshots, rendered text/roles, and user interactions. Avoid testing
+  private helpers through mocks, exact call sequences that are not contractual, DOM structure added
+  only for styling, or broad snapshots that accept unrelated churn.
+- **Prove the risk that motivated the change.** A bug test should fail before the fix for the right
+  reason. For races and lifecycle bugs, control ordering and assert the harmful outcome cannot occur
+  (stale overwrite, duplicate listener, overlapping request, mutation of an old snapshot, leaked
+  demand). For bridge changes, assert both serialization shape and the matching consumer contract.
+- **Cover meaningful partitions, not permutations.** Usually test the representative success path,
+  important boundary values, and distinct failure/recovery paths. Use table-driven tests when the
+  same rule has several inputs; do not multiply tests for equivalent cases merely to raise coverage.
+- **Keep tests deterministic and isolated.** Control time, randomness, async completion, filesystem
+  paths, and event order. Never depend on the public network, local user state, real hardware, test
+  execution order, or arbitrary sleeps. Await async work and restore timers, listeners, registries,
+  stores, mocks, and temporary files during cleanup.
+- **Use the smallest realistic fixture.** Include only the fields needed to expose the behavior,
+  while keeping fixtures valid according to the real Rust↔TypeScript or layout/widget contract.
+  Prefer builders and focused examples over giant production dumps.
+- **Keep assertions precise but resilient.** Assert all outputs that define the contract and no
+  irrelevant formatting/order unless it is itself required. Ensure error-path tests verify both the
+  error and the safety property—for example that corrupt input does not overwrite a valid file.
+- **Avoid low-value tests.** Do not add tests that only prove a mock returned its configured value,
+  repeat TypeScript's type checking, exercise framework/library behavior, or mirror the source line
+  by line. Delete or consolidate redundant tests when a stronger test subsumes them.
+- **Treat test diagnostics as failures to investigate.** Unexpected React `act` warnings, unhandled
+  rejections, console errors, leaked timers, and post-test state updates indicate an incomplete or
+  racy test even if the runner exits successfully. Fix the lifecycle or await the work; suppress a
+  diagnostic only when it is a narrowly identified environment artifact and keep other errors
+  visible.
+
 `state.rs::updater` is covered by a `#[cfg(test)] mod tests` block (create/update/delete);
 keep it green when you touch the reducer. Pure-seam tests in `sensors.rs` / `ha.rs` show the
 same pattern to follow for new seams.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5038,7 +5038,7 @@ dependencies = [
 
 [[package]]
 name = "widgetsack"
-version = "0.0.51"
+version = "0.0.52"
 dependencies = [
  "fontdb",
  "futures-util",

--- a/client/src/lib/components/NowPlaying/np-source.ts
+++ b/client/src/lib/components/NowPlaying/np-source.ts
@@ -17,7 +17,7 @@ export const npSource: SensorSource = {
 		// Make sure the media feed is flowing into mediaStore (idempotent), then mirror the active
 		// session into the hub on every change. Re-derives selection the same way the widget does
 		// (ignore filter + priority sort) so the sensors track exactly what's shown.
-		startMediaSource();
+		await startMediaSource();
 		const push = () => {
 			const s = mediaStore.getSnapshot();
 			const active = sortSessionsByPriority(

--- a/client/src/lib/components/NowPlaying/priority.test.ts
+++ b/client/src/lib/components/NowPlaying/priority.test.ts
@@ -80,9 +80,9 @@ describe('priority', () => {
 
 		const sorted = sortSessionsByPriority(sessions, priority);
 
-		expect(sorted.at(2)!.source).toBe('barbaz');
+		expect(sorted.at(0)!.source).toBe('barbaz');
 		expect(sorted.at(1)!.source).toBe('foobar');
-		expect(sorted.at(0)!.source).toBe('notinlist');
+		expect(sorted.at(2)!.source).toBe('notinlist');
 	});
 
 	it('sorts media by playing status after sorting by priority list', () => {
@@ -129,9 +129,9 @@ describe('priority', () => {
 		};
 		const priority = 'barbaz\nfoobar';
 		const sorted = sortSessionsByPriority(sessions, priority);
-		expect(sorted.at(2)!.source).toBe('barbaz');
+		expect(sorted.at(0)!.source).toBe('barbaz');
 		expect(sorted.at(1)!.source).toBe('foobar');
-		expect(sorted.at(0)!.source).toBeUndefined();
+		expect(sorted.at(2)!.source).toBeUndefined();
 
 		// Same outcome with the source-less record FIRST, so it also lands in the comparator's
 		// b-slot (both the `a?.source` and `b?.source` fallbacks run).
@@ -141,9 +141,9 @@ describe('priority', () => {
 			4: { ...sessionRecord, session_id: 4, source: 'foobar' }
 		};
 		const sorted2 = sortSessionsByPriority(reversed, priority);
-		expect(sorted2.at(2)!.source).toBe('barbaz');
+		expect(sorted2.at(0)!.source).toBe('barbaz');
 		expect(sorted2.at(1)!.source).toBe('foobar');
-		expect(sorted2.at(0)!.source).toBeUndefined();
+		expect(sorted2.at(2)!.source).toBeUndefined();
 	});
 
 	it('sorts media by last updated timestamp otherwise', () => {
@@ -171,9 +171,20 @@ describe('priority', () => {
 
 		const sorted = sortSessionsByPriority(sessions, priority);
 
-		expect(sorted.at(2)!.source).toBe('notinlist');
+		expect(sorted.at(0)!.source).toBe('notinlist');
 		expect(sorted.at(1)!.source).toBe('barbaz');
-		expect(sorted.at(0)!.source).toBe('foobar');
+		expect(sorted.at(2)!.source).toBe('foobar');
+	});
+
+	it('matches priority entries as exact lines rather than substrings', () => {
+		const sessions: Record<number, SessionRecord> = {
+			0: { ...sessionRecord, session_id: 0, source: 'foo' },
+			1: { ...sessionRecord, session_id: 1, source: 'foobar' }
+		};
+
+		const sorted = sortSessionsByPriority(sessions, 'foobar');
+
+		expect(sorted.map((s) => s.source)).toEqual(['foobar', 'foo']);
 	});
 });
 

--- a/client/src/lib/components/NowPlaying/priority.ts
+++ b/client/src/lib/components/NowPlaying/priority.ts
@@ -24,24 +24,30 @@ export const sortSessionsByPriority = (
 	currentSessions: Record<number, SessionRecord>,
 	sourcePriority: string
 ) => {
-	const orderedMedia = Object.values(currentSessions)
-		.sort(
-			(a, b) =>
-				(b?.timestamp_updated?.secs_since_epoch ?? 0) -
-				(a?.timestamp_updated?.secs_since_epoch ?? 0)
-		)
-		.sort((a, b) => {
-			let aPriority = sourcePriority.indexOf(a?.source?.toLowerCase() ?? '_____FIXME_____');
-			let bPriority = sourcePriority.indexOf(b?.source?.toLowerCase() ?? '_____FIXME_____');
+	const rank = new Map(
+		sourcePriority
+			.split('\n')
+			.map((source) => source.trim().toLowerCase())
+			.filter(Boolean)
+			.map((source, index) => [source, index])
+	);
+	const priorityOf = (session: SessionRecord): number =>
+		rank.get(session.source?.toLowerCase() ?? '') ?? Number.MAX_SAFE_INTEGER;
+	const playingOf = (session: SessionRecord): number =>
+		session.last_model_update?.Model?.playback?.status === 'Playing' ? 0 : 1;
 
-			aPriority = aPriority === -1 ? Number.MAX_VALUE : aPriority;
-			bPriority = bPriority === -1 ? Number.MAX_VALUE : bPriority;
-
-			return aPriority - bPriority;
-		})
-		.sort((_, b) => (b.last_model_update?.Model?.playback?.status === 'Playing' ? 1 : -1));
-
-	return orderedMedia;
+	return Object.values(currentSessions).sort((a, b) => {
+		const playing = playingOf(a) - playingOf(b);
+		if (playing !== 0) return playing;
+		const priority = priorityOf(a) - priorityOf(b);
+		if (priority !== 0) return priority;
+		const aTime = a.timestamp_updated;
+		const bTime = b.timestamp_updated;
+		const seconds = (bTime?.secs_since_epoch ?? 0) - (aTime?.secs_since_epoch ?? 0);
+		if (seconds !== 0) return seconds;
+		const nanos = (bTime?.nanos_since_epoch ?? 0) - (aTime?.nanos_since_epoch ?? 0);
+		return nanos !== 0 ? nanos : a.session_id - b.session_id;
+	});
 };
 
 // Insert/replace a session record, evicting any OTHER tracked session that shares its (non-empty)

--- a/client/src/lib/components/NowPlaying/source.test.ts
+++ b/client/src/lib/components/NowPlaying/source.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+	invoke: vi.fn(),
+	listen: vi.fn(),
+	handleInitialize: vi.fn(),
+	handleUpdate: vi.fn(),
+	handleDelete: vi.fn()
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: mocks.invoke }));
+vi.mock('@tauri-apps/api/event', () => ({ listen: mocks.listen }));
+vi.mock('../../../stores/stores', () => ({
+	handleInitialize: mocks.handleInitialize,
+	handleUpdate: mocks.handleUpdate,
+	handleDelete: mocks.handleDelete
+}));
+
+import { EVENTS } from '../../bridge/contract';
+import type { SessionRecord } from '../../../stores/stores';
+
+type EventCallback = (event: { payload: SessionRecord }) => void;
+
+const record = (sessionId: number): SessionRecord => ({
+	session_id: sessionId,
+	source: 'player.exe',
+	timestamp_created: null,
+	timestamp_updated: null,
+	last_media_update: null,
+	last_model_update: null
+});
+
+async function loadSource() {
+	vi.resetModules();
+	return import('./source');
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+describe('startMediaSource', () => {
+	it('attaches every listener first, then initializes and replays deltas received during the snapshot', async () => {
+		const callbacks = new Map<string, EventCallback>();
+		mocks.listen.mockImplementation((event: string, callback: EventCallback) => {
+			callbacks.set(event, callback);
+			return Promise.resolve(vi.fn());
+		});
+		let resolveInitial!: (value: { sessions: Record<number, SessionRecord> }) => void;
+		mocks.invoke.mockImplementation(
+			() =>
+				new Promise<{ sessions: Record<number, SessionRecord> }>((resolve) => {
+					resolveInitial = resolve;
+				})
+		);
+		const { startMediaSource } = await loadSource();
+
+		const starting = startMediaSource();
+		expect(mocks.listen.mock.calls.map((call) => call[0])).toEqual([
+			EVENTS.sessionCreate,
+			EVENTS.sessionUpdate,
+			EVENTS.sessionDelete
+		]);
+		expect(mocks.invoke).not.toHaveBeenCalled();
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(mocks.invoke).toHaveBeenCalledOnce();
+
+		callbacks.get(EVENTS.sessionUpdate)!({ payload: record(2) });
+		expect(mocks.handleUpdate).not.toHaveBeenCalled();
+		resolveInitial({ sessions: { 1: record(1) } });
+		await starting;
+
+		expect(mocks.handleInitialize).toHaveBeenCalledWith({ sessions: { 1: record(1) } });
+		expect(mocks.handleUpdate).toHaveBeenCalledWith({ sessionRecord: record(2) });
+		expect(mocks.handleInitialize.mock.invocationCallOrder[0]).toBeLessThan(
+			mocks.handleUpdate.mock.invocationCallOrder[0]!
+		);
+	});
+
+	it('treats create as an upsert and applies live deletes after initialization', async () => {
+		const callbacks = new Map<string, EventCallback>();
+		mocks.listen.mockImplementation((event: string, callback: EventCallback) => {
+			callbacks.set(event, callback);
+			return Promise.resolve(vi.fn());
+		});
+		mocks.invoke.mockResolvedValue({ sessions: {} });
+		const { startMediaSource } = await loadSource();
+		await startMediaSource();
+
+		callbacks.get(EVENTS.sessionCreate)!({ payload: record(3) });
+		callbacks.get(EVENTS.sessionDelete)!({ payload: record(3) });
+		expect(mocks.handleUpdate).toHaveBeenCalledWith({ sessionRecord: record(3) });
+		expect(mocks.handleDelete).toHaveBeenCalledWith({ sessionRecord: record(3) });
+	});
+
+	it('cleans up partial listeners and allows a retry after listener setup fails', async () => {
+		const unlistenA = vi.fn();
+		const unlistenB = vi.fn();
+		mocks.listen
+			.mockResolvedValueOnce(unlistenA)
+			.mockRejectedValueOnce(new Error('event bridge unavailable'))
+			.mockResolvedValueOnce(unlistenB);
+		mocks.invoke.mockResolvedValue({ sessions: {} });
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+		const { startMediaSource } = await loadSource();
+
+		await startMediaSource();
+		expect(unlistenA).toHaveBeenCalledOnce();
+		expect(unlistenB).toHaveBeenCalledOnce();
+		expect(mocks.invoke).not.toHaveBeenCalled();
+
+		mocks.listen.mockResolvedValue(vi.fn());
+		await startMediaSource();
+		expect(mocks.listen).toHaveBeenCalledTimes(6);
+		expect(mocks.invoke).toHaveBeenCalledOnce();
+		expect(warn).toHaveBeenCalledWith('Could not start the media event source', expect.any(Error));
+	});
+
+	it('keeps the live feed when only the initial snapshot fails', async () => {
+		const callbacks = new Map<string, EventCallback>();
+		mocks.listen.mockImplementation((event: string, callback: EventCallback) => {
+			callbacks.set(event, callback);
+			return Promise.resolve(vi.fn());
+		});
+		mocks.invoke.mockRejectedValue(new Error('snapshot unavailable'));
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+		const { startMediaSource } = await loadSource();
+		await startMediaSource();
+
+		callbacks.get(EVENTS.sessionUpdate)!({ payload: record(4) });
+		expect(mocks.handleUpdate).toHaveBeenCalledWith({ sessionRecord: record(4) });
+		expect(warn).toHaveBeenCalledWith(
+			'Could not load the initial media sessions',
+			expect.any(Error)
+		);
+	});
+});

--- a/client/src/lib/components/NowPlaying/source.ts
+++ b/client/src/lib/components/NowPlaying/source.ts
@@ -29,7 +29,7 @@ export type MediaCaps = {
 
 /** Ask the backend which controls the matched (or current) session supports. Returns null when the
  * query can't run (non-Windows, no backend in tests) so the caller shows every button by default. */
-export function getMediaCapabilities(source?: string): Promise<MediaCaps | null> {
+export function getMediaCapabilities(source?: string | null): Promise<MediaCaps | null> {
 	return invoke<MediaCaps | null>(COMMANDS.mediaCapabilities, { source: source ?? null }).catch(
 		() => null
 	);
@@ -46,18 +46,63 @@ export function mediaControl(
 	return invoke(COMMANDS.mediaControl, { action, source, value });
 }
 
-let started = false;
+type MediaDelta = { kind: 'update' | 'delete'; record: SessionRecord };
 
-export function startMediaSource(): void {
-	if (started) return;
-	started = true;
-	invoke<{ sessions: Record<number, SessionRecord> }>(COMMANDS.getInitialSessions, { message: '' })
-		.then((ev) => handleInitialize({ sessions: ev.sessions }))
-		.catch(() => undefined);
-	tauriEvent.listen<SessionRecord>(EVENTS.sessionUpdate, (ev) =>
-		handleUpdate({ sessionRecord: ev.payload })
-	);
-	tauriEvent.listen<SessionRecord>(EVENTS.sessionDelete, (ev) =>
-		handleDelete({ sessionRecord: ev.payload })
-	);
+let startPromise: Promise<void> | null = null;
+
+function applyDelta(delta: MediaDelta): void {
+	if (delta.kind === 'delete') handleDelete({ sessionRecord: delta.record });
+	else handleUpdate({ sessionRecord: delta.record });
+}
+
+async function attachMediaSource(): Promise<void> {
+	// Subscribe before asking for the snapshot. Deltas arriving while invoke is in flight are queued,
+	// then replayed after initialization, so an update/delete can never be overwritten by an older
+	// snapshot. Session-create is an upsert just like session-update on the frontend.
+	let live = false;
+	const queued: MediaDelta[] = [];
+	const receive = (delta: MediaDelta): void => {
+		if (live) applyDelta(delta);
+		else queued.push(delta);
+	};
+	const listeners = await Promise.allSettled([
+		tauriEvent.listen<SessionRecord>(EVENTS.sessionCreate, (ev) =>
+			receive({ kind: 'update', record: ev.payload })
+		),
+		tauriEvent.listen<SessionRecord>(EVENTS.sessionUpdate, (ev) =>
+			receive({ kind: 'update', record: ev.payload })
+		),
+		tauriEvent.listen<SessionRecord>(EVENTS.sessionDelete, (ev) =>
+			receive({ kind: 'delete', record: ev.payload })
+		)
+	]);
+	const failed = listeners.find((result) => result.status === 'rejected');
+	if (failed?.status === 'rejected') {
+		for (const result of listeners) if (result.status === 'fulfilled') result.value();
+		throw failed.reason;
+	}
+
+	try {
+		const initial = await invoke<{ sessions: Record<number, SessionRecord> }>(
+			COMMANDS.getInitialSessions,
+			{ message: '' }
+		);
+		handleInitialize({ sessions: initial.sessions });
+	} catch (error) {
+		// The live listeners are still useful when the initial snapshot is unavailable.
+		console.warn('Could not load the initial media sessions', error);
+	}
+	for (const delta of queued) applyDelta(delta);
+	live = true;
+}
+
+/** Start the per-webview media feed once. A listener-attachment failure resets the singleton so a
+ * later widget/settings mount can retry; an initial-snapshot failure keeps the live feed running. */
+export function startMediaSource(): Promise<void> {
+	if (startPromise) return startPromise;
+	startPromise = attachMediaSource().catch((error) => {
+		startPromise = null;
+		console.warn('Could not start the media event source', error);
+	});
+	return startPromise;
 }

--- a/client/src/lib/core/imageSrc.test.ts
+++ b/client/src/lib/core/imageSrc.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { describe, it, expect } from 'vitest';
 import { isDirectUrl, imageFit } from './imageSrc';
 
@@ -10,6 +12,16 @@ describe('isDirectUrl', () => {
 		expect(isDirectUrl('/abs/path.png')).toBe(true);
 		expect(isDirectUrl('photo.jpg')).toBe(false);
 		expect(isDirectUrl('  subfolder-cat.png ')).toBe(false);
+	});
+
+	it('keeps production CSP aligned with the supported remote image schemes', () => {
+		const config = JSON.parse(
+			readFileSync(resolve(process.cwd(), '../widgetsack/tauri.conf.json'), 'utf8')
+		) as { app: { security: { csp: string } } };
+		const imgDirective = config.app.security.csp
+			.split(';')
+			.find((directive) => directive.trim().startsWith('img-src'));
+		expect(imgDirective?.split(/\s+/)).toEqual(expect.arrayContaining(['http:', 'https:']));
 	});
 });
 

--- a/client/src/lib/core/templates.test.ts
+++ b/client/src/lib/core/templates.test.ts
@@ -338,6 +338,20 @@ describe('template registry (register / unregister / list / subscribe)', () => {
 		expect(listTemplateGroups().find((g) => g.group === PLUGIN_GROUP)?.templates).toEqual([sample]);
 	});
 
+	it('keeps groups with the same display label separate when their identities differ', () => {
+		const second = { ...sample, id: 'plugin-widget-2' };
+		registerTemplates('pkg:one', [sample], 'Shared Name');
+		registerTemplates('pkg:two', [second], 'Shared Name');
+
+		const shared = listTemplateGroups().filter((g) => g.group === 'Shared Name');
+		expect(shared.map((g) => g.templates[0]?.id)).toEqual(['plugin-widget', 'plugin-widget-2']);
+		unregisterTemplates('pkg:one');
+		expect(getTemplate('plugin-widget')).toBeUndefined();
+		expect(getTemplate('plugin-widget-2')).toBe(second);
+
+		unregisterTemplates('pkg:two');
+	});
+
 	it('getTemplate finds a template contributed by a registered group (loop continues past built-ins)', () => {
 		expect(getTemplate('plugin-widget')).toBeUndefined();
 		registerTemplates(PLUGIN_GROUP, [sample]);

--- a/client/src/lib/core/templates.ts
+++ b/client/src/lib/core/templates.ts
@@ -356,7 +356,11 @@ export type TemplateGroup = { group: string; templates: Template[] };
 /** The built-in templates' group name (always present, always first, never unregisterable). */
 export const BUILTIN_TEMPLATE_GROUP = 'Built-in';
 
-const templateGroups = new Map<string, Template[]>([[BUILTIN_TEMPLATE_GROUP, TEMPLATES]]);
+type RegisteredTemplateGroup = { label: string; templates: Template[] };
+
+const templateGroups = new Map<string, RegisteredTemplateGroup>([
+	[BUILTIN_TEMPLATE_GROUP, { label: BUILTIN_TEMPLATE_GROUP, templates: TEMPLATES }]
+]);
 const templateListeners = new Set<() => void>();
 // Cached list identity so useSyncExternalStore sees a stable snapshot between changes.
 let templateSnapshot: TemplateGroup[] | null = null;
@@ -366,23 +370,27 @@ function notifyTemplates(): void {
 	for (const listener of templateListeners) listener();
 }
 
-/** Register (or replace) a named template group. The built-in group cannot be overwritten. */
-export function registerTemplates(group: string, list: Template[]): void {
-	if (group === BUILTIN_TEMPLATE_GROUP) return;
-	templateGroups.set(group, list.slice());
+/** Register (or replace) a template group by stable identity. `label` is only its palette heading,
+ * so two plugin packages may share a display name without replacing each other's templates. */
+export function registerTemplates(id: string, list: Template[], label = id): void {
+	if (id === BUILTIN_TEMPLATE_GROUP) return;
+	templateGroups.set(id, { label, templates: list.slice() });
 	notifyTemplates();
 }
 
 /** Remove a registered template group (no-op for the built-ins / an unknown group). */
-export function unregisterTemplates(group: string): void {
-	if (group === BUILTIN_TEMPLATE_GROUP) return;
-	if (templateGroups.delete(group)) notifyTemplates();
+export function unregisterTemplates(id: string): void {
+	if (id === BUILTIN_TEMPLATE_GROUP) return;
+	if (templateGroups.delete(id)) notifyTemplates();
 }
 
 /** Every template group, built-ins first then registration order. Stable identity between changes. */
 export function listTemplateGroups(): TemplateGroup[] {
 	if (!templateSnapshot) {
-		templateSnapshot = Array.from(templateGroups, ([group, templates]) => ({ group, templates }));
+		templateSnapshot = Array.from(templateGroups.values(), ({ label, templates }) => ({
+			group: label,
+			templates
+		}));
 	}
 	return templateSnapshot;
 }
@@ -397,8 +405,8 @@ export function subscribeTemplates(listener: () => void): () => void {
 
 /** Find a template by id across every registered group (built-ins first). */
 export function getTemplate(id: string): Template | undefined {
-	for (const list of templateGroups.values()) {
-		const t = list.find((tpl) => tpl.id === id);
+	for (const { templates } of templateGroups.values()) {
+		const t = templates.find((tpl) => tpl.id === id);
 		if (t) return t;
 	}
 	return undefined;

--- a/client/src/lib/overlay.ts
+++ b/client/src/lib/overlay.ts
@@ -555,20 +555,12 @@ export async function resolveThemeCss(name: string): Promise<string> {
 
 /** Write theme `name` (a bare stem) → `themes/<name>.css`. Used by the studio theme editor. */
 export async function saveThemeCss(name: string, contents: string): Promise<void> {
-	try {
-		await invoke(COMMANDS.saveTheme, { name, contents });
-	} catch (err) {
-		console.warn('save_theme failed', err);
-	}
+	await invoke(COMMANDS.saveTheme, { name, contents });
 }
 
 /** Delete theme `name` → removes `themes/<name>.css` (idempotent). Used by the studio theme list. */
 export async function deleteThemeCss(name: string): Promise<void> {
-	try {
-		await invoke(COMMANDS.deleteTheme, { name });
-	} catch (err) {
-		console.warn('delete_theme failed', err);
-	}
+	await invoke(COMMANDS.deleteTheme, { name });
 }
 
 // ---- wallpapers: media files for the per-monitor background layer (in a fixed `wallpapers/` folder)

--- a/client/src/lib/widgets/Canvas.tsx
+++ b/client/src/lib/widgets/Canvas.tsx
@@ -148,6 +148,7 @@ import { useSplitters } from './canvas/useSplitters';
 import { useStudioInit } from './canvas/useStudioInit';
 import { recordWidgetRender } from './canvas/widgetProfile';
 import type { EditorState, Extra, MonitorOption } from './canvas/types';
+import Select from './Select';
 import type { SettingsTab } from './StudioSettingsPanel';
 import mascotUrl from '../../assets/mascot.png';
 import './Canvas.css';
@@ -170,7 +171,6 @@ const ThemePreview = lazy(() => import('./ThemePreview'));
 const TokenFields = lazy(() => import('./TokenFields'));
 const Outline = lazy(() => import('./Outline'));
 const NavRail = lazy(() => import('./NavRail'));
-const Select = lazy(() => import('./Select'));
 const SensorList = lazy(() => import('./SensorList'));
 const ThemeList = lazy(() => import('./ThemeList'));
 const StudioSettingsPanel = lazy(() => import('./StudioSettingsPanel'));
@@ -944,6 +944,7 @@ export default function Canvas({ studio = false }: Props) {
 			// An explicit '' (default tokens) on the monitor is honored — it's a string, so the ?? keeps it.
 			const lock = obj?.themeLock !== false;
 			patch.themeLock = lock;
+			patch.globalTheme = typeof obj?.theme === 'string' ? obj.theme : '';
 			const t = lock ? obj?.theme : (mon?.theme ?? obj?.theme);
 			if (typeof t === 'string' && t !== stateThemeRef.current) {
 				patch.selectedTheme = t;
@@ -1011,8 +1012,7 @@ export default function Canvas({ studio = false }: Props) {
 			import('./BackgroundPanel'),
 			import('./PluginsPanel'),
 			import('./DesignerListPanel'),
-			import('./MultiInspector'),
-			import('./Select')
+			import('./MultiInspector')
 		]).catch(() => undefined);
 	}, [studio]);
 

--- a/client/src/lib/widgets/CssEditor.test.tsx
+++ b/client/src/lib/widgets/CssEditor.test.tsx
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import { render, waitFor } from '@testing-library/react';
+// Warm the implementation during module collection, outside any individual test timeout. The wrapper
+// still resolves through React.lazy, while full-suite worker contention cannot consume its 3s wait.
+import './CssEditorImpl';
 import CssEditor from './CssEditor';
 
 // Smoke tests: the lazy CodeMirror impl must construct under happy-dom and render the document.
@@ -8,14 +11,20 @@ import CssEditor from './CssEditor';
 describe('CssEditor', () => {
 	it('lazily mounts a CodeMirror editor and renders the value', async () => {
 		const { container } = render(<CssEditor value=".value { color: red }" />);
-		await waitFor(() => expect(container.querySelector('.cm-editor')).toBeTruthy());
+		await waitFor(() => expect(container.querySelector('.cm-editor')).toBeTruthy(), {
+			timeout: 3000
+		});
 		expect(container.querySelector('.cm-content')?.textContent).toContain('color: red');
 	});
 
 	it('exposes the aria-label on the editable content', async () => {
 		const { container } = render(<CssEditor value="" ariaLabel="widget css" />);
-		await waitFor(() =>
-			expect(container.querySelector('.cm-content')?.getAttribute('aria-label')).toBe('widget css')
+		await waitFor(
+			() =>
+				expect(container.querySelector('.cm-content')?.getAttribute('aria-label')).toBe(
+					'widget css'
+				),
+			{ timeout: 3000 }
 		);
 	});
 });

--- a/client/src/lib/widgets/DesignerListPanel.test.tsx
+++ b/client/src/lib/widgets/DesignerListPanel.test.tsx
@@ -139,12 +139,16 @@ describe('DesignerListPanel template groups', () => {
 	it('labels a plugin template group "Templates · <group>" (built-ins stay plain "Templates")', () => {
 		// A plugin package contributes its own group; the built-in group keeps the unqualified header.
 		registerTemplates('My Pack', [{ ...TEMPLATES[1], id: 'pack-system', name: 'Pack System' }]);
+		let unmount: () => void = () => undefined;
 		try {
-			const { getByText } = render(<DesignerListPanel {...baseProps()} />);
+			const view = render(<DesignerListPanel {...baseProps()} />);
+			unmount = view.unmount;
+			const { getByText } = view;
 			expect(getByText('Templates')).toBeTruthy();
 			expect(getByText('Templates · My Pack')).toBeTruthy();
 			expect(getByText('Pack System')).toBeTruthy();
 		} finally {
+			unmount();
 			unregisterTemplates('My Pack');
 		}
 	});
@@ -170,12 +174,14 @@ describe('DesignerListPanel header actions', () => {
 	});
 
 	it('alerts a failure (and does not claim success) when the copy fails', async () => {
+		const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
 		vi.mocked(copyToClipboard).mockResolvedValueOnce(false);
 		const { getByText } = render(<DesignerListPanel {...baseProps()} />);
 		fireEvent.click(getByText('⧉ Copy widget reference'));
 		await waitFor(() =>
 			expect(alertSpy).toHaveBeenCalledWith(expect.stringMatching(/Copy failed/i))
 		);
+		expect(log).toHaveBeenCalledOnce();
 	});
 });
 

--- a/client/src/lib/widgets/DragSnapLayer.test.tsx
+++ b/client/src/lib/widgets/DragSnapLayer.test.tsx
@@ -526,7 +526,9 @@ describe('DragSnapLayer (zone widgets)', () => {
 		act(() => handlers['win_drag_start']?.({ payload: { hwnd: 7 } }));
 		// Let many poll intervals fire while probes are slow.
 		await act(async () => void (await new Promise((r) => setTimeout(r, 250))));
-		act(() => handlers['win_drag_end']?.({ payload: { hwnd: 7 } })); // stops the interval
+		await act(async () => {
+			await handlers['win_drag_end']?.({ payload: { hwnd: 7 } }); // stops the interval
+		});
 
 		expect(pointerProbe).toHaveBeenCalled(); // probing happened
 		expect(maxInFlight).toBe(1); // the busy guard prevented any overlap

--- a/client/src/lib/widgets/Inspector.wiring.test.tsx
+++ b/client/src/lib/widgets/Inspector.wiring.test.tsx
@@ -42,6 +42,20 @@ vi.mock('../ddc/monitors', () => ({
 	setMonitorInput: vi.fn().mockResolvedValue(true)
 }));
 
+const originalConsoleError = console.error;
+let inspectorErrorSpy: ReturnType<typeof vi.spyOn>;
+beforeEach(() => {
+	// The Inspector wiring matrix mounts/unmounts the async monitor probe and external template
+	// registry dozens of times. Vitest can report their already-cancelled completion against the next
+	// test. Filter only that known act diagnostic; application errors remain visible.
+	inspectorErrorSpy = vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+		const text = args.map(String).join(' ');
+		if (text.includes('not wrapped in act') && text.includes('Inspector')) return;
+		originalConsoleError(...args);
+	});
+});
+afterEach(() => inspectorErrorSpy.mockRestore());
+
 const w = (over: Partial<WidgetInstance> = {}): WidgetInstance => ({
 	id: 'w1',
 	type: 'clock',
@@ -291,11 +305,13 @@ describe('Inspector add-palette open state', () => {
 				tree: () => leaf(w({ id: 'p', type: 'text' }))
 			}
 		]);
+		let unmount: () => void = () => undefined;
 		try {
-			render(<Inspector onOp={vi.fn()} />);
+			unmount = render(<Inspector onOp={vi.fn()} />).unmount;
 			expect(within(palette()).getByText('Templates · MyPlugin', { selector: '.hd' })).toBeTruthy();
 			expect(within(palette()).getByRole('button', { name: /^Plugin Widget/ })).toBeTruthy();
 		} finally {
+			unmount();
 			unregisterTemplates('MyPlugin');
 		}
 	});
@@ -737,6 +753,10 @@ describe('Inspector config-field reset (macro / monitorSources / toggle)', () =>
 				onOp={onOp}
 			/>
 		);
+		await act(async () => {
+			await Promise.resolve();
+			await Promise.resolve();
+		});
 		// With a non-empty spec the editor shows a (manual) row, not the empty-state placeholder —
 		// wait for the detect effect to settle on the row-count status before interacting.
 		await screen.findByText('1 input');
@@ -1035,12 +1055,14 @@ describe('Inspector template options form — unlabeled param', () => {
 				tree: () => leaf(w({ id: 'p', type: 'text' }))
 			}
 		]);
+		let unmount: () => void = () => undefined;
 		try {
-			render(<Inspector onOp={vi.fn()} />);
+			unmount = render(<Inspector onOp={vi.fn()} />).unmount;
 			// No `label` on the spec → the key names both the visible row and the select's aria-label.
 			expect(within(palette()).getByLabelText('Key Only — lang')).toBeTruthy();
 			expect(within(palette()).getByText('lang', { selector: 'label' })).toBeTruthy();
 		} finally {
+			unmount();
 			unregisterTemplates('KeyOnly');
 		}
 	});
@@ -1178,12 +1200,17 @@ describe('Inspector remaining branch wiring', () => {
 				onOp={vi.fn()}
 			/>
 		);
+		await act(async () => {
+			await Promise.resolve();
+			await Promise.resolve();
+		});
 		expect(within(panel()).getByText('macro help')).toBeTruthy();
 		expect(within(panel()).getByText('sources help')).toBeTruthy();
 		expect(within(panel()).getByText('toggle help')).toBeTruthy();
 		expect(within(panel()).getByText('text help')).toBeTruthy();
-		// Let the (mocked) monitor-inputs detect effect settle inside the test.
-		await screen.findByPlaceholderText('0x11=Desktop, 0x12=Switch');
+		// Let the (mocked) monitor-inputs detect effect settle inside the test. The placeholder exists
+		// before that promise resolves, so wait for the post-scan status instead.
+		await screen.findByText('0 inputs');
 	});
 
 	it('clears the sources spec to undefined when the last monitor input is unchecked', async () => {
@@ -1197,6 +1224,10 @@ describe('Inspector remaining branch wiring', () => {
 				onOp={onOp}
 			/>
 		);
+		await act(async () => {
+			await Promise.resolve();
+			await Promise.resolve();
+		});
 		// The manual 0x11 entry appears as one checked row once detection resolves; unchecking it
 		// empties the spec, which the Inspector stores as undefined.
 		await screen.findByText('1 input');

--- a/client/src/lib/widgets/NowPlayingHost.tsx
+++ b/client/src/lib/widgets/NowPlayingHost.tsx
@@ -23,7 +23,7 @@ type Props = {
 
 export default function NowPlayingHost({ label, onControl }: Props) {
 	useEffect(() => {
-		startMediaSource();
+		void startMediaSource();
 	}, []);
 
 	const state = useStore(mediaStore);

--- a/client/src/lib/widgets/StudioSettingsPanel.tsx
+++ b/client/src/lib/widgets/StudioSettingsPanel.tsx
@@ -185,7 +185,7 @@ export default function StudioSettingsPanel({
 							</span>
 							<select
 								value={theme.selected}
-								onChange={(e) => theme.setTheme(e.currentTarget.value)}
+								onChange={(e) => void theme.setTheme(e.currentTarget.value)}
 								aria-label={theme.lock ? 'Theme for all monitors' : 'Theme for this monitor'}
 							>
 								{theme.options.map((o) => (

--- a/client/src/lib/widgets/canvas/editorOps.defs.test.ts
+++ b/client/src/lib/widgets/canvas/editorOps.defs.test.ts
@@ -3,7 +3,7 @@
 // (Partial<EditorState>) the reducer applies via spread; they never mutate the input. We assert on
 // the observable result (the patched tree shape, ids, library defs, the returned boolean/value),
 // never on internals.
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
 	cfgNum,
 	clone,
@@ -367,19 +367,25 @@ describe('deleteDef', () => {
 	});
 
 	it('refuses to delete a def that is in use (returns empty patch)', () => {
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
 		const s = state({
 			monitor: { root: container('root', 'col', []), floating: [instanceOf('def-1')] },
 			library: { version: 1, defs: [gaugeDef('def-1')] }
 		});
 		expect(deleteDef(s, 'def-1')).toEqual({});
+		expect(warn).toHaveBeenCalledOnce();
+		warn.mockRestore();
 	});
 
 	it('refuses to delete the def currently being edited (returns empty patch)', () => {
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
 		const s = state({
 			library: { version: 1, defs: [gaugeDef('def-1')] },
 			editingDefId: 'def-1'
 		});
 		expect(deleteDef(s, 'def-1')).toEqual({});
+		expect(warn).toHaveBeenCalledOnce();
+		warn.mockRestore();
 	});
 
 	it('is a no-op (empty patch) when there is no library', () => {

--- a/client/src/lib/widgets/canvas/types.ts
+++ b/client/src/lib/widgets/canvas/types.ts
@@ -17,6 +17,8 @@ export type Baseline = {
 	library: Library | undefined;
 	theme: string;
 	themeLock: boolean;
+	/** Saved global inherit-theme, distinct from `theme` when per-monitor themes are unlocked. */
+	globalTheme?: string;
 	tokens: Record<string, string>;
 };
 
@@ -42,6 +44,8 @@ export type EditorState = {
 	// `theme` and every monitor uses it; when false the picker sets the CURRENT monitor's own theme
 	// (MonitorLayout.theme), so each display can differ. Toggled from studio Settings.
 	themeLock: boolean;
+	/** Last loaded global inherit-theme; `selectedTheme` may instead be this monitor's override. */
+	globalTheme?: string;
 	tokenOverrides: Record<string, string>;
 	// Def editor (6b): while editing a def, `monitor` is the scoped tree and the real monitor is
 	// stashed in `savedMonitor`. `defEditBaseline` is the scoped tree as of def-edit START, so the

--- a/client/src/lib/widgets/canvas/useBackground.test.ts
+++ b/client/src/lib/widgets/canvas/useBackground.test.ts
@@ -98,7 +98,7 @@ describe('useBackground', () => {
 		// refreshWallpapers re-reads the folder on demand.
 		listWallpapers.mockResolvedValue(['only.png']);
 		await act(async () => {
-			result.current.refreshWallpapers();
+			await result.current.refreshWallpapers();
 		});
 		await waitFor(() => expect(result.current.wallpaperFiles).toEqual(['only.png']));
 	});
@@ -116,10 +116,11 @@ describe('useBackground', () => {
 	});
 
 	it('patchBg merges into the existing spec via setBackground', () => {
+		wallpaperAssetUrl.mockReturnValue(new Promise(() => undefined));
 		const handleOp = vi.fn<(op: LayoutOp) => void>();
 		const m = monitor({ background: { kind: 'image', src: 'wall.png' } });
 		const { result } = renderHook(() =>
-			useBackground({ studio: true, navSection: 'background', monitor: m, handleOp })
+			useBackground({ studio: true, navSection: 'layouts', monitor: m, handleOp })
 		);
 		act(() => result.current.patchBg({ opacity: 0.5 }));
 		expect(handleOp).toHaveBeenCalledWith({
@@ -131,7 +132,7 @@ describe('useBackground', () => {
 	it('patchBg starts from a default color base when there is no background yet', () => {
 		const handleOp = vi.fn<(op: LayoutOp) => void>();
 		const { result } = renderHook(() =>
-			useBackground({ studio: true, navSection: 'background', monitor: monitor(), handleOp })
+			useBackground({ studio: true, navSection: 'layouts', monitor: monitor(), handleOp })
 		);
 		act(() => result.current.patchBg({ src: '#abc' }));
 		expect(handleOp).toHaveBeenCalledWith({
@@ -141,10 +142,11 @@ describe('useBackground', () => {
 	});
 
 	it('setBgKind keeps src when the kind is unchanged, else resets it', () => {
+		wallpaperAssetUrl.mockReturnValue(new Promise(() => undefined));
 		const handleOp = vi.fn<(op: LayoutOp) => void>();
 		const m = monitor({ background: { kind: 'image', src: 'wall.png' } });
 		const { result } = renderHook(() =>
-			useBackground({ studio: true, navSection: 'background', monitor: m, handleOp })
+			useBackground({ studio: true, navSection: 'layouts', monitor: m, handleOp })
 		);
 		act(() => result.current.setBgKind('image')); // same kind → keep src
 		expect(handleOp).toHaveBeenLastCalledWith({
@@ -161,7 +163,7 @@ describe('useBackground', () => {
 	it('clearBg dispatches setBackground with an undefined spec', () => {
 		const handleOp = vi.fn<(op: LayoutOp) => void>();
 		const { result } = renderHook(() =>
-			useBackground({ studio: true, navSection: 'background', monitor: monitor(), handleOp })
+			useBackground({ studio: true, navSection: 'layouts', monitor: monitor(), handleOp })
 		);
 		act(() => result.current.clearBg());
 		expect(handleOp).toHaveBeenCalledWith({ op: 'setBackground', spec: undefined });

--- a/client/src/lib/widgets/canvas/useBackground.ts
+++ b/client/src/lib/widgets/canvas/useBackground.ts
@@ -23,7 +23,7 @@ export type Background = {
 	resolveWallpaper: (name: string) => string;
 	/** The wallpapers/ folder contents (the Background section's image/video picker). */
 	wallpaperFiles: string[];
-	refreshWallpapers: () => void;
+	refreshWallpapers: () => Promise<void>;
 	patchBg: (patch: Partial<BackgroundSpec>) => void;
 	setBgKind: (kind: BackgroundKind) => void;
 	clearBg: () => void;
@@ -53,11 +53,11 @@ export function useBackground({ studio, navSection, monitor, handleOp }: Deps): 
 	// The wallpapers/ folder contents (the Background section's image/video picker). Refreshed when
 	// the section opens — so a file dropped into the folder appears after a re-open or ↻.
 	const [wallpaperFiles, setWallpaperFiles] = useState<string[]>([]);
-	const refreshWallpapers = useCallback(() => {
-		listWallpapers().then(setWallpaperFiles);
+	const refreshWallpapers = useCallback(async () => {
+		setWallpaperFiles(await listWallpapers());
 	}, []);
 	useEffect(() => {
-		if (studio && navSection === 'background') refreshWallpapers();
+		if (studio && navSection === 'background') void refreshWallpapers();
 	}, [studio, navSection, refreshWallpapers]);
 	// Merge a patch into the current background spec (creating a default 'color' base if none yet),
 	// or switch kind (which resets `src`, since a colour, a filename and a URL aren't interchangeable).

--- a/client/src/lib/widgets/canvas/useEditorModel.test.ts
+++ b/client/src/lib/widgets/canvas/useEditorModel.test.ts
@@ -245,7 +245,29 @@ describe('history reset + baseline', () => {
 		expect(b).not.toBeNull();
 		expect(b.monitor).toBe(result.current.state.monitor);
 		expect(b.theme).toBe('builtin:dark');
+		expect(b.globalTheme).toBe('builtin:dark');
 		expect(b.tokens).toEqual({ '--accent': '#f00' });
+	});
+
+	it('keeps the global inherit-theme separate in an unlocked baseline', () => {
+		const { result } = renderHook(() => useEditorModel(true, []));
+		act(() =>
+			result.current.dispatch({
+				type: 'load',
+				patch: {
+					selectedTheme: 'monitor-theme',
+					themeLock: false,
+					globalTheme: 'global-inherit-theme'
+				}
+			})
+		);
+		act(() => result.current.dispatch({ type: 'setBaseline' }));
+
+		expect(result.current.state.savedBaseline).toMatchObject({
+			theme: 'monitor-theme',
+			themeLock: false,
+			globalTheme: 'global-inherit-theme'
+		});
 	});
 
 	it('setBaseline mid-def-edit also re-anchors the def-edit baseline to the scoped monitor', () => {

--- a/client/src/lib/widgets/canvas/useEditorModel.ts
+++ b/client/src/lib/widgets/canvas/useEditorModel.ts
@@ -137,6 +137,7 @@ function setBaselinePatch(s: EditorState): Patch {
 			library: s.library,
 			theme: s.selectedTheme,
 			themeLock: s.themeLock,
+			globalTheme: s.themeLock ? s.selectedTheme : (s.globalTheme ?? ''),
 			tokens: s.tokenOverrides
 		},
 		// While editing a def, re-anchor the def-edit baseline too, so a mid-def-edit Save clears the
@@ -481,6 +482,7 @@ function reduceLoad(state: EditorState, action: LoadAction): EditorState {
 				library: b.library,
 				selectedTheme: b.theme,
 				themeLock: b.themeLock,
+				globalTheme: b.globalTheme,
 				tokenOverrides: b.tokens,
 				pendingExtras: []
 			};
@@ -566,6 +568,7 @@ const initial = (studio: boolean, seedMonitor: MonitorLayout): EditorState => ({
 	lastPrimary: null,
 	selectedTheme: '',
 	themeLock: true, // default: one theme across all monitors (Settings unlocks per-monitor themes)
+	globalTheme: '',
 	tokenOverrides: {},
 	editingDefId: null,
 	savedMonitor: null,

--- a/client/src/lib/widgets/canvas/usePersistence.test.ts
+++ b/client/src/lib/widgets/canvas/usePersistence.test.ts
@@ -23,21 +23,32 @@ vi.mock('@tauri-apps/api/core', () => ({
 let loadLayoutRaw: string | null = null;
 let saveRejects = false;
 let savedContents: string | null = null;
+let savedTouchedMonitors: string[] | undefined;
+let savedTouchedGlobals: string[] | undefined;
 
 beforeEach(() => {
 	loadLayoutRaw = null;
 	saveRejects = false;
 	savedContents = null;
+	savedTouchedMonitors = undefined;
+	savedTouchedGlobals = undefined;
 	invoke.mockReset();
-	invoke.mockImplementation(async (cmd: string, args?: { contents?: string }) => {
-		if (cmd === COMMANDS.loadLayout) return loadLayoutRaw;
-		if (cmd === COMMANDS.saveLayout) {
-			if (saveRejects) throw new Error('save_layout rejected');
-			savedContents = args?.contents ?? null;
-			return undefined;
+	invoke.mockImplementation(
+		async (
+			cmd: string,
+			args?: { contents?: string; touchedMonitors?: string[]; touchedGlobals?: string[] }
+		) => {
+			if (cmd === COMMANDS.loadLayout) return loadLayoutRaw;
+			if (cmd === COMMANDS.saveLayout) {
+				if (saveRejects) throw new Error('save_layout rejected');
+				savedContents = args?.contents ?? null;
+				savedTouchedMonitors = args?.touchedMonitors;
+				savedTouchedGlobals = args?.touchedGlobals;
+				return undefined;
+			}
+			throw new Error(`unexpected command ${cmd}`);
 		}
-		throw new Error(`unexpected command ${cmd}`);
-	});
+	);
 });
 afterEach(() => {
 	vi.useRealTimers();
@@ -98,6 +109,7 @@ describe('persistToDisk — widgets.json assembly', () => {
 		expect(out).not.toHaveProperty('theme');
 		expect(out).not.toHaveProperty('themeLock');
 		expect(out).not.toHaveProperty('tokens');
+		expect(savedTouchedMonitors).toEqual(['mon-A']);
 		expect(out).not.toHaveProperty('library');
 		const monitors = out.monitors as Record<string, MonitorLayout>;
 		expect(Object.keys(monitors)).toEqual(['mon-A']);
@@ -158,7 +170,22 @@ describe('persistToDisk — widgets.json assembly', () => {
 			theme: 'builtin:dark'
 		});
 		// Unlocked here so the GLOBAL theme falls back to the file's existing global (inherit-default).
-		const { result } = renderHook(() => usePersistence(editorState({ themeLock: false }), 'mon-A'));
+		const { result } = renderHook(() =>
+			usePersistence(
+				editorState({
+					themeLock: false,
+					savedBaseline: {
+						monitor: monitorWith(),
+						library: undefined,
+						theme: '',
+						themeLock: false,
+						globalTheme: 'builtin:dark',
+						tokens: {}
+					}
+				}),
+				'mon-A'
+			)
+		);
 		await act(async () => {
 			await result.current.persistToDisk([]);
 		});
@@ -304,8 +331,8 @@ describe('persistToDisk — widgets.json assembly', () => {
 		warn.mockRestore();
 	});
 
-	it('survives a load_layout that throws / returns garbage and still writes a fresh monitors map', async () => {
-		// loadLayout rejects → the catch falls back to an empty monitors map (no other monitors).
+	it('refuses to overwrite widgets.json when load_layout throws', async () => {
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
 		invoke.mockImplementation(async (cmd: string, args?: { contents?: string }) => {
 			if (cmd === COMMANDS.loadLayout) throw new Error('disk read failed');
 			if (cmd === COMMANDS.saveLayout) {
@@ -314,11 +341,131 @@ describe('persistToDisk — widgets.json assembly', () => {
 			}
 		});
 		const { result } = renderHook(() => usePersistence(editorState(), 'mon-A'));
+		let ok = true;
+		await act(async () => {
+			ok = await result.current.persistToDisk([]);
+		});
+		expect(ok).toBe(false);
+		expect(savedContents).toBeNull();
+		expect(warn).toHaveBeenCalledOnce();
+	});
+
+	it('names every monitor changed by a cross-monitor move in the transaction', async () => {
+		loadLayoutRaw = JSON.stringify({
+			version: 2,
+			monitors: { 'mon-B': monitorWith('keep') }
+		});
+		const extras: Extra[] = [{ key: 'mon-B', leaf: leaf(createWidget('text', 'moved')) }];
+		const { result } = renderHook(() => usePersistence(editorState(), 'mon-A'));
+		await act(async () => {
+			await result.current.persistToDisk(extras);
+		});
+		expect(savedTouchedMonitors).toEqual(['mon-A', 'mon-B']);
+	});
+
+	it('does not mark unchanged cached globals as touched during a monitor-only save', async () => {
+		const oldLibrary: Library = { version: 1, defs: [] };
+		const baseline: Baseline = {
+			monitor: monitorWith('old-monitor'),
+			library: oldLibrary,
+			theme: 'old-theme',
+			themeLock: true,
+			tokens: { '--old': '1' }
+		};
+		loadLayoutRaw = JSON.stringify({
+			version: 2,
+			monitors: { 'mon-A': monitorWith('disk-monitor') },
+			library: {
+				version: 1,
+				defs: [{ id: 'new', name: 'New', size: { w: 100, h: 100 }, child: monitorWith().root }]
+			},
+			theme: 'new-theme',
+			themeLock: false,
+			tokens: { '--new': '2' }
+		});
+		const { result } = renderHook(() =>
+			usePersistence(
+				editorState({
+					monitor: monitorWith('local-monitor'),
+					library: oldLibrary,
+					selectedTheme: 'old-theme',
+					themeLock: true,
+					tokenOverrides: { '--old': '1' },
+					savedBaseline: baseline
+				}),
+				'mon-A'
+			)
+		);
+
 		await act(async () => {
 			await result.current.persistToDisk([]);
 		});
-		const monitors = written().monitors as Record<string, MonitorLayout>;
-		expect(Object.keys(monitors)).toEqual(['mon-A']);
+
+		expect(savedTouchedGlobals).toEqual([]);
+	});
+
+	it('marks only intentionally edited global fields as touched', async () => {
+		const oldLibrary: Library = { version: 1, defs: [] };
+		const newLibrary: Library = {
+			version: 1,
+			defs: [{ id: 'new', name: 'New', size: { w: 100, h: 100 }, child: monitorWith().root }]
+		};
+		const baseline: Baseline = {
+			monitor: monitorWith(),
+			library: oldLibrary,
+			theme: 'old-theme',
+			themeLock: true,
+			tokens: {}
+		};
+		const { result } = renderHook(() =>
+			usePersistence(
+				editorState({
+					library: newLibrary,
+					selectedTheme: 'new-theme',
+					themeLock: true,
+					savedBaseline: baseline
+				}),
+				'mon-A'
+			)
+		);
+
+		await act(async () => {
+			await result.current.persistToDisk([]);
+		});
+
+		expect(savedTouchedGlobals).toEqual(['library', 'theme']);
+	});
+
+	it('omits intentionally cleared library and locked theme instead of falling back to disk', async () => {
+		const oldLibrary: Library = { version: 1, defs: [] };
+		const baseline: Baseline = {
+			monitor: monitorWith(),
+			library: oldLibrary,
+			theme: 'old-theme',
+			themeLock: true,
+			globalTheme: 'old-theme',
+			tokens: {}
+		};
+		loadLayoutRaw = JSON.stringify({
+			version: 2,
+			monitors: { 'mon-A': monitorWith() },
+			library: oldLibrary,
+			theme: 'old-theme'
+		});
+		const { result } = renderHook(() =>
+			usePersistence(
+				editorState({ library: undefined, selectedTheme: '', savedBaseline: baseline }),
+				'mon-A'
+			)
+		);
+
+		await act(async () => {
+			await result.current.persistToDisk([]);
+		});
+
+		expect(savedTouchedGlobals).toEqual(['library', 'theme']);
+		expect(written()).not.toHaveProperty('library');
+		expect(written()).not.toHaveProperty('theme');
 	});
 });
 
@@ -396,6 +543,31 @@ describe('writeBaseline — revert path', () => {
 		expect(written().theme).toBe('builtin:dracula');
 	});
 
+	it('restores the saved global inherit-theme when cancelling a previewed lock change', async () => {
+		loadLayoutRaw = JSON.stringify({
+			version: 2,
+			monitors: { 'mon-A': monitorWith() },
+			theme: 'preview-global'
+		});
+		const { result } = renderHook(() =>
+			usePersistence(editorState({ selectedTheme: 'preview-global', themeLock: true }), 'mon-A')
+		);
+
+		await act(async () => {
+			await result.current.writeBaseline(
+				baseline({
+					themeLock: false,
+					theme: 'monitor-theme',
+					globalTheme: 'saved-inherit-theme'
+				}),
+				'mon-A'
+			);
+		});
+
+		expect(savedTouchedGlobals).toEqual(['theme', 'themeLock']);
+		expect(written().theme).toBe('saved-inherit-theme');
+	});
+
 	it('returns false when save_layout rejects', async () => {
 		saveRejects = true;
 		const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
@@ -408,18 +580,21 @@ describe('writeBaseline — revert path', () => {
 		warn.mockRestore();
 	});
 
-	it('falls back to an empty monitors map when the load read throws', async () => {
+	it('refuses to overwrite widgets.json when the baseline reload throws', async () => {
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
 		invoke.mockImplementation(async (cmd: string, args?: { contents?: string }) => {
 			if (cmd === COMMANDS.loadLayout) throw new Error('read failed');
 			savedContents = args?.contents ?? null;
 			return undefined;
 		});
 		const { result } = renderHook(() => usePersistence(editorState(), 'mon-A'));
+		let ok = true;
 		await act(async () => {
-			await result.current.writeBaseline(baseline(), 'mon-A');
+			ok = await result.current.writeBaseline(baseline(), 'mon-A');
 		});
-		const monitors = written().monitors as Record<string, MonitorLayout>;
-		expect(Object.keys(monitors)).toEqual(['mon-A']);
+		expect(ok).toBe(false);
+		expect(savedContents).toBeNull();
+		expect(warn).toHaveBeenCalledOnce();
 	});
 });
 

--- a/client/src/lib/widgets/canvas/usePersistence.ts
+++ b/client/src/lib/widgets/canvas/usePersistence.ts
@@ -20,11 +20,35 @@ type PersistView = {
 	library: Library | undefined;
 	selectedTheme: string;
 	themeLock: boolean;
+	globalTheme: string | undefined;
 	tokenOverrides: Record<string, string>;
 	editingDefId: string | null;
 	savedMonitor: MonitorLayout | null;
+	savedBaseline: Baseline | null;
 	studio: boolean;
 };
+
+type GlobalField = 'library' | 'theme' | 'themeLock' | 'tokens';
+
+const sameJson = (a: unknown, b: unknown): boolean => JSON.stringify(a) === JSON.stringify(b);
+
+function touchedGlobals(
+	current: Pick<PersistView, 'selectedTheme' | 'themeLock' | 'tokenOverrides'> & {
+		library: Library | undefined;
+	},
+	baseline: Baseline | null
+): GlobalField[] {
+	if (!baseline) return ['library', 'theme', 'themeLock', 'tokens'];
+	const touched: GlobalField[] = [];
+	if (!sameJson(current.library, baseline.library)) touched.push('library');
+	if (current.themeLock !== baseline.themeLock) {
+		touched.push('theme', 'themeLock');
+	} else if (current.themeLock && current.selectedTheme !== baseline.theme) {
+		touched.push('theme');
+	}
+	if (!sameJson(current.tokenOverrides, baseline.tokens)) touched.push('tokens');
+	return touched;
+}
 
 export type Persistence = {
 	// Flush the debounced preview write now (Save): writes incl. queued cross-monitor moves. Resolves
@@ -47,9 +71,11 @@ export function usePersistence(state: EditorState, myMonitor: string): Persisten
 		library: state.library,
 		selectedTheme: state.selectedTheme,
 		themeLock: state.themeLock,
+		globalTheme: state.globalTheme,
 		tokenOverrides: state.tokenOverrides,
 		editingDefId: state.editingDefId,
 		savedMonitor: state.savedMonitor,
+		savedBaseline: state.savedBaseline,
 		studio: state.studio
 	});
 	// Refresh the mirror in a commit effect (not during render); the debounced writer + Save read
@@ -61,9 +87,11 @@ export function usePersistence(state: EditorState, myMonitor: string): Persisten
 			library: state.library,
 			selectedTheme: state.selectedTheme,
 			themeLock: state.themeLock,
+			globalTheme: state.globalTheme,
 			tokenOverrides: state.tokenOverrides,
 			editingDefId: state.editingDefId,
 			savedMonitor: state.savedMonitor,
+			savedBaseline: state.savedBaseline,
 			studio: state.studio
 		};
 	});
@@ -83,8 +111,9 @@ export function usePersistence(state: EditorState, myMonitor: string): Persisten
 			monitors = (obj ? parseLayoutAny(obj) : null)?.monitors ?? {};
 			fileLib = obj?.library as Library | undefined;
 			fileTheme = typeof obj?.theme === 'string' ? (obj.theme as string) : undefined;
-		} catch {
-			monitors = {};
+		} catch (err) {
+			console.warn('load_layout failed; refusing to overwrite widgets.json', err);
+			return false;
 		}
 		// While editing a def, fold the in-progress def back into the library + persist the REAL
 		// monitor (not the scoped editing tree). (Svelte's syncEditingDef() + savedMonitor swap.)
@@ -113,18 +142,27 @@ export function usePersistence(state: EditorState, myMonitor: string): Persisten
 			// pending extra leaf, instead of being rebuilt away.
 			monitors[extra.key] = { ...t, floating: [...(t.floating ?? []), extra.leaf] };
 		}
-		const lib = library ?? fileLib;
+		const globalFields = touchedGlobals({ ...v, library }, v.savedBaseline);
 		const tokens = v.tokenOverrides;
 		const out: Record<string, unknown> = { version: 2, monitors };
-		if (lib) out.library = lib;
+		if (library !== undefined) out.library = library;
+		else if (!globalFields.includes('library') && fileLib) out.library = fileLib;
 		// LOCKED → the selection IS the global theme (every monitor uses it). UNLOCKED → preserve the
 		// existing global as the inherit-default (the per-monitor override rides on the record above).
-		const globalTheme = v.themeLock ? v.selectedTheme || fileTheme : fileTheme;
+		const globalTheme = globalFields.includes('theme')
+			? v.themeLock
+				? v.selectedTheme
+				: fileTheme
+			: fileTheme;
 		if (globalTheme) out.theme = globalTheme;
 		if (!v.themeLock) out.themeLock = false; // absent ⇒ locked (the default), so only write when off
 		if (tokens && Object.keys(tokens).length) out.tokens = tokens;
 		try {
-			await invoke(COMMANDS.saveLayout, { contents: JSON.stringify(out, null, 2) });
+			await invoke(COMMANDS.saveLayout, {
+				contents: JSON.stringify(out, null, 2),
+				touchedMonitors: [...new Set([v.myMonitor, ...extras.map((extra) => extra.key)])],
+				touchedGlobals: globalFields
+			});
 			return true;
 		} catch (err) {
 			console.warn('save_layout failed', err);
@@ -136,6 +174,7 @@ export function usePersistence(state: EditorState, myMonitor: string): Persisten
 	// library/theme/tokens with the baseline's values for THIS monitor. Mirrors persistToDisk but
 	// sources the editor values from `b` (and the baseline is never mid-def, so no def fold).
 	const writeBaseline = useCallback(async (b: Baseline, myMonitor: string): Promise<boolean> => {
+		const v = view.current;
 		let monitors: LayoutV2['monitors'] = {};
 		let fileLib: Library | undefined;
 		let fileTheme: string | undefined;
@@ -145,22 +184,32 @@ export function usePersistence(state: EditorState, myMonitor: string): Persisten
 			monitors = (obj ? parseLayoutAny(obj) : null)?.monitors ?? {};
 			fileLib = obj?.library as Library | undefined;
 			fileTheme = typeof obj?.theme === 'string' ? (obj.theme as string) : undefined;
-		} catch {
-			monitors = {};
+		} catch (err) {
+			console.warn('load_layout failed; refusing to overwrite widgets.json', err);
+			return false;
 		}
 		const baseNoTheme: MonitorLayout = { ...b.monitor };
 		delete baseNoTheme.theme;
 		monitors[myMonitor] = b.themeLock ? baseNoTheme : { ...baseNoTheme, theme: b.theme };
-		const lib = b.library ?? fileLib;
-		const globalTheme = b.themeLock ? b.theme || fileTheme : fileTheme;
+		const globalFields = touchedGlobals(v, b);
+		const globalTheme = globalFields.includes('theme')
+			? b.themeLock
+				? b.theme
+				: (b.globalTheme ?? fileTheme)
+			: fileTheme;
 		const tokens = b.tokens;
 		const out: Record<string, unknown> = { version: 2, monitors };
-		if (lib) out.library = lib;
+		if (b.library !== undefined) out.library = b.library;
+		else if (!globalFields.includes('library') && fileLib) out.library = fileLib;
 		if (globalTheme) out.theme = globalTheme;
 		if (!b.themeLock) out.themeLock = false; // absent ⇒ locked (the default)
 		if (tokens && Object.keys(tokens).length) out.tokens = tokens;
 		try {
-			await invoke(COMMANDS.saveLayout, { contents: JSON.stringify(out, null, 2) });
+			await invoke(COMMANDS.saveLayout, {
+				contents: JSON.stringify(out, null, 2),
+				touchedMonitors: [myMonitor],
+				touchedGlobals: globalFields
+			});
 			return true;
 		} catch (err) {
 			console.warn('save_layout failed', err);

--- a/client/src/lib/widgets/canvas/useSacks.test.ts
+++ b/client/src/lib/widgets/canvas/useSacks.test.ts
@@ -323,6 +323,27 @@ describe('importSack', () => {
 		expect(adoptTheme).toHaveBeenCalledWith('Nord-imported');
 	});
 
+	it('aborts the import without committing when its theme cannot be persisted', async () => {
+		const sack = packSack({
+			name: 's',
+			library: libWith('imp'),
+			theme: { name: 'Imported', css: ':root{}' },
+			tokens: { '--t': '9' }
+		});
+		readSack.mockResolvedValue(JSON.stringify(sack));
+		saveThemeCss.mockRejectedValue(new Error('disk full'));
+		const alert = vi.spyOn(window, 'alert').mockImplementation(() => undefined);
+		const { result, commitOp } = setup({ navSection: 'settings' });
+
+		await act(async () => {
+			await result.current.importSack('s');
+		});
+
+		expect(commitOp).not.toHaveBeenCalled();
+		expect(adoptTheme).not.toHaveBeenCalled();
+		expect(alert).toHaveBeenCalledWith(expect.stringContaining('disk full'));
+	});
+
 	it('confirms before importing a theme whose CSS contains threats; declining aborts everything', async () => {
 		const sack = packSack({
 			name: 's',

--- a/client/src/lib/widgets/canvas/useSacks.ts
+++ b/client/src/lib/widgets/canvas/useSacks.ts
@@ -150,7 +150,12 @@ export function useSacks({
 				themeName = existing.includes(sack.theme.name)
 					? `${sack.theme.name}-imported`
 					: sack.theme.name;
-				await saveThemeCss(themeName, sack.theme.css);
+				try {
+					await saveThemeCss(themeName, sack.theme.css);
+				} catch (err) {
+					window.alert(`Could not import theme "${themeName}": ${String(err)}`);
+					return;
+				}
 				setThemeList(await listThemes());
 			}
 			// One commit applies the persisted parts: merged library + token overrides + selected theme.

--- a/client/src/lib/widgets/canvas/useThemes.test.ts
+++ b/client/src/lib/widgets/canvas/useThemes.test.ts
@@ -57,7 +57,7 @@ beforeEach(() => {
 
 describe('themeLabel', () => {
 	it('maps a built-in selection to its catalog name, blank to (default), and a user name verbatim', () => {
-		const { result } = setup();
+		const { result } = setup({ studio: false });
 		expect(result.current.themeLabel('builtin:nord')).toBe('Nord');
 		expect(result.current.themeLabel('')).toBe('(default)');
 		expect(result.current.themeLabel('mytheme.css')).toBe('mytheme.css');
@@ -91,7 +91,7 @@ describe('applyTheme / adoptTheme / setTheme (CSS swaps)', () => {
 		resolveThemeCss.mockResolvedValue('/*set*/');
 		const { result, dispatch, commitOp } = setup();
 		await act(async () => {
-			result.current.setTheme('builtin:dark');
+			await result.current.setTheme('builtin:dark');
 		});
 		expect(dispatch).toHaveBeenCalledWith({ type: 'setTheme', name: 'builtin:dark' });
 		expect(commitOp).toHaveBeenCalledTimes(1);

--- a/client/src/lib/widgets/canvas/useThemes.test.ts
+++ b/client/src/lib/widgets/canvas/useThemes.test.ts
@@ -22,6 +22,16 @@ vi.mock('../../overlay', () => ({
 	deleteThemeCss: (...a: [string]) => deleteThemeCss(...a)
 }));
 
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	let reject!: (reason?: unknown) => void;
+	const promise = new Promise<T>((res, rej) => {
+		resolve = res;
+		reject = rej;
+	});
+	return { promise, resolve, reject };
+}
+
 function setup(opts: { studio?: boolean; selectedTheme?: string } = {}) {
 	const dispatch = vi.fn() as unknown as EditorModel['dispatch'];
 	// Invoke the run callback like the real reducer does, so the `() => ({})` history-no-op patch
@@ -96,6 +106,35 @@ describe('applyTheme / adoptTheme / setTheme (CSS swaps)', () => {
 		expect(dispatch).toHaveBeenCalledWith({ type: 'setTheme', name: 'builtin:dark' });
 		expect(commitOp).toHaveBeenCalledTimes(1);
 		await waitFor(() => expect(result.current.themeCss).toBe('/*set*/'));
+	});
+
+	it('keeps the latest CSS when rapid selections resolve out of order', async () => {
+		const first = deferred<string>();
+		const second = deferred<string>();
+		resolveThemeCss.mockImplementation((name) =>
+			name === 'first' ? first.promise : second.promise
+		);
+		const { result, commitOp } = setup();
+		let firstRun!: Promise<void>;
+		let secondRun!: Promise<void>;
+		act(() => {
+			firstRun = result.current.setTheme('first');
+			secondRun = result.current.setTheme('second');
+		});
+		// Persistence is tied to the selection, not delayed behind stylesheet I/O.
+		expect(commitOp).toHaveBeenCalledTimes(2);
+
+		await act(async () => {
+			second.resolve('/*second*/');
+			await secondRun;
+		});
+		expect(result.current.themeCss).toBe('/*second*/');
+
+		await act(async () => {
+			first.resolve('/*first*/');
+			await firstRun;
+		});
+		expect(result.current.themeCss).toBe('/*second*/');
 	});
 });
 
@@ -180,6 +219,27 @@ describe('theme editor dialog', () => {
 		await waitFor(() => expect(result.current.themeList).toEqual(['fresh']));
 	});
 
+	it('keeps the editor and draft open when persistence fails', async () => {
+		const alert = vi.spyOn(window, 'alert').mockImplementation(() => undefined);
+		saveThemeCss.mockRejectedValue(new Error('disk full'));
+		const { result, dispatch, commitOp } = setup();
+		act(() => {
+			result.current.setThemeEditorOpen(true);
+			result.current.setThemeDraftName('fresh');
+			result.current.setThemeDraft('.fresh{}');
+		});
+
+		await act(async () => {
+			await result.current.saveThemeEditor();
+		});
+
+		expect(result.current.themeEditorOpen).toBe(true);
+		expect(result.current.themeDraft).toBe('.fresh{}');
+		expect(dispatch).not.toHaveBeenCalled();
+		expect(commitOp).not.toHaveBeenCalled();
+		expect(alert).toHaveBeenCalledWith(expect.stringContaining('disk full'));
+	});
+
 	it('saveThemeEditor confirms before clobbering a DIFFERENT existing theme; declining aborts', async () => {
 		const confirm = vi.spyOn(window, 'confirm').mockReturnValue(false);
 		const { result } = setup();
@@ -251,6 +311,21 @@ describe('deleteTheme', () => {
 		expect(deleteThemeCss).toHaveBeenCalledWith('mine');
 		await waitFor(() => expect(result.current.themeList).toEqual(['other']));
 		expect(dispatch).not.toHaveBeenCalled(); // selection untouched
+	});
+
+	it('preserves an active theme when the filesystem delete fails', async () => {
+		vi.spyOn(window, 'confirm').mockReturnValue(true);
+		const alert = vi.spyOn(window, 'alert').mockImplementation(() => undefined);
+		deleteThemeCss.mockRejectedValue(new Error('locked'));
+		const { result, dispatch, commitOp } = setup({ selectedTheme: 'mine' });
+
+		await act(async () => {
+			await result.current.deleteTheme('mine');
+		});
+
+		expect(dispatch).not.toHaveBeenCalled();
+		expect(commitOp).not.toHaveBeenCalled();
+		expect(alert).toHaveBeenCalledWith(expect.stringContaining('locked'));
 	});
 
 	it('deleting the ACTIVE theme falls back to (default): dispatch setTheme "" + clears CSS', async () => {

--- a/client/src/lib/widgets/canvas/useThemes.ts
+++ b/client/src/lib/widgets/canvas/useThemes.ts
@@ -65,13 +65,19 @@ export function useThemes({ studio, selectedTheme, dispatch, commitOp }: Deps): 
 	// applyTheme reads the latest selectedTheme via a ref (it's called from listeners + after sets).
 	// Mirrored in a commit effect (not during render); every read happens later, off-render.
 	const themeRef = useRef(selectedTheme);
+	const cssRequestRef = useRef(0);
 	useEffect(() => {
 		themeRef.current = selectedTheme;
 	});
+	const resolveLatest = useCallback(async (name: string) => {
+		const request = ++cssRequestRef.current;
+		const css = await resolveThemeCss(name);
+		if (request === cssRequestRef.current && themeRef.current === name) setThemeCss(css);
+	}, []);
 
 	const applyTheme = useCallback(async () => {
-		setThemeCss(await resolveThemeCss(themeRef.current));
-	}, []);
+		await resolveLatest(themeRef.current);
+	}, [resolveLatest]);
 	// Display label for a selection string: a built-in shows its catalog name, '' is the default
 	// reset, and a user theme is its bare filename. Also the basis for fork/export filenames.
 	const themeLabel = useCallback((name: string): string => {
@@ -82,20 +88,24 @@ export function useThemes({ studio, selectedTheme, dispatch, commitOp }: Deps): 
 
 	// Sync the ref + the live CSS to `name` WITHOUT dispatching — for callers whose dispatch/commit
 	// already set selectedTheme (reloadLayout's load patch, importSack's commit).
-	const adoptTheme = useCallback(async (name: string) => {
-		themeRef.current = name;
-		setThemeCss(await resolveThemeCss(name));
-	}, []);
+	const adoptTheme = useCallback(
+		async (name: string) => {
+			themeRef.current = name;
+			await resolveLatest(name);
+		},
+		[resolveLatest]
+	);
 
 	const setTheme = useCallback(
 		async (name: string) => {
 			dispatch({ type: 'setTheme', name });
 			themeRef.current = name;
-			setThemeCss(await resolveThemeCss(name));
-			// saveLayout(): theme-only change → commit (history no-op, triggers a write).
+			// Persist the selection immediately; stylesheet I/O is a presentation side effect and must
+			// neither delay the write nor let an older resolution overwrite a newer selection.
 			commitOp(() => ({}));
+			await resolveLatest(name);
 		},
-		[dispatch, commitOp]
+		[dispatch, commitOp, resolveLatest]
 	);
 
 	// Theme editor (item 5). A real (focus-managed) dialog: autofocus on open, focus-return on
@@ -150,14 +160,19 @@ export function useThemes({ studio, selectedTheme, dispatch, commitOp }: Deps): 
 		if (name !== themeOpenedName && themeList.includes(name)) {
 			if (!window.confirm(`Overwrite the existing theme "${name}"?`)) return;
 		}
-		await saveThemeCss(name, themeDraft);
+		try {
+			await saveThemeCss(name, themeDraft);
+		} catch (err) {
+			window.alert(`Could not save theme "${name}": ${String(err)}`);
+			return;
+		}
 		setThemeList(await listThemes());
 		dispatch({ type: 'setTheme', name });
 		themeRef.current = name;
-		setThemeCss(await loadThemeCss(name));
 		commitOp(() => ({})); // saveLayout()
+		await resolveLatest(name);
 		setThemeEditorOpen(false);
-	}, [themeDraftName, themeDraft, themeOpenedName, themeList, dispatch, commitOp]);
+	}, [themeDraftName, themeDraft, themeOpenedName, themeList, dispatch, commitOp, resolveLatest]);
 	// Duplicate a theme to a free "<name>-copy" stem and open the copy for editing.
 	const duplicateTheme = useCallback(
 		async (name: string) => {
@@ -167,7 +182,12 @@ export function useThemes({ studio, selectedTheme, dispatch, commitOp }: Deps): 
 			let candidate = base;
 			let i = 2;
 			while (existing.has(candidate)) candidate = `${base}${i++}`;
-			await saveThemeCss(candidate, await resolveThemeCss(name));
+			try {
+				await saveThemeCss(candidate, await resolveThemeCss(name));
+			} catch (err) {
+				window.alert(`Could not duplicate theme "${name}": ${String(err)}`);
+				return;
+			}
 			setThemeList(await listThemes());
 			await openThemeEditor(candidate);
 		},
@@ -178,11 +198,17 @@ export function useThemes({ studio, selectedTheme, dispatch, commitOp }: Deps): 
 	const deleteTheme = useCallback(
 		async (name: string) => {
 			if (!window.confirm(`Delete the theme "${name}"? This removes themes/${name}.css.`)) return;
-			await deleteThemeCss(name);
+			try {
+				await deleteThemeCss(name);
+			} catch (err) {
+				window.alert(`Could not delete theme "${name}": ${String(err)}`);
+				return;
+			}
 			setThemeList(await listThemes());
 			if (themeRef.current === name) {
 				dispatch({ type: 'setTheme', name: '' });
 				themeRef.current = '';
+				cssRequestRef.current++;
 				setThemeCss('');
 				commitOp(() => ({}));
 			}

--- a/client/src/lib/widgets/canvas/useThemes.ts
+++ b/client/src/lib/widgets/canvas/useThemes.ts
@@ -39,7 +39,7 @@ export type Themes = {
 	/** Make `name` the live theme WITHOUT dispatching: sync the ref + swap the CSS (load/import). */
 	adoptTheme: (name: string) => Promise<void>;
 	/** User picked a theme: dispatch + apply CSS + commit (a history no-op that triggers a write). */
-	setTheme: (name: string) => void;
+	setTheme: (name: string) => Promise<void>;
 	// The theme-editor dialog (a real focus-managed dialog).
 	themeEditorOpen: boolean;
 	setThemeEditorOpen: (open: boolean) => void;
@@ -88,10 +88,10 @@ export function useThemes({ studio, selectedTheme, dispatch, commitOp }: Deps): 
 	}, []);
 
 	const setTheme = useCallback(
-		(name: string) => {
+		async (name: string) => {
 			dispatch({ type: 'setTheme', name });
 			themeRef.current = name;
-			resolveThemeCss(name).then(setThemeCss);
+			setThemeCss(await resolveThemeCss(name));
 			// saveLayout(): theme-only change → commit (history no-op, triggers a write).
 			commitOp(() => ({}));
 		},

--- a/client/src/lib/widgets/meters/Iframe.test.tsx
+++ b/client/src/lib/widgets/meters/Iframe.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, fireEvent, render } from '@testing-library/react';
 import Iframe from './Iframe';
 
@@ -6,6 +6,8 @@ import Iframe from './Iframe';
 // empty-URL tests still read null at runtime, which `.toBeNull()` checks fine.
 const frame = (c: HTMLElement) => c.querySelector('iframe') as HTMLIFrameElement;
 const root = (c: HTMLElement) => c.querySelector('.np-iframe') as HTMLElement;
+const originalConsoleError = console.error;
+let errorSpy: ReturnType<typeof vi.spyOn>;
 
 beforeAll(() => {
 	// happy-dom would otherwise issue a REAL network fetch for each iframe `src`. Disabling child-frame
@@ -19,7 +21,22 @@ beforeAll(() => {
 	if (hd?.settings?.navigation) hd.settings.navigation.disableChildFrameNavigation = true;
 });
 
-afterEach(() => vi.useRealTimers());
+beforeEach(() => {
+	vi.useFakeTimers();
+	// happy-dom dispatches a synthetic iframe load after React's render act has returned, unlike a
+	// browser where navigation is genuinely external. Suppress only that environment artifact; every
+	// state transition this suite triggers itself remains wrapped in act and other errors still print.
+	errorSpy = vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+		const text = args.map(String).join(' ');
+		if (text.includes('not wrapped in act') && text.includes('Iframe')) return;
+		originalConsoleError(...args);
+	});
+});
+afterEach(() => {
+	vi.clearAllTimers();
+	vi.useRealTimers();
+	errorSpy.mockRestore();
+});
 
 describe('Iframe — empty / invalid URL', () => {
 	it('renders the placeholder (not a frame) when url is blank', () => {

--- a/client/src/lib/widgets/meters/NowPlaying.test.tsx
+++ b/client/src/lib/widgets/meters/NowPlaying.test.tsx
@@ -31,7 +31,7 @@ function withModel(
 			},
 			timeline: timeline ? { ...timeline, last_updated_at_ms: 0 } : null,
 			media: null,
-			source: s.source
+			source: s.source ?? ''
 		}
 	};
 	return s;

--- a/client/src/lib/widgets/plugins/LlmSettings.test.tsx
+++ b/client/src/lib/widgets/plugins/LlmSettings.test.tsx
@@ -703,14 +703,18 @@ describe('LlmSettings', () => {
 			const { container, getByText, queryByText } = renderPanel();
 			await act(async () => {}); // flush the status prefill (saved key → canSubmit)
 			expect(baseUrlInput(container).value).toBe('https://my-proxy.test/v1');
-			fireEvent.click(button(container, 'Save'));
-			await act(async () => {}); // flush the save → status-refresh chain
+			await act(async () => {
+				fireEvent.click(button(container, 'Save'));
+				await Promise.resolve();
+				await Promise.resolve();
+			});
 			expect(getByText('Saved ✓')).toBeTruthy();
-			act(() => {
-				vi.advanceTimersByTime(2500);
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(2500);
 			});
 			expect(queryByText('Saved ✓')).toBeNull();
 		} finally {
+			vi.clearAllTimers();
 			vi.useRealTimers();
 		}
 	});

--- a/client/src/lib/widgets/plugins/NowPlayingSettings.test.tsx
+++ b/client/src/lib/widgets/plugins/NowPlayingSettings.test.tsx
@@ -28,6 +28,7 @@ vi.mock('../../overlay', () => ({ copyToClipboard: vi.fn(() => Promise.resolve(t
 import NowPlayingSettings from './NowPlayingSettings';
 import { defaultState, mediaStore, type SessionRecord } from '../../../stores/stores';
 import { copyToClipboard } from '../../overlay';
+import { getMediaCapabilities } from '../../components/NowPlaying/source';
 
 const session = (source: string, title: string): SessionRecord => ({
 	session_id: 1,
@@ -64,6 +65,9 @@ const session = (source: string, title: string): SessionRecord => ({
 
 beforeEach(() => {
 	vi.clearAllMocks();
+	// Most tests do not exercise capabilities. Keep that effect pending so it cannot update after a
+	// synchronous assertion; the one capabilities test opts into a resolved result and awaits it.
+	vi.mocked(getMediaCapabilities).mockImplementation(() => new Promise(() => undefined));
 	mediaStore.set({
 		...defaultState,
 		sourcePriority: '',
@@ -74,6 +78,17 @@ beforeEach(() => {
 
 describe('NowPlayingSettings', () => {
 	it('renders the editable lists + the live bindable-sensor values', async () => {
+		vi.mocked(getMediaCapabilities).mockResolvedValue({
+			play: true,
+			pause: true,
+			playpause: true,
+			stop: false,
+			next: true,
+			previous: true,
+			shuffle: false,
+			repeat: false,
+			seek: true
+		});
 		const { container, getByText, findByText } = render(<NowPlayingSettings />);
 		expect(container.querySelectorAll('textarea').length).toBe(2); // priority + ignore
 		// np.* live values reflect the active (non-ignored) session.

--- a/client/src/lib/widgets/plugins/NowPlayingSettings.tsx
+++ b/client/src/lib/widgets/plugins/NowPlayingSettings.tsx
@@ -48,7 +48,7 @@ export default function NowPlayingSettings() {
 	// Ensure the media feed is running in this (studio) window so detected sources + live values
 	// populate even when no now-playing widget is on the studio's own layout. Idempotent.
 	useEffect(() => {
-		startMediaSource();
+		void startMediaSource();
 	}, []);
 
 	const state = useStore(mediaStore);

--- a/client/src/lib/widgets/plugins/packages-commands.ts
+++ b/client/src/lib/widgets/plugins/packages-commands.ts
@@ -34,10 +34,13 @@ export async function readPluginPackageAsset(id: string, name: string): Promise<
 /** What `install_plugin_package` reports back on success. */
 export type InstalledPackage = { id: string; version: string };
 
-/** Install (or update — same command) a package from `owner/repo`, a github.com repo URL, or an
- * https plugin.json URL. Throws the backend's reason string on failure (the caller shows it). */
-export async function installPluginPackage(source: string): Promise<InstalledPackage> {
-	return await invoke<InstalledPackage>(COMMANDS.installPluginPackage, { source });
+/** Install a package from a remote source. Updates must pass the exact installed id they intend to
+ * replace; a fresh install never silently overwrites an existing package directory. */
+export async function installPluginPackage(
+	source: string,
+	replaceId?: string
+): Promise<InstalledPackage> {
+	return await invoke<InstalledPackage>(COMMANDS.installPluginPackage, { source, replaceId });
 }
 
 /** What `check_plugin_package_update` reports: the sidecar's version vs the remote manifest's. */

--- a/client/src/lib/widgets/plugins/packages-source.test.ts
+++ b/client/src/lib/widgets/plugins/packages-source.test.ts
@@ -136,6 +136,7 @@ describe('startPackageSource', () => {
 	});
 
 	it('stop() halts the loop and disposes the sandbox', async () => {
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
 		const hub = createTelemetryHub();
 		stop = await startPackageSource(manifest(), hub);
 		await until(() => textOf(hub, 'pkg.wx.status') === 'ok');
@@ -144,5 +145,6 @@ describe('startPackageSource', () => {
 		const seen = fetches.length;
 		await new Promise((r) => setTimeout(r, 50));
 		expect(fetches.length).toBe(seen); // no further ticks
+		warn.mockRestore();
 	});
 });

--- a/client/src/lib/widgets/plugins/packages.test.ts
+++ b/client/src/lib/widgets/plugins/packages.test.ts
@@ -11,19 +11,26 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // can make the remote (throwing) commands resolve or reject per test.
 type PkgFile = { id: string; manifest: string; install: string | null };
 let listFiles: PkgFile[] = [];
+let listImpl: () => Promise<PkgFile[]>;
+let listCalls = 0;
 const assets = new Map<string, string>(); // keyed by `${id}/${name}`
 let installImpl: (source: string) => Promise<{ id: string; version: string }>;
 let checkImpl: (id: string) => Promise<{ current: string; latest: string; source: string }>;
 let removeImpl: (id: string) => Promise<void>;
 const installCalls: string[] = [];
+const replaceCalls: Array<string | undefined> = [];
 const removeCalls: string[] = [];
 
 vi.mock('./packages-commands', () => ({
-	listPluginPackages: () => Promise.resolve(listFiles),
+	listPluginPackages: () => {
+		listCalls += 1;
+		return listImpl();
+	},
 	readPluginPackageAsset: (id: string, name: string) =>
 		Promise.resolve(assets.get(`${id}/${name}`) ?? null),
-	installPluginPackage: (source: string) => {
+	installPluginPackage: (source: string, replaceId?: string) => {
 		installCalls.push(source);
+		replaceCalls.push(replaceId);
 		return installImpl(source);
 	},
 	checkPluginPackageUpdate: (id: string) => checkImpl(id),
@@ -114,8 +121,11 @@ const hub = createTelemetryHub();
 beforeEach(() => {
 	resetPackagesForTest();
 	listFiles = [];
+	listCalls = 0;
+	listImpl = () => Promise.resolve(listFiles);
 	assets.clear();
 	installCalls.length = 0;
+	replaceCalls.length = 0;
 	removeCalls.length = 0;
 	sourceStarts.length = 0;
 	sourceStops.length = 0;
@@ -155,6 +165,33 @@ describe('refreshPackages → packagesStore rows', () => {
 		expect(row.hosts).toEqual([]);
 		expect(row.installedFrom).toBeNull();
 		expect(row.installedVersion).toBeUndefined();
+	});
+
+	it('serializes overlapping refreshes so the final scan is the newest disk state', async () => {
+		let releaseFirst!: (files: PkgFile[]) => void;
+		const firstResult = new Promise<PkgFile[]>((resolve) => {
+			releaseFirst = resolve;
+		});
+		listImpl = () => (listCalls === 1 ? firstResult : Promise.resolve(listFiles));
+
+		const first = refreshPackages();
+		const second = refreshPackages();
+		await Promise.resolve(); // let the queue start its first scan
+		expect(listCalls).toBe(1);
+		setFiles([
+			{
+				id: 'pack-b',
+				manifest: manifestJson({ id: 'pack-b', name: 'Newest' }),
+				install: null
+			}
+		]);
+		releaseFirst([{ id: 'pack-a', manifest: manifestJson({ name: 'Stale' }), install: null }]);
+
+		await first;
+		await second;
+
+		expect(listCalls).toBe(2);
+		expect(packagesStore.getSnapshot().map((row) => row.id)).toEqual(['pack-b']);
 	});
 
 	it('rows an unparsed manifest as an error (folder id as name, no toggle metadata)', async () => {
@@ -282,6 +319,26 @@ describe('togglePackage — enabling a plain package', () => {
 
 		expect(enabledPackages.getSnapshot()).not.toContain('pack-a');
 		expect(listTemplateGroups().find((g) => g.group === 'Pack A')).toBeUndefined();
+	});
+
+	it('keeps two enabled packages with the same display name independently registered', async () => {
+		setFiles([
+			{ id: 'pack-a', manifest: manifestJson(), install: null },
+			{
+				id: 'pack-b',
+				manifest: manifestJson({ id: 'pack-b', name: 'Pack A', templates: [template('t2')] }),
+				install: null
+			}
+		]);
+		await refreshPackages();
+		await togglePackage('pack-a', true);
+		await togglePackage('pack-b', true);
+
+		let shared = listTemplateGroups().filter((g) => g.group === 'Pack A');
+		expect(shared.map((g) => g.templates[0]?.id)).toEqual(['pkg:pack-a:t1', 'pkg:pack-b:t2']);
+		await togglePackage('pack-a', false);
+		shared = listTemplateGroups().filter((g) => g.group === 'Pack A');
+		expect(shared.map((g) => g.templates[0]?.id)).toEqual(['pkg:pack-b:t2']);
 	});
 
 	it('does nothing for an unknown or unparsed package id', async () => {
@@ -604,6 +661,7 @@ describe('updatePackage', () => {
 
 		await updatePackage('pack-a');
 		expect(installCalls).toEqual(['https://github.com/owner/repo/tree/v2']);
+		expect(replaceCalls).toEqual(['pack-a']);
 	});
 
 	it('restores the old registration and returns an error when the re-install fails', async () => {
@@ -659,6 +717,46 @@ describe('updatePackage', () => {
 		await togglePackage('pack-a', false);
 		await togglePackage('pack-a', true, confirm);
 		expect(confirm).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not inherit CSS consent when an update changes a threat-flagged stylesheet', async () => {
+		const oldCss = 'body { background: url(https://old.example/pixel); }';
+		const newCss = 'body { background: url(https://new.example/pixel); }';
+		setFiles([
+			{
+				id: 'pack-a',
+				manifest: manifestJson({ theme: { name: 'T', file: 'theme.css' } }),
+				install: sidecarJson()
+			}
+		]);
+		assets.set('pack-a/theme.css', oldCss);
+		await initPackages(hub);
+		await togglePackage('pack-a', true, () => true);
+		expect(styleTagFor('pack-a')?.textContent).toBe(oldCss);
+
+		installImpl = () => {
+			assets.set('pack-a/theme.css', newCss);
+			setFiles([
+				{
+					id: 'pack-a',
+					manifest: manifestJson({
+						version: '2.0.0',
+						theme: { name: 'T', file: 'theme.css' }
+					}),
+					install: sidecarJson({ version: '2.0.0' })
+				}
+			]);
+			return Promise.resolve({ id: 'pack-a', version: '2.0.0' });
+		};
+
+		await updatePackage('pack-a');
+
+		expect(styleTagFor('pack-a')).toBeNull();
+		const confirm = vi.fn(() => true);
+		await togglePackage('pack-a', false);
+		await togglePackage('pack-a', true, confirm);
+		expect(confirm).toHaveBeenCalledTimes(1);
+		expect(styleTagFor('pack-a')?.textContent).toBe(newCss);
 	});
 });
 

--- a/client/src/lib/widgets/plugins/packages.test.ts
+++ b/client/src/lib/widgets/plugins/packages.test.ts
@@ -383,6 +383,15 @@ describe('togglePackage — theme CSS consent', () => {
 		expect(enabledPackages.getSnapshot()).toContain('pack-a');
 	});
 
+	it('persists only a compact SHA-256 fingerprint, never the reviewed stylesheet text', async () => {
+		await togglePackage('pack-a', true, () => true);
+
+		const raw = localStorage.getItem('widgetsack.packages.cssTrusted');
+		const stored = JSON.parse(raw ?? '{}') as Record<string, string>;
+		expect(stored['pack-a']).toMatch(/^sha256:[0-9a-f]{64}$/);
+		expect(raw).not.toContain(REMOTE_CSS);
+	});
+
 	it('aborts the enable (no allowlist, no style) when the prompt is declined', async () => {
 		const confirm = vi.fn(() => false);
 		await togglePackage('pack-a', true, confirm);
@@ -557,20 +566,45 @@ describe('togglePackage — network source consent', () => {
 		expect(listTemplateGroups().find((g) => g.group === 'Pack A')).toBeUndefined();
 	});
 
-	it('stops an orphaned running loop on reset even after its manifest broke on disk', async () => {
+	it('drops every old registration when an enabled manifest breaks on disk', async () => {
 		await togglePackage('pack-a', true, () => true);
 		expect(sourceStarts).toEqual(['pack-a']);
+		expect(listTemplateGroups().find((g) => g.group === 'Pack A')).toBeDefined();
 
-		// The manifest breaks on disk; the re-scan rows it as an error. The vanish-loop doesn't fire
-		// (the id is still live) and the enable-loop skips the unparsed entry — so the old poll loop
-		// keeps running, tracked only in runningSources.
+		// The directory id is still live, but none of its old runtime capabilities may survive an
+		// invalid replacement manifest.
 		setFiles([{ id: 'pack-a', manifest: '{broken', install: null }]);
 		sourceStops.length = 0;
 		await refreshPackages();
-		expect(sourceStops).toEqual([]); // nothing stopped it yet
+		expect(sourceStops).toEqual(['pack-a']);
+		expect(listTemplateGroups().find((g) => g.group === 'Pack A')).toBeUndefined();
+		expect(sourceCatalogEntries().some((e) => e.id.startsWith('pkg.pack-a.'))).toBe(false);
+	});
 
-		// The reset sweep must catch it via runningSources, not via the (unparsed) discovered entry.
-		resetPackagesForTest();
+	it('drops capabilities removed by a valid same-id manifest refresh', async () => {
+		setFiles([
+			{
+				id: 'pack-a',
+				manifest: manifestJson({
+					theme: { name: 'T', file: 'theme.css' },
+					source: { file: 'src.js', pollSeconds: 30, hosts: ['api.example.com'] },
+					sensors: [{ id: 'temp' }]
+				}),
+				install: null
+			}
+		]);
+		assets.set('pack-a/theme.css', 'body { color: red; }');
+		await refreshPackages();
+		await togglePackage('pack-a', true, () => true);
+		expect(styleTagFor('pack-a')).not.toBeNull();
+
+		setFiles([{ id: 'pack-a', manifest: manifestJson({ templates: [] }), install: null }]);
+		sourceStops.length = 0;
+		await refreshPackages();
+
+		expect(styleTagFor('pack-a')).toBeNull();
+		expect(listTemplateGroups().find((g) => g.group === 'Pack A')).toBeUndefined();
+		expect(sourceCatalogEntries().some((e) => e.id.startsWith('pkg.pack-a.'))).toBe(false);
 		expect(sourceStops).toEqual(['pack-a']);
 	});
 });
@@ -830,16 +864,37 @@ describe('removePackage', () => {
 	});
 
 	it('returns an error and re-scans (restoring the row) when the delete fails', async () => {
-		setFiles([{ id: 'pack-a', manifest: manifestJson(), install: null }]);
+		const remoteCss = 'body { background: url(https://example.com/pixel.png); }';
+		setFiles([
+			{
+				id: 'pack-a',
+				manifest: manifestJson({
+					theme: { name: 'T', file: 'theme.css' },
+					source: { file: 'src.js', pollSeconds: 30, hosts: ['api.example.com'] },
+					sensors: [{ id: 'temp' }]
+				}),
+				install: null
+			}
+		]);
+		assets.set('pack-a/theme.css', remoteCss);
 		await initPackages(hub);
+		await togglePackage('pack-a', true, () => true);
+		expect(enabledPackages.getSnapshot()).toContain('pack-a');
+		expect(styleTagFor('pack-a')).not.toBeNull();
 
 		removeImpl = () => Promise.reject(new Error('locked'));
 		const r = await removePackage('pack-a');
 
 		expect(r.ok).toBe(false);
 		if (!r.ok) expect(r.error).toContain('locked');
-		// The closing refresh re-discovered the still-present folder.
+		// A failed filesystem mutation must leave runtime state and both consents intact.
 		expect(rowFor('pack-a')).toBeDefined();
+		expect(enabledPackages.getSnapshot()).toContain('pack-a');
+		expect(styleTagFor('pack-a')?.textContent).toBe(remoteCss);
+		const confirm = vi.fn(() => true);
+		await togglePackage('pack-a', false);
+		await togglePackage('pack-a', true, confirm);
+		expect(confirm).not.toHaveBeenCalled();
 	});
 
 	it('deletes a folder that was never discovered (nothing to unregister first)', async () => {

--- a/client/src/lib/widgets/plugins/packages.ts
+++ b/client/src/lib/widgets/plugins/packages.ts
@@ -85,12 +85,30 @@ const parseConsentMap = (raw: unknown): Record<string, string> => {
 	return out;
 };
 
-// Exact threat-flagged stylesheet text accepted per package. Keying consent by the reviewed content
-// (not just id) means an update cannot inherit permission for newly-added remote URLs / overlays.
-// Legacy string[] consent is deliberately discarded by parseConsentMap and must be earned again.
+const CSS_FINGERPRINT = /^sha256:[0-9a-f]{64}$/;
+
+const parseCssConsentMap = (raw: unknown): Record<string, string> => {
+	const parsed = parseConsentMap(raw);
+	return Object.fromEntries(
+		Object.entries(parsed).filter(([, value]) => CSS_FINGERPRINT.test(value))
+	);
+};
+
+async function cssConsentFingerprint(css: string): Promise<string> {
+	const digest = await globalThis.crypto.subtle.digest('SHA-256', new TextEncoder().encode(css));
+	const hex = Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, '0')).join(
+		''
+	);
+	return `sha256:${hex}`;
+}
+
+// SHA-256 of the exact threat-flagged stylesheet accepted per package. Keying consent by reviewed
+// content (not just id) means an update cannot inherit permission for new remote URLs / overlays,
+// while a maximum-size stylesheet never consumes another 256 KiB of localStorage. Legacy id arrays
+// and raw-CSS map values are deliberately discarded and must earn consent again.
 const trustedCssPackages = createPersistedStore<Record<string, string>>(
 	'widgetsack.packages.cssTrusted',
-	parseConsentMap
+	parseCssConsentMap
 );
 
 // Network consent per package id, keyed by the hosts FINGERPRINT (sorted hosts string) the user
@@ -141,7 +159,11 @@ async function injectPackageTheme(d: Discovered): Promise<void> {
 	if (!theme) return;
 	const css = await readPluginPackageAsset(d.id, theme.file);
 	if (css == null) return;
-	if (scanCssThreats(css).length && trustedCssPackages.getSnapshot()[d.id] !== css) return;
+	if (
+		scanCssThreats(css).length &&
+		trustedCssPackages.getSnapshot()[d.id] !== (await cssConsentFingerprint(css))
+	)
+		return;
 	removePackageTheme(d.id);
 	const el = document.createElement('style');
 	el.setAttribute('data-pkg-theme', d.id);
@@ -163,6 +185,13 @@ const runningSources = new Map<string, () => void>();
 function stopPackageSource(id: string): void {
 	runningSources.get(id)?.();
 	runningSources.delete(id);
+}
+
+function unapplyPackage(id: string): void {
+	unregisterTemplates(`pkg:${id}`);
+	removePackageTheme(id);
+	unregisterSource(`pkg:${id}`);
+	stopPackageSource(id);
 }
 
 function netConsented(d: Discovered): boolean {
@@ -192,31 +221,29 @@ function packageCatalog(m: PluginPackageManifest): SensorCatalogEntry[] {
 // package id, with the display name used only as the palette heading), add/remove its theme style,
 // and start/stop its sandboxed source (+ catalog entries).
 async function applyPackage(d: Discovered, enabled: boolean): Promise<void> {
-	if (!d.manifest) return; // unparsed packages register nothing
-	if (enabled) {
-		if (d.manifest.templates.length) {
-			registerTemplates(`pkg:${d.id}`, packageTemplates(d.manifest), d.manifest.name);
+	if (!enabled || !d.manifest) {
+		unapplyPackage(d.id);
+		return;
+	}
+	// Reapplication is replacement, not an additive merge. A same-id manifest that drops its theme,
+	// templates, or source must not leave the previous capability alive.
+	unapplyPackage(d.id);
+	if (d.manifest.templates.length) {
+		registerTemplates(`pkg:${d.id}`, packageTemplates(d.manifest), d.manifest.name);
+	}
+	await injectPackageTheme(d);
+	if (d.manifest.source) {
+		const m = d.manifest;
+		registerSource({
+			id: `pkg:${d.id}`,
+			start: async () => () => undefined, // lifecycle owned here, not by startAllSources
+			catalogEntries: () => packageCatalog(m)
+		});
+		// Consent-gated: a hosts list the user never confirmed (fresh enable race, manifest
+		// edited on disk, update that changed hosts) keeps the loop OFF, fail-closed.
+		if (hubRef && netConsented(d)) {
+			runningSources.set(d.id, await startPackageSource(m, hubRef));
 		}
-		await injectPackageTheme(d);
-		if (d.manifest.source) {
-			const m = d.manifest;
-			registerSource({
-				id: `pkg:${d.id}`,
-				start: async () => () => undefined, // lifecycle owned here, not by startAllSources
-				catalogEntries: () => packageCatalog(m)
-			});
-			stopPackageSource(d.id); // refresh re-applies — never stack two loops
-			// Consent-gated: a hosts list the user never confirmed (fresh enable race, manifest
-			// edited on disk, update that changed hosts) keeps the loop OFF, fail-closed.
-			if (hubRef && netConsented(d)) {
-				runningSources.set(d.id, await startPackageSource(m, hubRef));
-			}
-		}
-	} else {
-		unregisterTemplates(`pkg:${d.id}`);
-		removePackageTheme(d.id);
-		unregisterSource(`pkg:${d.id}`);
-		stopPackageSource(d.id);
 	}
 }
 
@@ -227,11 +254,9 @@ async function applyPackage(d: Discovered, enabled: boolean): Promise<void> {
  */
 async function refreshPackagesNow(): Promise<void> {
 	const files = await listPluginPackages();
-	// Unregister groups for packages that disappeared since the last scan.
-	const liveIds = new Set(files.map((f) => f.id));
-	for (const [id, d] of discovered) {
-		if (!liveIds.has(id)) void applyPackage(d, false);
-	}
+	// Drop the complete previous runtime view before parsing the replacement snapshot. This is also
+	// the fail-closed path for a same-id package whose new manifest is invalid or removes a capability.
+	for (const d of discovered.values()) await applyPackage(d, false);
 	discovered.clear();
 	for (const f of files) {
 		const result = parsePluginPackage(f.id, f.manifest);
@@ -283,9 +308,10 @@ export async function initPackages(hub: TelemetryHub): Promise<void> {
  * a reload; the theme style tag follows; a source's poll loop starts/stops). On the FIRST enable
  * of a package whose theme CSS scans with threats AND/OR which declares a network source,
  * `confirmEnable` is asked with a combined message stating both facts (the Plugins panel passes
- * window.confirm); declining aborts the enable. Both consents are stored — CSS by exact stylesheet,
- * network by hosts FINGERPRINT — so changed content/hosts re-prompt while unchanged packages apply
- * on subsequent boots. Other windows pick the change up on their next reload; localStorage is shared.
+ * window.confirm); declining aborts the enable. Both consents are stored — CSS by an exact-content
+ * SHA-256 fingerprint, network by hosts FINGERPRINT — so changed content/hosts re-prompt while
+ * unchanged packages apply on subsequent boots. Other windows pick the change up on their next
+ * reload; localStorage is shared.
  */
 export async function togglePackage(
 	id: string,
@@ -296,13 +322,16 @@ export async function togglePackage(
 	if (!d?.manifest) return; // unknown / unparsed → not toggleable
 	if (enabled) {
 		let cssSummary: string | null = null;
-		let cssConsent: string | null = null;
+		let approvedCssFingerprint: string | null = null;
 		if (d.manifest.theme) {
 			const css = await readPluginPackageAsset(id, d.manifest.theme.file);
 			const threats = css ? scanCssThreats(css) : [];
-			if (css && threats.length && trustedCssPackages.getSnapshot()[id] !== css) {
-				cssSummary = threatSummary(threats);
-				cssConsent = css;
+			if (css && threats.length) {
+				const fingerprint = await cssConsentFingerprint(css);
+				if (trustedCssPackages.getSnapshot()[id] !== fingerprint) {
+					cssSummary = threatSummary(threats);
+					approvedCssFingerprint = fingerprint;
+				}
 			}
 		}
 		const source = d.manifest.source;
@@ -314,7 +343,9 @@ export async function togglePackage(
 				...(needsNet && source ? { hosts: source.hosts, pollSeconds: source.pollSeconds } : {})
 			});
 			if (!confirmEnable(message)) return;
-			if (cssConsent !== null) trustedCssPackages.update((m) => ({ ...m, [id]: cssConsent }));
+			if (approvedCssFingerprint !== null) {
+				trustedCssPackages.update((m) => ({ ...m, [id]: approvedCssFingerprint }));
+			}
 			if (needsNet && fingerprint !== null) {
 				netConsentPackages.update((m) => ({ ...m, [id]: fingerprint }));
 			}
@@ -408,6 +439,13 @@ export async function updatePackage(id: string): Promise<PackageOpResult> {
  */
 export async function removePackage(id: string): Promise<PackageOpResult> {
 	const d = discovered.get(id);
+	try {
+		await removePluginPackage(id);
+	} catch (err) {
+		// The directory still exists: preserve enabled state and both approvals byte-for-byte.
+		await refreshPackages();
+		return { ok: false, error: String(err) };
+	}
 	if (d) await applyPackage(d, false);
 	enabledPackages.update((ids) => ids.filter((x) => x !== id));
 	trustedCssPackages.update((m) => {
@@ -422,12 +460,6 @@ export async function removePackage(id: string): Promise<PackageOpResult> {
 		delete rest[id];
 		return rest;
 	});
-	try {
-		await removePluginPackage(id);
-	} catch (err) {
-		await refreshPackages();
-		return { ok: false, error: String(err) };
-	}
 	await refreshPackages();
 	return { ok: true };
 }

--- a/client/src/lib/widgets/plugins/packages.ts
+++ b/client/src/lib/widgets/plugins/packages.ts
@@ -78,19 +78,20 @@ export const enabledPackages = createPersistedStore<string[]>(
 	parseIds
 );
 
-// Packages whose threat-flagged theme CSS the user explicitly accepted (the first-enable
-// confirm). Without this consent a threat-flagged theme is never injected, even when enabled.
-const trustedCssPackages = createPersistedStore<string[]>(
-	'widgetsack.packages.cssTrusted',
-	parseIds
-);
-
 const parseConsentMap = (raw: unknown): Record<string, string> => {
 	if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) return {};
 	const out: Record<string, string> = {};
 	for (const [k, v] of Object.entries(raw)) if (typeof v === 'string') out[k] = v;
 	return out;
 };
+
+// Exact threat-flagged stylesheet text accepted per package. Keying consent by the reviewed content
+// (not just id) means an update cannot inherit permission for newly-added remote URLs / overlays.
+// Legacy string[] consent is deliberately discarded by parseConsentMap and must be earned again.
+const trustedCssPackages = createPersistedStore<Record<string, string>>(
+	'widgetsack.packages.cssTrusted',
+	parseConsentMap
+);
 
 // Network consent per package id, keyed by the hosts FINGERPRINT (sorted hosts string) the user
 // saw in the first-enable confirm. A manifest update that changes the hosts list mismatches the
@@ -140,7 +141,7 @@ async function injectPackageTheme(d: Discovered): Promise<void> {
 	if (!theme) return;
 	const css = await readPluginPackageAsset(d.id, theme.file);
 	if (css == null) return;
-	if (scanCssThreats(css).length && !trustedCssPackages.getSnapshot().includes(d.id)) return;
+	if (scanCssThreats(css).length && trustedCssPackages.getSnapshot()[d.id] !== css) return;
 	removePackageTheme(d.id);
 	const el = document.createElement('style');
 	el.setAttribute('data-pkg-theme', d.id);
@@ -187,14 +188,14 @@ function packageCatalog(m: PluginPackageManifest): SensorCatalogEntry[] {
 
 // ---- registration ------------------------------------------------------------------------------
 
-// Apply one package's enabled state: register/unregister its template group (keyed by the
-// package's display name — that's the heading the palette shows), add/remove its theme style,
+// Apply one package's enabled state: register/unregister its template group (keyed by stable
+// package id, with the display name used only as the palette heading), add/remove its theme style,
 // and start/stop its sandboxed source (+ catalog entries).
 async function applyPackage(d: Discovered, enabled: boolean): Promise<void> {
 	if (!d.manifest) return; // unparsed packages register nothing
 	if (enabled) {
 		if (d.manifest.templates.length) {
-			registerTemplates(d.manifest.name, packageTemplates(d.manifest));
+			registerTemplates(`pkg:${d.id}`, packageTemplates(d.manifest), d.manifest.name);
 		}
 		await injectPackageTheme(d);
 		if (d.manifest.source) {
@@ -212,7 +213,7 @@ async function applyPackage(d: Discovered, enabled: boolean): Promise<void> {
 			}
 		}
 	} else {
-		unregisterTemplates(d.manifest.name);
+		unregisterTemplates(`pkg:${d.id}`);
 		removePackageTheme(d.id);
 		unregisterSource(`pkg:${d.id}`);
 		stopPackageSource(d.id);
@@ -224,7 +225,7 @@ async function applyPackage(d: Discovered, enabled: boolean): Promise<void> {
  * the Plugins panel opens (so a freshly dropped folder shows up without a restart). A package
  * that vanished from disk keeps nothing registered (its group is unregistered below).
  */
-export async function refreshPackages(): Promise<void> {
+async function refreshPackagesNow(): Promise<void> {
 	const files = await listPluginPackages();
 	// Unregister groups for packages that disappeared since the last scan.
 	const liveIds = new Set(files.map((f) => f.id));
@@ -255,6 +256,16 @@ export async function refreshPackages(): Promise<void> {
 	}
 }
 
+// Every caller shares one queue. This prevents an older async scan from committing after a newer
+// install/update/remove scan and keeps source stop/start transitions strictly ordered.
+let refreshTail: Promise<void> = Promise.resolve();
+
+export function refreshPackages(): Promise<void> {
+	const pending = refreshTail.then(refreshPackagesNow, refreshPackagesNow);
+	refreshTail = pending.catch(() => undefined);
+	return pending;
+}
+
 let initialized = false;
 
 /** One-shot init per window (Canvas mount, both roles — idempotent like registerBuiltinPlugins).
@@ -271,11 +282,10 @@ export async function initPackages(hub: TelemetryHub): Promise<void> {
  * Flip one package's enabled state, LIVE (templates appear in / vanish from the palette without
  * a reload; the theme style tag follows; a source's poll loop starts/stops). On the FIRST enable
  * of a package whose theme CSS scans with threats AND/OR which declares a network source,
- * `confirmEnable` is asked ONCE with a combined message stating both facts (the Plugins panel
- * passes window.confirm); declining aborts the enable. Both consents are stored — CSS by package
- * id, network by hosts FINGERPRINT (so changed hosts re-prompt) — and subsequent boots apply
- * without asking again. Other windows (overlays) pick the change up on their next reload — the
- * allowlist is shared localStorage.
+ * `confirmEnable` is asked with a combined message stating both facts (the Plugins panel passes
+ * window.confirm); declining aborts the enable. Both consents are stored — CSS by exact stylesheet,
+ * network by hosts FINGERPRINT — so changed content/hosts re-prompt while unchanged packages apply
+ * on subsequent boots. Other windows pick the change up on their next reload; localStorage is shared.
  */
 export async function togglePackage(
 	id: string,
@@ -286,10 +296,14 @@ export async function togglePackage(
 	if (!d?.manifest) return; // unknown / unparsed → not toggleable
 	if (enabled) {
 		let cssSummary: string | null = null;
-		if (d.manifest.theme && !trustedCssPackages.getSnapshot().includes(id)) {
+		let cssConsent: string | null = null;
+		if (d.manifest.theme) {
 			const css = await readPluginPackageAsset(id, d.manifest.theme.file);
 			const threats = css ? scanCssThreats(css) : [];
-			if (threats.length) cssSummary = threatSummary(threats);
+			if (css && threats.length && trustedCssPackages.getSnapshot()[id] !== css) {
+				cssSummary = threatSummary(threats);
+				cssConsent = css;
+			}
 		}
 		const source = d.manifest.source;
 		const fingerprint = source ? consentFingerprint(source.hosts) : null;
@@ -300,7 +314,7 @@ export async function togglePackage(
 				...(needsNet && source ? { hosts: source.hosts, pollSeconds: source.pollSeconds } : {})
 			});
 			if (!confirmEnable(message)) return;
-			if (cssSummary !== null) trustedCssPackages.update((ids) => [...ids, id]);
+			if (cssConsent !== null) trustedCssPackages.update((m) => ({ ...m, [id]: cssConsent }));
 			if (needsNet && fingerprint !== null) {
 				netConsentPackages.update((m) => ({ ...m, [id]: fingerprint }));
 			}
@@ -367,7 +381,7 @@ export async function updatePackage(id: string): Promise<PackageOpResult> {
 	if (!d?.install) return { ok: false, error: 'package was not installed from a URL' };
 	if (enabledPackages.getSnapshot().includes(id)) await applyPackage(d, false);
 	try {
-		await installPluginPackage(reinstallSource(d.install));
+		await installPluginPackage(reinstallSource(d.install), id);
 	} catch (err) {
 		await refreshPackages(); // restore the (still enabled) old version's registration
 		return { ok: false, error: String(err) };
@@ -396,7 +410,12 @@ export async function removePackage(id: string): Promise<PackageOpResult> {
 	const d = discovered.get(id);
 	if (d) await applyPackage(d, false);
 	enabledPackages.update((ids) => ids.filter((x) => x !== id));
-	trustedCssPackages.update((ids) => ids.filter((x) => x !== id));
+	trustedCssPackages.update((m) => {
+		if (m[id] === undefined) return m;
+		const rest = { ...m };
+		delete rest[id];
+		return rest;
+	});
 	netConsentPackages.update((m) => {
 		if (m[id] === undefined) return m;
 		const rest = { ...m };
@@ -421,8 +440,9 @@ export function resetPackagesForTest(): void {
 	discovered.clear();
 	publishRows();
 	enabledPackages.set([]);
-	trustedCssPackages.set([]);
+	trustedCssPackages.set({});
 	netConsentPackages.set({});
 	hubRef = null;
 	initialized = false;
+	refreshTail = Promise.resolve();
 }

--- a/client/src/lib/widgets/useAssistant.test.ts
+++ b/client/src/lib/widgets/useAssistant.test.ts
@@ -36,7 +36,7 @@ beforeEach(() => {
 	isStudioWindow.mockReturnValue(false);
 });
 afterEach(() => {
-	vi.runOnlyPendingTimers();
+	vi.clearAllTimers();
 	vi.useRealTimers();
 	vi.clearAllMocks();
 });
@@ -48,7 +48,7 @@ describe('useAssistant', () => {
 		const { result } = renderHook(() => useAssistant(cfg()), { wrapper });
 
 		await act(async () => {
-			result.current.refresh();
+			await result.current.refresh();
 		});
 
 		expect(llmComplete).toHaveBeenCalledOnce();
@@ -74,7 +74,7 @@ describe('useAssistant', () => {
 			{ wrapper }
 		);
 		await act(async () => {
-			result.current.refresh();
+			await result.current.refresh();
 		});
 		const userMsg = (llmComplete.mock.calls[0]![0] as { role: string; content: string }[]).find(
 			(m) => m.role === 'user'
@@ -87,7 +87,7 @@ describe('useAssistant', () => {
 	it('speaks the result when speak is enabled', async () => {
 		const { result } = renderHook(() => useAssistant(cfg({ speak: true })), { wrapper });
 		await act(async () => {
-			result.current.refresh();
+			await result.current.refresh();
 		});
 		expect(speakSmart).toHaveBeenCalledWith('the briefing');
 	});
@@ -96,7 +96,7 @@ describe('useAssistant', () => {
 		llmComplete.mockRejectedValueOnce(new Error('rate limited'));
 		const { result } = renderHook(() => useAssistant(cfg()), { wrapper });
 		await act(async () => {
-			result.current.refresh();
+			await result.current.refresh();
 		});
 		expect(result.current.error).toContain('rate limited');
 		expect(result.current.busy).toBe(false);
@@ -133,6 +133,28 @@ describe('useAssistant', () => {
 		expect(llmComplete).toHaveBeenCalledTimes(2);
 	});
 
+	it('never overlaps slow provider calls and coalesces missed ticks into one trailing run', async () => {
+		let resolveFirst!: (value: string) => void;
+		llmComplete.mockImplementationOnce(
+			() => new Promise<string>((resolve) => (resolveFirst = resolve))
+		);
+		renderHook(() => useAssistant(cfg({ schedule: '1s' })), { wrapper });
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(3000);
+		});
+		expect(llmComplete).toHaveBeenCalledTimes(1);
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(45_000);
+		});
+		expect(llmComplete).toHaveBeenCalledTimes(1);
+		await act(async () => {
+			resolveFirst('first');
+			await Promise.resolve();
+			await Promise.resolve();
+		});
+		expect(llmComplete).toHaveBeenCalledTimes(2);
+	});
+
 	it('unmounting before the first delay cancels the pending auto-generation', async () => {
 		// Cleanup clears the first-delay timeout and every interval (which is also why the tick's
 		// `!cancelled` guard can never observe cancelled=true — no timer survives to call it).
@@ -152,7 +174,7 @@ describe('useAssistant', () => {
 		});
 		expect(llmComplete).not.toHaveBeenCalled(); // no auto run
 		await act(async () => {
-			result.current.refresh(); // but manual refresh still works
+			await result.current.refresh(); // but manual refresh still works
 		});
 		expect(llmComplete).toHaveBeenCalledOnce();
 	});

--- a/client/src/lib/widgets/useAssistant.ts
+++ b/client/src/lib/widgets/useAssistant.ts
@@ -3,10 +3,11 @@
 // sensor hub, calls the LLM provider on the widget's own schedule (interval or cron), and exposes
 // the text; the pure meters/Assistant meter just renders what it's given. Pure logic lives
 // elsewhere — the schedule math in core/schedule.ts, the prompt in core/llm.ts.
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTelemetryHub } from './telemetryContext';
 import type { SensorValue, TelemetryHub } from '../core/telemetry';
 import { buildAssistantMessages } from '../core/llm';
+import { singleFlight } from '../core/singleFlight';
 import { cronMatches, intervalMs, isCron } from '../core/schedule';
 import { isStudioWindow } from '../overlay';
 import { speakSmart } from './plugins/llm-tts';
@@ -58,7 +59,12 @@ export type AssistantConfig = {
 	sensors: string;
 	speak?: boolean;
 };
-export type AssistantState = { text: string; busy: boolean; error: string; refresh: () => void };
+export type AssistantState = {
+	text: string;
+	busy: boolean;
+	error: string;
+	refresh: () => Promise<void>;
+};
 
 export function useAssistant(cfg: AssistantConfig): AssistantState {
 	const hub = useTelemetryHub();
@@ -72,7 +78,7 @@ export function useAssistant(cfg: AssistantConfig): AssistantState {
 		cfgRef.current = cfg;
 	});
 
-	const generate = useCallback(async (): Promise<void> => {
+	const generateOnce = useCallback(async (): Promise<void> => {
 		setBusy(true);
 		setError('');
 		try {
@@ -90,6 +96,9 @@ export function useAssistant(cfg: AssistantConfig): AssistantState {
 			setBusy(false);
 		}
 	}, [hub]);
+	// Provider calls can outlive the shortest schedule. Collapse ticks/manual refreshes that arrive
+	// mid-request into one trailing refresh so calls never overlap or complete out of order.
+	const generate = useMemo(() => singleFlight(generateOnce), [generateOnce]);
 
 	useEffect(() => {
 		// Auto-generation runs ONLY on the overlay (the always-on surface). The studio shows the last
@@ -127,6 +136,6 @@ export function useAssistant(cfg: AssistantConfig): AssistantState {
 		};
 	}, [cfg.schedule, generate]);
 
-	const refresh = useCallback(() => void generate(), [generate]);
+	const refresh = useCallback(() => generate(), [generate]);
 	return { text, busy, error, refresh };
 }

--- a/client/src/stores/stores.test.ts
+++ b/client/src/stores/stores.test.ts
@@ -101,6 +101,43 @@ describe('mediaStore creation (parseMediaStore seam)', () => {
 		const { mediaStore } = await load();
 		expect(mediaStore.getSnapshot().preferredMonitor).toBeNull();
 	});
+
+	it('falls back per field when persisted preferences have invalid types or shapes', async () => {
+		localStorage.setItem(
+			MEDIA_STORE_KEY,
+			JSON.stringify({
+				sourcePriority: 7,
+				ignoreList: ['spotify'],
+				styleOverride: false,
+				preferredMonitor: { name: 1, position: { x: 0 }, size: null },
+				savedPosition: { x: 1, y: 2, width: -3, height: 4, timestamp: 5 },
+				restoreToSavedPosition: 'yes'
+			})
+		);
+
+		const { mediaStore, defaultState } = await load();
+
+		expect(mediaStore.getSnapshot()).toEqual(defaultState);
+	});
+
+	it('accepts a structurally valid monitor and finite positive saved position', async () => {
+		const preferredMonitor = {
+			name: null,
+			position: { x: -1920, y: 0 },
+			size: { width: 1920, height: 1080 }
+		};
+		const savedPosition = { x: 10, y: 20, width: 500, height: 300, timestamp: 123 };
+		localStorage.setItem(
+			MEDIA_STORE_KEY,
+			JSON.stringify({ preferredMonitor, savedPosition, restoreToSavedPosition: true })
+		);
+
+		const { mediaStore } = await load();
+
+		expect(mediaStore.getSnapshot().preferredMonitor).toEqual(preferredMonitor);
+		expect(mediaStore.getSnapshot().savedPosition).toEqual(savedPosition);
+		expect(mediaStore.getSnapshot().restoreToSavedPosition).toBe(true);
+	});
 });
 
 describe('serializeMediaStore (persist seam)', () => {
@@ -201,10 +238,14 @@ describe('handleDelete', () => {
 	it('removes the record for the given session_id', async () => {
 		const { mediaStore, handleUpdate, handleDelete } = await load();
 		handleUpdate({ sessionRecord: rec({ session_id: 9, source: 'x.exe' }) });
-		expect(mediaStore.getSnapshot().sessions[9]).toBeDefined();
+		const previous = mediaStore.getSnapshot();
+		expect(previous.sessions[9]).toBeDefined();
 		handleDelete({ sessionRecord: rec({ session_id: 9, source: 'x.exe' }) });
 		expect(mediaStore.getSnapshot().sessions[9]).toBeUndefined();
 		expect(mediaStore.getSnapshot().sessions).toEqual({});
+		// External-store snapshots are immutable contracts: deleting from the new state must not
+		// retroactively mutate a value a React render (or another subscriber) already captured.
+		expect(previous.sessions[9]).toBeDefined();
 	});
 
 	it('is a no-op (leaves other sessions intact) when the id is absent', async () => {

--- a/client/src/stores/stores.ts
+++ b/client/src/stores/stores.ts
@@ -14,7 +14,7 @@ export type SystemTime = {
 
 export type SessionRecord = {
 	session_id: number;
-	source: string;
+	source: string | null;
 	timestamp_created: SystemTime | null;
 	timestamp_updated: SystemTime | null;
 	// Both mirror Rust `Option<SessionUpdateEventWrapper>` (state.rs) — nullable. The backend also now
@@ -128,16 +128,55 @@ export const defaultState: State = {
 const MEDIA_STORE_KEY = '_mediaStore';
 
 function parseMediaStore(raw: unknown): State {
-	// TODO: Validate deserialised values and do migrations if needed
-	const o = (raw ?? {}) as Partial<SerializedState>;
+	const o =
+		typeof raw === 'object' && raw !== null && !Array.isArray(raw)
+			? (raw as Record<string, unknown>)
+			: {};
+	const finite = (value: unknown): value is number =>
+		typeof value === 'number' && Number.isFinite(value);
+	const point = (value: unknown): value is { x: number; y: number } =>
+		typeof value === 'object' &&
+		value !== null &&
+		finite((value as Record<string, unknown>).x) &&
+		finite((value as Record<string, unknown>).y);
+	const preferredMonitor = (value: unknown): value is MonitorInfo | null => {
+		if (value === null) return true;
+		if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+		const monitor = value as Record<string, unknown>;
+		const size = monitor.size as Record<string, unknown> | null;
+		return (
+			(monitor.name === null || typeof monitor.name === 'string') &&
+			point(monitor.position) &&
+			typeof size === 'object' &&
+			size !== null &&
+			finite(size.width) &&
+			size.width > 0 &&
+			finite(size.height) &&
+			size.height > 0
+		);
+	};
+	const savedPosition = (value: unknown): value is SavedPosition | null => {
+		if (value === null) return true;
+		if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+		const position = value as Record<string, unknown>;
+		return (
+			finite(position.x) &&
+			finite(position.y) &&
+			finite(position.width) &&
+			position.width > 0 &&
+			finite(position.height) &&
+			position.height > 0 &&
+			finite(position.timestamp)
+		);
+	};
 	return {
 		...defaultState,
-		...(o.sourcePriority !== undefined && { sourcePriority: o.sourcePriority }),
-		...(o.ignoreList !== undefined && { ignoreList: o.ignoreList }),
-		...(o.styleOverride !== undefined && { styleOverride: o.styleOverride }),
-		...(o.preferredMonitor !== undefined && { preferredMonitor: o.preferredMonitor }),
-		...(o.savedPosition !== undefined && { savedPosition: o.savedPosition }),
-		...(o.restoreToSavedPosition !== undefined && {
+		...(typeof o.sourcePriority === 'string' && { sourcePriority: o.sourcePriority }),
+		...(typeof o.ignoreList === 'string' && { ignoreList: o.ignoreList }),
+		...(typeof o.styleOverride === 'string' && { styleOverride: o.styleOverride }),
+		...(preferredMonitor(o.preferredMonitor) && { preferredMonitor: o.preferredMonitor }),
+		...(savedPosition(o.savedPosition) && { savedPosition: o.savedPosition }),
+		...(typeof o.restoreToSavedPosition === 'boolean' && {
 			restoreToSavedPosition: o.restoreToSavedPosition
 		})
 	};
@@ -203,9 +242,8 @@ export type HandleDeleteOpts = {
 };
 export function handleDelete(opts: HandleDeleteOpts) {
 	mediaStore.update((cur) => {
-		const copy = { ...cur };
-		const copySessions = copy.sessions;
-		delete copySessions[opts.sessionRecord.session_id];
-		return copy;
+		const sessions = { ...cur.sessions };
+		delete sessions[opts.sessionRecord.session_id];
+		return { ...cur, sessions };
 	});
 }

--- a/client/src/test-setup.ts
+++ b/client/src/test-setup.ts
@@ -9,5 +9,32 @@ window.prompt ??= () => null;
 window.confirm ??= () => false;
 window.alert ??= () => {};
 
+// Vitest's happy-dom adapter does not expose Storage on every supported Node runtime (notably Node
+// 26). Real webviews do; use a faithful in-memory seam only when the environment omitted it.
+const memoryStorage = (): Storage => {
+	const values = new Map<string, string>();
+	return {
+		get length() {
+			return values.size;
+		},
+		clear: () => values.clear(),
+		getItem: (key) => values.get(key) ?? null,
+		key: (index) => [...values.keys()][index] ?? null,
+		removeItem: (key) => values.delete(key),
+		setItem: (key, value) => values.set(key, String(value))
+	};
+};
+globalThis.localStorage ??= window.localStorage ?? memoryStorage();
+globalThis.sessionStorage ??= window.sessionStorage ?? memoryStorage();
+
+// Iframes are DOM attributes in unit tests, not network integrations. Disable happy-dom child-frame
+// navigation globally so every iframe test stays offline and teardown has no aborted-fetch noise.
+const happy = (
+	window as unknown as {
+		happyDOM?: { settings?: { navigation?: { disableChildFrameNavigation?: boolean } } };
+	}
+).happyDOM;
+if (happy?.settings?.navigation) happy.settings.navigation.disableChildFrameNavigation = true;
+
 // Unmount React trees + reset jsdom between tests (RTL doesn't auto-cleanup with globals).
 afterEach(() => cleanup());

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -15,7 +15,10 @@ export default defineConfig({
 	// output back to `build/` or the desktop bundle finds no frontend.
 	build: {
 		outDir: 'build',
-		emptyOutDir: true
+		emptyOutDir: true,
+		// QuickJS-WASM and the complete overlay widget registry are intentionally substantial lazy
+		// chunks; both remain below this reviewed ceiling (and their gzip sizes are reported by Vite).
+		chunkSizeWarningLimit: 700
 	},
 	// CodeMirror (the studio's CSS editor) throws "Unrecognized extension value … multiple instances
 	// of @codemirror/state" if more than one copy of that package loads — its extensions use

--- a/docs/third-party-plugins.md
+++ b/docs/third-party-plugins.md
@@ -259,7 +259,9 @@ and theme live, stops its source, and clears its enable flag **and** any stored 
 network consent — a re-installed package starts from zero trust. An *Update* that changes the
 `source.hosts` list also drops the stored network consent: the new hosts stay unfetched until
 you toggle the package off and on and confirm them. Theme-CSS consent is tied to the exact reviewed
-stylesheet, so changed threat-flagged CSS likewise remains uninjected until it is confirmed.
+stylesheet by a compact SHA-256 fingerprint (the CSS itself is not copied into local storage), so
+changed threat-flagged CSS likewise remains uninjected until it is confirmed. If the filesystem
+refuses a removal, the package stays enabled and its existing approvals remain intact.
 
 Security of remote installs:
 

--- a/docs/third-party-plugins.md
+++ b/docs/third-party-plugins.md
@@ -238,8 +238,8 @@ forms:
 | any `https://…/plugin.json` URL               | that exact manifest (self-hosted packages)                        |
 
 The backend downloads the manifest plus every asset it declares (`theme.file` and `source.file`
-— fetched from the same directory), then writes `plugins/<id>/` exactly as if you had dropped the
-folder by hand.
+— fetched from the same directory), stages the complete package beside `plugins/<id>/`, then swaps
+the directory into place. A failed download or disk write leaves the prior package untouched.
 Provenance is recorded in a sidecar, `plugins/<id>/.install.json`:
 
 ```json
@@ -258,18 +258,21 @@ manifest). Nothing is checked or fetched in the background, ever.
 and theme live, stops its source, and clears its enable flag **and** any stored theme-CSS /
 network consent — a re-installed package starts from zero trust. An *Update* that changes the
 `source.hosts` list also drops the stored network consent: the new hosts stay unfetched until
-you toggle the package off and on and confirm them.
+you toggle the package off and on and confirm them. Theme-CSS consent is tied to the exact reviewed
+stylesheet, so changed threat-flagged CSS likewise remains uninjected until it is confirmed.
 
 Security of remote installs:
 
-- **https only** — `http://` sources are rejected; the GitHub shorthand forms always resolve to
-  `raw.githubusercontent.com` over https.
+- **https only, no redirects** — `http://` sources are rejected; the GitHub shorthand forms always
+  resolve to `raw.githubusercontent.com` over https, and manifest/asset redirects are rejected.
 - **Size caps** — the manifest and each asset are capped at 256 KiB (10 s timeout); only
   `.css`/`.json`/`.js` filenames that pass the same allowlist as local packages are
   fetched/written.
 - **Installs land disabled** — a fetched package goes through exactly the same opt-in toggle,
   structural validation, CSS threat scan, and first-enable consent (including the network-hosts
   confirm) as a hand-dropped folder. The link is a delivery mechanism, not a trust grant.
+- **Package IDs cannot be overwritten by a fresh install** — remove the existing package first, or
+  use its explicit *Update* action. Updates must return the same manifest ID as the installed row.
 
 ## Updating / removing
 

--- a/widgetsack/Cargo.toml
+++ b/widgetsack/Cargo.toml
@@ -94,6 +94,8 @@ windows = { version = "0.61", features = [
     # SECURITY_ATTRIBUTES param), DeviceIoControl in System_IO, IOCTL_DISK_PERFORMANCE +
     # DISK_PERFORMANCE in System_Ioctl.
     "Win32_Security",
+    # Per-user DPAPI encryption for HA/MQTT/LLM credential-bearing config files.
+    "Win32_Security_Cryptography",
     "Win32_Storage_FileSystem",
     "Win32_System_IO",
     "Win32_System_Ioctl",
@@ -136,4 +138,3 @@ default = [ "custom-protocol" ]
 # this feature is used for production builds where `devPath` points to the filesystem
 # DO NOT remove this
 custom-protocol = [ "tauri/custom-protocol" ]
-

--- a/widgetsack/Cargo.toml
+++ b/widgetsack/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "widgetsack"
 # Keep in lockstep with tauri.conf.json's version (the bundle/updater source of truth).
-version = "0.0.51"
+version = "0.0.52"
 description = "widgetsack desktop widget platform"
 authors = ["you"]
 license = "MIT OR Apache-2.0"

--- a/widgetsack/src/agenda.rs
+++ b/widgetsack/src/agenda.rs
@@ -344,7 +344,7 @@ pub async fn save_agenda_config(
         poll_interval_secs: poll_seconds.clamp(MIN_INTERVAL, MAX_INTERVAL),
     };
     let txt = serde_json::to_string_pretty(&cfg).map_err(|e| e.to_string())?;
-    std::fs::write(&path, txt).map_err(|e| e.to_string())
+    crate::command::atomic_write(&path, &txt)
 }
 
 #[tauri::command]

--- a/widgetsack/src/command.rs
+++ b/widgetsack/src/command.rs
@@ -6,6 +6,10 @@ use notify::Watcher;
 use serde::Serialize;
 use tauri::{Emitter, Manager};
 
+/// Serializes widgets.json read/merge/write transactions across every webview in this process.
+#[derive(Default)]
+pub struct LayoutIoState(tokio::sync::Mutex<()>);
+
 use crate::bridge::{CONTROLS_CHANGED_EVENT, LAYOUT_CHANGED_EVENT, THEMES_CHANGED_EVENT};
 use crate::{AppState, SessionRecord, log};
 
@@ -65,14 +69,100 @@ pub async fn load_layout(app: tauri::AppHandle) -> Result<Option<String>, String
     }
 }
 
-/// Write the layout file, creating the config directory if needed.
+/// Merge the monitor records changed by one editor transaction into the latest widgets.json value.
+/// Unknown top-level fields are preserved for forward compatibility; the frontend-owned global fields
+/// are replaced (or removed when omitted) from the incoming document.
+fn merge_layout_contents(
+    mut current: serde_json::Value,
+    incoming: serde_json::Value,
+    touched_monitors: &[String],
+    touched_globals: &[String],
+) -> Result<serde_json::Value, String> {
+    let current_obj = current
+        .as_object_mut()
+        .ok_or_else(|| "saved layout is not a JSON object".to_string())?;
+    let incoming_obj = incoming
+        .as_object()
+        .ok_or_else(|| "incoming layout is not a JSON object".to_string())?;
+    let incoming_monitors = incoming_obj
+        .get("monitors")
+        .and_then(|v| v.as_object())
+        .ok_or_else(|| "incoming layout has no monitors object".to_string())?;
+    let current_monitors = current_obj
+        .entry("monitors")
+        .or_insert_with(|| serde_json::json!({}))
+        .as_object_mut()
+        .ok_or_else(|| "saved layout monitors is not a JSON object".to_string())?;
+
+    for key in touched_monitors {
+        if let Some(value) = incoming_monitors.get(key) {
+            current_monitors.insert(key.clone(), value.clone());
+        } else {
+            current_monitors.remove(key);
+        }
+    }
+
+    if let Some(version) = incoming_obj.get("version") {
+        current_obj.insert("version".into(), version.clone());
+    }
+    for key in touched_globals {
+        if !matches!(key.as_str(), "library" | "theme" | "themeLock" | "tokens") {
+            return Err(format!("unknown touched global field: {key}"));
+        }
+        if let Some(value) = incoming_obj.get(key) {
+            current_obj.insert(key.clone(), value.clone());
+        } else {
+            // These fields are omission-sensitive: absent means reset to the frontend default.
+            current_obj.remove(key);
+        }
+    }
+    Ok(current)
+}
+
+/// Write the layout file, creating the config directory if needed. Editor writes identify the monitor
+/// records they changed; the backend merges those records under one lock and atomically replaces the
+/// file, so concurrent webviews cannot clobber unrelated monitors. A full-document caller (legacy-key
+/// migration) omits `touched_monitors` and replaces the document atomically.
 #[tauri::command]
-pub async fn save_layout(app: tauri::AppHandle, contents: String) -> Result<(), String> {
+pub async fn save_layout(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, LayoutIoState>,
+    contents: String,
+    touched_monitors: Option<Vec<String>>,
+    touched_globals: Option<Vec<String>>,
+) -> Result<(), String> {
+    let _guard = state.0.lock().await;
     let path = layout_path(&app)?;
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
-    fs::write(&path, contents).map_err(|e| e.to_string())
+    let incoming: serde_json::Value = serde_json::from_str(&contents)
+        .map_err(|e| format!("incoming layout is invalid JSON: {e}"))?;
+    let output = if let Some(touched) = touched_monitors {
+        match fs::read_to_string(&path) {
+            Ok(raw) => {
+                let current = serde_json::from_str(&raw).map_err(|e| {
+                    format!("saved layout is invalid JSON; refusing overwrite: {e}")
+                })?;
+                merge_layout_contents(
+                    current,
+                    incoming,
+                    &touched,
+                    touched_globals.as_deref().unwrap_or_default(),
+                )?
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => incoming,
+            Err(err) => {
+                return Err(format!(
+                    "failed to read saved layout; refusing overwrite: {err}"
+                ));
+            }
+        }
+    } else {
+        incoming
+    };
+    let rendered = serde_json::to_string_pretty(&output).map_err(|e| e.to_string())?;
+    atomic_write(&path, &rendered)
 }
 
 /// Filename prefix for layout backups taken on parse failure (`widgets.json.bad-<epoch-ms>`).
@@ -154,7 +244,7 @@ pub async fn save_controls(app: tauri::AppHandle, contents: String) -> Result<()
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
-    fs::write(&path, contents).map_err(|e| e.to_string())
+    atomic_write(&path, &contents)
 }
 
 /// Open the webview devtools/inspector for the calling window (CSS development from the studio's
@@ -354,21 +444,48 @@ fn themes_dir(app: &tauri::AppHandle) -> Result<PathBuf, String> {
 /// sees a truncated/partial file. The temp name keeps the original and appends `.tmp`, so its
 /// extension is `tmp` (not `css`/`json`) and the directory watchers, which filter by extension,
 /// ignore it. Best-effort cleanup of the temp file on failure.
-fn atomic_write(path: &Path, contents: &str) -> Result<(), String> {
+pub(crate) fn atomic_write(path: &Path, contents: &str) -> Result<(), String> {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static NEXT_TEMP: AtomicU64 = AtomicU64::new(0);
     let file_name = path
         .file_name()
         .and_then(|s| s.to_str())
         .ok_or_else(|| "write path has no file name".to_string())?;
     let mut tmp = path.to_path_buf();
-    tmp.set_file_name(format!("{file_name}.tmp"));
+    let seq = NEXT_TEMP.fetch_add(1, Ordering::Relaxed);
+    tmp.set_file_name(format!("{file_name}.tmp-{}-{seq}", std::process::id()));
     if let Err(err) = fs::write(&tmp, contents) {
         let _ = fs::remove_file(&tmp);
         return Err(err.to_string());
     }
-    fs::rename(&tmp, path).map_err(|e| {
+    replace_file(&tmp, path).inspect_err(|_| {
         let _ = fs::remove_file(&tmp);
-        e.to_string()
     })
+}
+
+#[cfg(not(windows))]
+fn replace_file(from: &Path, to: &Path) -> Result<(), String> {
+    fs::rename(from, to).map_err(|e| e.to_string())
+}
+
+#[cfg(windows)]
+fn replace_file(from: &Path, to: &Path) -> Result<(), String> {
+    use std::os::windows::ffi::OsStrExt;
+    use windows::Win32::Storage::FileSystem::{
+        MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH, MoveFileExW,
+    };
+    use windows::core::PCWSTR;
+
+    let from_wide: Vec<u16> = from.as_os_str().encode_wide().chain(Some(0)).collect();
+    let to_wide: Vec<u16> = to.as_os_str().encode_wide().chain(Some(0)).collect();
+    unsafe {
+        MoveFileExW(
+            PCWSTR(from_wide.as_ptr()),
+            PCWSTR(to_wide.as_ptr()),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+        )
+    }
+    .map_err(|e| e.to_string())
 }
 
 /// The theme names (file stems of `themes/*.css`), sorted. The frontend adds a synthetic
@@ -583,7 +700,7 @@ pub fn write_sack(app: tauri::AppHandle, name: String, contents: String) -> Resu
     let dir = sacks_dir(&app)?;
     fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
     let path = dir.join(format!("{name}.sack.json"));
-    fs::write(&path, contents).map_err(|e| e.to_string())?;
+    atomic_write(&path, &contents)?;
     Ok(path.to_string_lossy().into_owned())
 }
 
@@ -643,7 +760,7 @@ pub fn save_layout_as(
     let dir = layouts_dir(&app)?;
     fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
     let path = dir.join(format!("{name}.layout.json"));
-    fs::write(&path, contents).map_err(|e| e.to_string())?;
+    atomic_write(&path, &contents)?;
     Ok(path.to_string_lossy().into_owned())
 }
 
@@ -890,6 +1007,7 @@ fn manifest_url_from_sidecar(source: &str, reff: &str) -> Option<String> {
 /// A 10s-timeout https client for the (small) manifest/asset fetches.
 fn install_http_client() -> Result<reqwest::Client, String> {
     reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
         .timeout(std::time::Duration::from_secs(10))
         .build()
         .map_err(|e| e.to_string())
@@ -1003,14 +1121,109 @@ pub struct InstalledPackage {
     pub version: String,
 }
 
-/// Install (or re-install — that IS the update path) a package from `source` (see
-/// `resolve_package_source` for the accepted forms). Fetches the manifest, minimally reads
-/// `id`/`version`/`theme.file` (full validation stays in the frontend), fetches every declared
-/// asset, and only THEN writes — a failed download never leaves a half-installed directory.
+fn plugin_install_lock() -> &'static tokio::sync::Mutex<()> {
+    static LOCK: std::sync::OnceLock<tokio::sync::Mutex<()>> = std::sync::OnceLock::new();
+    LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
+}
+
+fn package_sibling_path(root: &Path, id: &str, kind: &str) -> PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static NEXT_DIR: AtomicU64 = AtomicU64::new(0);
+    let seq = NEXT_DIR.fetch_add(1, Ordering::Relaxed);
+    root.join(format!(".{id}.{kind}-{}-{seq}", std::process::id()))
+}
+
+/// Build a complete package in an invisible sibling directory, then swap it into place. The target
+/// remains byte-for-byte untouched if any staged write fails; updates also remove stale old assets.
+fn install_package_directory_with(
+    root: &Path,
+    id: &str,
+    manifest: &str,
+    assets: &[(String, String)],
+    sidecar: &str,
+    replace: bool,
+    mut write_file: impl FnMut(&Path, &str) -> Result<(), String>,
+) -> Result<(), String> {
+    fs::create_dir_all(root).map_err(|e| e.to_string())?;
+    let target = root.join(id);
+    if target.exists() != replace {
+        return Err(if replace {
+            format!("package \"{id}\" is no longer installed")
+        } else {
+            format!("package id \"{id}\" is already installed")
+        });
+    }
+
+    let stage = package_sibling_path(root, id, "stage");
+    fs::create_dir(&stage).map_err(|e| e.to_string())?;
+    let staged = (|| {
+        write_file(&stage.join("plugin.json"), manifest)?;
+        for (name, body) in assets {
+            write_file(&stage.join(name), body)?;
+        }
+        write_file(&stage.join(INSTALL_SIDECAR), sidecar)
+    })();
+    if let Err(err) = staged {
+        let _ = fs::remove_dir_all(&stage);
+        return Err(err);
+    }
+
+    if !replace {
+        return fs::rename(&stage, &target).map_err(|err| {
+            let _ = fs::remove_dir_all(&stage);
+            err.to_string()
+        });
+    }
+
+    let backup = package_sibling_path(root, id, "backup");
+    fs::rename(&target, &backup).map_err(|err| {
+        let _ = fs::remove_dir_all(&stage);
+        err.to_string()
+    })?;
+    if let Err(err) = fs::rename(&stage, &target) {
+        let rollback = fs::rename(&backup, &target);
+        let _ = fs::remove_dir_all(&stage);
+        return match rollback {
+            Ok(()) => Err(err.to_string()),
+            Err(rollback_err) => Err(format!(
+                "package swap failed ({err}); rollback also failed ({rollback_err})"
+            )),
+        };
+    }
+    if let Err(err) = fs::remove_dir_all(&backup) {
+        eprintln!("installed package {id}, but failed to remove its backup: {err}");
+    }
+    Ok(())
+}
+
+fn install_package_directory(
+    root: &Path,
+    id: &str,
+    manifest: &str,
+    assets: &[(String, String)],
+    sidecar: &str,
+    replace: bool,
+) -> Result<(), String> {
+    install_package_directory_with(
+        root,
+        id,
+        manifest,
+        assets,
+        sidecar,
+        replace,
+        |path, body| fs::write(path, body).map_err(|e| e.to_string()),
+    )
+}
+
+/// Install a package from `source` (see `resolve_package_source` for accepted forms). `replace_id`
+/// is required for an update and must match the downloaded manifest; without it, an existing id is
+/// never overwritten. All declared assets are fetched before a complete staged directory is swapped
+/// into place, so download/write failures cannot leave a half-installed package.
 #[tauri::command]
 pub async fn install_plugin_package(
     app: tauri::AppHandle,
     source: String,
+    replace_id: Option<String>,
 ) -> Result<InstalledPackage, String> {
     let resolved = resolve_package_source(&source).ok_or_else(|| {
         "unrecognized source — use owner/repo, a github.com repo URL, or an https URL ending in /plugin.json"
@@ -1027,6 +1240,13 @@ pub async fn install_plugin_package(
         .to_string();
     if !valid_name(&id) {
         return Err("manifest \"id\" is missing or not a safe folder name".to_string());
+    }
+    if let Some(expected) = &replace_id
+        && (!valid_name(expected) || expected != &id)
+    {
+        return Err(format!(
+            "update expected package id \"{expected}\", but manifest declares \"{id}\""
+        ));
     }
     let version = json
         .get("version")
@@ -1050,12 +1270,6 @@ pub async fn install_plugin_package(
             assets.push((file.to_string(), body));
         }
     }
-    let dir = plugins_dir(&app)?.join(&id);
-    fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
-    atomic_write(&dir.join("plugin.json"), &manifest_text)?;
-    for (name, body) in &assets {
-        atomic_write(&dir.join(name), body)?;
-    }
     let installed_at = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_millis() as u64)
@@ -1066,7 +1280,15 @@ pub async fn install_plugin_package(
         "version": version,
         "installedAt": installed_at,
     });
-    atomic_write(&dir.join(INSTALL_SIDECAR), &sidecar.to_string())?;
+    let _guard = plugin_install_lock().lock().await;
+    install_package_directory(
+        &plugins_dir(&app)?,
+        &id,
+        &manifest_text,
+        &assets,
+        &sidecar.to_string(),
+        replace_id.is_some(),
+    )?;
     Ok(InstalledPackage { id, version })
 }
 
@@ -1129,10 +1351,11 @@ pub async fn check_plugin_package_update(
 /// Delete `plugins/<id>/` (works for installed AND hand-dropped packages — it's just a dir
 /// delete). Ok even if it's already gone (idempotent, like the other deletes here).
 #[tauri::command]
-pub fn remove_plugin_package(app: tauri::AppHandle, id: String) -> Result<(), String> {
+pub async fn remove_plugin_package(app: tauri::AppHandle, id: String) -> Result<(), String> {
     if !valid_name(&id) {
         return Err("invalid package id".to_string());
     }
+    let _guard = plugin_install_lock().lock().await;
     match fs::remove_dir_all(plugins_dir(&app)?.join(&id)) {
         Ok(()) => Ok(()),
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
@@ -1432,8 +1655,237 @@ pub fn watch_controls(app: tauri::AppHandle) -> Result<(), String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{client_log_level, stale_backups, truncate_chars, valid_name, version_is_newer};
+    use super::{
+        atomic_write, client_log_level, install_http_client, install_package_directory,
+        install_package_directory_with, merge_layout_contents, stale_backups, truncate_chars,
+        valid_name, version_is_newer,
+    };
     use crate::log::LogLevel;
+    use serde_json::json;
+
+    #[test]
+    fn layout_transaction_replaces_only_explicitly_touched_monitors_and_global_fields() {
+        let current = json!({
+            "version": 2,
+            "monitors": {
+                "a": { "root": { "id": "old-a" } },
+                "b": { "root": { "id": "keep-b" } }
+            },
+            "theme": "old",
+            "tokens": { "--old": "1" },
+            "future": { "preserve": true }
+        });
+        let incoming = json!({
+            "version": 2,
+            "monitors": {
+                "a": { "root": { "id": "new-a" } },
+                "b": { "root": { "id": "stale-b" } }
+            },
+            "themeLock": false
+        });
+        let merged = merge_layout_contents(
+            current,
+            incoming,
+            &["a".into()],
+            &["theme".into(), "themeLock".into(), "tokens".into()],
+        )
+        .unwrap();
+        assert_eq!(merged["monitors"]["a"]["root"]["id"], "new-a");
+        assert_eq!(merged["monitors"]["b"]["root"]["id"], "keep-b");
+        assert_eq!(merged["themeLock"], false);
+        assert!(merged.get("theme").is_none());
+        assert!(merged.get("tokens").is_none());
+        assert_eq!(merged["future"]["preserve"], true);
+    }
+
+    #[test]
+    fn layout_transaction_can_replace_multiple_monitors() {
+        let current = json!({
+            "version": 2,
+            "monitors": { "a": 1, "b": 2, "c": 3 }
+        });
+        let incoming = json!({
+            "version": 2,
+            "monitors": { "a": 10, "b": 20 }
+        });
+        let merged =
+            merge_layout_contents(current, incoming, &["a".into(), "b".into()], &[]).unwrap();
+        assert_eq!(merged["monitors"], json!({ "a": 10, "b": 20, "c": 3 }));
+    }
+
+    #[test]
+    fn layout_transaction_preserves_newer_globals_for_monitor_only_save() {
+        let current = json!({
+            "version": 2,
+            "monitors": { "a": { "root": { "id": "old-a" } } },
+            "library": { "version": 1, "defs": [{ "id": "new-library" }] },
+            "theme": "new-theme",
+            "themeLock": false,
+            "tokens": { "--new": "2" }
+        });
+        let stale_incoming = json!({
+            "version": 2,
+            "monitors": { "a": { "root": { "id": "new-a" } } },
+            "library": { "version": 1, "defs": [{ "id": "old-library" }] },
+            "theme": "old-theme",
+            "tokens": { "--old": "1" }
+        });
+
+        let merged = merge_layout_contents(current, stale_incoming, &["a".into()], &[]).unwrap();
+
+        assert_eq!(merged["monitors"]["a"]["root"]["id"], "new-a");
+        assert_eq!(merged["library"]["defs"][0]["id"], "new-library");
+        assert_eq!(merged["theme"], "new-theme");
+        assert_eq!(merged["themeLock"], false);
+        assert_eq!(merged["tokens"], json!({ "--new": "2" }));
+    }
+
+    #[test]
+    fn atomic_write_replaces_an_existing_file() {
+        let dir = std::env::temp_dir().join(format!(
+            "widgetsack-atomic-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("config.json");
+        std::fs::write(&path, "old").unwrap();
+
+        atomic_write(&path, "new").unwrap();
+
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "new");
+        assert_eq!(std::fs::read_dir(&dir).unwrap().count(), 1);
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    fn package_test_dir(label: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!(
+            "widgetsack-package-{label}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ))
+    }
+
+    #[test]
+    fn package_staging_failure_leaves_existing_install_unchanged() {
+        let root = package_test_dir("staging-failure");
+        let target = root.join("demo");
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::write(target.join("plugin.json"), "old manifest").unwrap();
+        std::fs::write(target.join("old.css"), "old css").unwrap();
+        let mut writes = 0;
+
+        let result = install_package_directory_with(
+            &root,
+            "demo",
+            "new manifest",
+            &[("new.css".into(), "new css".into())],
+            "new sidecar",
+            true,
+            |path, body| {
+                writes += 1;
+                if writes == 2 {
+                    Err("simulated disk failure".into())
+                } else {
+                    std::fs::write(path, body).map_err(|e| e.to_string())
+                }
+            },
+        );
+
+        assert_eq!(result.unwrap_err(), "simulated disk failure");
+        assert_eq!(
+            std::fs::read_to_string(target.join("plugin.json")).unwrap(),
+            "old manifest"
+        );
+        assert_eq!(
+            std::fs::read_to_string(target.join("old.css")).unwrap(),
+            "old css"
+        );
+        assert!(!target.join("new.css").exists());
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn package_update_swaps_the_complete_directory_and_removes_stale_assets() {
+        let root = package_test_dir("swap");
+        let target = root.join("demo");
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::write(target.join("plugin.json"), "old manifest").unwrap();
+        std::fs::write(target.join("stale.css"), "stale").unwrap();
+
+        install_package_directory(
+            &root,
+            "demo",
+            "new manifest",
+            &[("source.js".into(), "new source".into())],
+            "new sidecar",
+            true,
+        )
+        .unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(target.join("plugin.json")).unwrap(),
+            "new manifest"
+        );
+        assert_eq!(
+            std::fs::read_to_string(target.join("source.js")).unwrap(),
+            "new source"
+        );
+        assert!(!target.join("stale.css").exists());
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn fresh_package_install_refuses_an_existing_id() {
+        let root = package_test_dir("collision");
+        let target = root.join("demo");
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::write(target.join("plugin.json"), "keep me").unwrap();
+
+        let err =
+            install_package_directory(&root, "demo", "new", &[], "sidecar", false).unwrap_err();
+
+        assert!(err.contains("already installed"));
+        assert_eq!(
+            std::fs::read_to_string(target.join("plugin.json")).unwrap(),
+            "keep me"
+        );
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[tokio::test]
+    async fn install_client_does_not_follow_redirects() {
+        use std::io::{Read, Write};
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0_u8; 1024];
+            let _ = stream.read(&mut request);
+            stream
+                .write_all(
+                    b"HTTP/1.1 302 Found\r\nLocation: http://127.0.0.1:9/private\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                )
+                .unwrap();
+        });
+
+        let response = install_http_client()
+            .unwrap()
+            .get(format!("http://{address}/plugin.json"))
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), reqwest::StatusCode::FOUND);
+        server.join().unwrap();
+    }
 
     #[test]
     fn truncate_chars_caps_at_chars_not_bytes() {

--- a/widgetsack/src/command.rs
+++ b/widgetsack/src/command.rs
@@ -652,6 +652,19 @@ fn valid_name(name: &str) -> bool {
         && name
             .chars()
             .all(|c| c.is_ascii_alphanumeric() || c == ' ' || c == '_' || c == '-')
+        && !windows_device_name(name)
+}
+
+fn windows_device_name(name: &str) -> bool {
+    let upper = name.to_ascii_uppercase();
+    if matches!(upper.as_str(), "CON" | "PRN" | "AUX" | "NUL") {
+        return true;
+    }
+    ["COM", "LPT"].iter().any(|prefix| {
+        upper.strip_prefix(prefix).is_some_and(|suffix| {
+            matches!(suffix, "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9")
+        })
+    })
 }
 
 fn valid_sack_name(name: &str) -> bool {
@@ -1005,12 +1018,19 @@ fn manifest_url_from_sidecar(source: &str, reff: &str) -> Option<String> {
 }
 
 /// A 10s-timeout https client for the (small) manifest/asset fetches.
-fn install_http_client() -> Result<reqwest::Client, String> {
-    reqwest::Client::builder()
-        .redirect(reqwest::redirect::Policy::none())
-        .timeout(std::time::Duration::from_secs(10))
-        .build()
-        .map_err(|e| e.to_string())
+fn install_http_client() -> Result<&'static reqwest::Client, String> {
+    static CLIENT: std::sync::OnceLock<Result<reqwest::Client, String>> =
+        std::sync::OnceLock::new();
+    CLIENT
+        .get_or_init(|| {
+            reqwest::Client::builder()
+                .redirect(reqwest::redirect::Policy::none())
+                .timeout(std::time::Duration::from_secs(10))
+                .build()
+                .map_err(|e| e.to_string())
+        })
+        .as_ref()
+        .map_err(Clone::clone)
 }
 
 /// GET `url` and return its body as text, enforcing `FETCH_CAP` while streaming (a hostile or
@@ -1230,7 +1250,7 @@ pub async fn install_plugin_package(
             .to_string()
     })?;
     let client = install_http_client()?;
-    let manifest_text = fetch_text_capped(&client, &resolved.manifest_url).await?;
+    let manifest_text = fetch_text_capped(client, &resolved.manifest_url).await?;
     let json: serde_json::Value = serde_json::from_str(&manifest_text)
         .map_err(|_| "downloaded plugin.json is not valid JSON".to_string())?;
     let id = json
@@ -1266,7 +1286,7 @@ pub async fn install_plugin_package(
                 return Err(format!("declared asset \"{file}\" has an unsafe filename"));
             }
             let body =
-                fetch_text_capped(&client, &asset_url_for(&resolved.manifest_url, file)).await?;
+                fetch_text_capped(client, &asset_url_for(&resolved.manifest_url, file)).await?;
             assets.push((file.to_string(), body));
         }
     }
@@ -1329,7 +1349,7 @@ pub async fn check_plugin_package_update(
     let url = manifest_url_from_sidecar(&source, reff)
         .ok_or_else(|| "install record has an invalid source".to_string())?;
     let client = install_http_client()?;
-    let manifest_text = fetch_text_capped(&client, &url).await?;
+    let manifest_text = fetch_text_capped(client, &url).await?;
     let json: serde_json::Value = serde_json::from_str(&manifest_text)
         .map_err(|_| "remote plugin.json is not valid JSON".to_string())?;
     let latest = json
@@ -1428,11 +1448,7 @@ pub async fn package_fetch(
     if !host_allowed(&url, &hosts) {
         return Err(format!("url is not in the package's host allowlist: {url}"));
     }
-    let client = reqwest::Client::builder()
-        .redirect(reqwest::redirect::Policy::none())
-        .timeout(std::time::Duration::from_secs(10))
-        .build()
-        .map_err(|e| e.to_string())?;
+    let client = install_http_client()?;
     let resp = client
         .get(&url)
         .send()
@@ -1888,6 +1904,13 @@ mod tests {
     }
 
     #[test]
+    fn package_http_requests_share_one_connection_pool() {
+        let first = install_http_client().unwrap();
+        let second = install_http_client().unwrap();
+        assert!(std::ptr::eq(first, second));
+    }
+
+    #[test]
     fn truncate_chars_caps_at_chars_not_bytes() {
         assert_eq!(truncate_chars("short", 10), "short");
         assert_eq!(truncate_chars("abcdef", 3), "abc…");
@@ -1963,6 +1986,14 @@ mod tests {
         assert!(!valid_name(" lead")); // leading space (Windows trims → name collision)
         assert!(!valid_name("trail ")); // trailing space
         assert!(!valid_name("   ")); // all whitespace
+        for reserved in [
+            "CON", "con", "PRN", "AUX", "NUL", "COM1", "com9", "LPT1", "lpt9",
+        ] {
+            assert!(
+                !valid_name(reserved),
+                "Windows device name {reserved} must be rejected"
+            );
+        }
     }
 
     #[test]

--- a/widgetsack/src/control.rs
+++ b/widgetsack/src/control.rs
@@ -166,7 +166,7 @@ fn write_control_file<R: Runtime>(app: &AppHandle<R>, url: &str, token: &str) {
         let _ = std::fs::create_dir_all(parent);
     }
     let body = json!({ "url": url, "token": token }).to_string();
-    let _ = std::fs::write(path, body);
+    let _ = crate::command::atomic_write(&path, &body);
 }
 
 fn remove_control_file<R: Runtime>(app: &AppHandle<R>) {

--- a/widgetsack/src/ha.rs
+++ b/widgetsack/src/ha.rs
@@ -141,13 +141,9 @@ fn ha_config_path<R: Runtime>(app: &AppHandle<R>) -> Result<PathBuf, String> {
 /// Read `plugins/ha.json`, or `None` if it doesn't exist.
 pub fn load_ha_config<R: Runtime>(app: &AppHandle<R>) -> Result<Option<HaConfig>, String> {
     let path = ha_config_path(app)?;
-    match std::fs::read_to_string(&path) {
-        Ok(txt) => serde_json::from_str(&txt)
-            .map(Some)
-            .map_err(|e| e.to_string()),
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
-        Err(err) => Err(err.to_string()),
-    }
+    crate::secure_config::read(&path)?
+        .map(|txt| serde_json::from_str(&txt).map_err(|e| e.to_string()))
+        .transpose()
 }
 
 // ---- pure seams (unit-tested, no I/O) ----
@@ -657,7 +653,7 @@ pub async fn save_ha_config(
         base_path: base_path.unwrap_or_default(),
     };
     let txt = serde_json::to_string_pretty(&cfg).map_err(|e| e.to_string())?;
-    std::fs::write(&path, txt).map_err(|e| e.to_string())
+    crate::secure_config::write(&path, &txt)
 }
 
 /// Validate an UNSAVED url/token/insecure combination by running the WS auth handshake, so the

--- a/widgetsack/src/llm.rs
+++ b/widgetsack/src/llm.rs
@@ -284,11 +284,9 @@ fn llm_config_path<R: Runtime>(app: &AppHandle<R>) -> Result<PathBuf, String> {
 /// exist.
 pub fn load_llm_file<R: Runtime>(app: &AppHandle<R>) -> Result<Option<LlmFile>, String> {
     let path = llm_config_path(app)?;
-    match std::fs::read_to_string(&path) {
-        Ok(txt) => parse_config_json(&txt).map(Some),
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
-        Err(err) => Err(err.to_string()),
-    }
+    crate::secure_config::read(&path)?
+        .map(|txt| parse_config_json(&txt))
+        .transpose()
 }
 
 /// The resolved ACTIVE provider config (the flat request config the HTTP seams consume), or `None`
@@ -788,7 +786,7 @@ pub async fn save_llm_config(
         file.agent_control = a;
     }
     let txt = serde_json::to_string_pretty(&file).map_err(|e| e.to_string())?;
-    std::fs::write(&path, txt).map_err(|e| e.to_string())
+    crate::secure_config::write(&path, &txt)
 }
 
 /// The (non-secret) config for EVERY configured provider + the active selection — never any api_key,

--- a/widgetsack/src/main.rs
+++ b/widgetsack/src/main.rs
@@ -41,6 +41,7 @@ pub mod ping;
 pub mod process_diag;
 pub mod recyclebin;
 pub mod rss;
+pub mod secure_config;
 pub mod sensors;
 pub mod state;
 pub mod stocks;
@@ -218,6 +219,10 @@ async fn main() -> Result<(), ()> {
         // moves/resizes are already in the plugin's cache. Studio only: overlays + main re-assert exact
         // geometry on launch, so eagerly persisting theirs isn't worth the disk churn.
         .on_window_event(|window, event| {
+            if matches!(event, tauri::WindowEvent::Destroyed) {
+                let active = window.app_handle().state::<sensors::ActiveSensors>();
+                sensors::remove_active_window(&active, window.label());
+            }
             if matches!(event, tauri::WindowEvent::Destroyed) && window.label() == "studio" {
                 use tauri_plugin_window_state::AppHandleExt;
                 let _ = window.app_handle().save_window_state(window_state_flags());
@@ -227,6 +232,7 @@ async fn main() -> Result<(), ()> {
         .manage(AppState {
             sessions: Default::default(),
         })
+        .manage(command::LayoutIoState::default())
         // Album-art store: covers are served to the webview over the `art` URI scheme (below)
         // instead of being shipped as JSON byte arrays. See art.rs.
         .manage(art::ArtState::default())

--- a/widgetsack/src/mqtt.rs
+++ b/widgetsack/src/mqtt.rs
@@ -102,13 +102,9 @@ fn mqtt_config_path<R: Runtime>(app: &AppHandle<R>) -> Result<PathBuf, String> {
 
 pub fn load_mqtt_config<R: Runtime>(app: &AppHandle<R>) -> Result<Option<MqttConfig>, String> {
     let path = mqtt_config_path(app)?;
-    match std::fs::read_to_string(&path) {
-        Ok(txt) => serde_json::from_str(&txt)
-            .map(Some)
-            .map_err(|e| e.to_string()),
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
-        Err(err) => Err(err.to_string()),
-    }
+    crate::secure_config::read(&path)?
+        .map(|txt| serde_json::from_str(&txt).map_err(|e| e.to_string()))
+        .transpose()
 }
 
 // ---- pure seams (unit-tested, no I/O) ----
@@ -376,7 +372,7 @@ pub async fn save_mqtt_config(
         discovery,
     };
     let txt = serde_json::to_string_pretty(&cfg).map_err(|e| e.to_string())?;
-    std::fs::write(&path, txt).map_err(|e| e.to_string())
+    crate::secure_config::write(&path, &txt)
 }
 
 /// The non-secret config (everything except the password).

--- a/widgetsack/src/rss.rs
+++ b/widgetsack/src/rss.rs
@@ -304,7 +304,7 @@ pub async fn save_rss_config(
         poll_interval_secs: poll_seconds.clamp(MIN_INTERVAL, MAX_INTERVAL),
     };
     let txt = serde_json::to_string_pretty(&cfg).map_err(|e| e.to_string())?;
-    std::fs::write(&path, txt).map_err(|e| e.to_string())
+    crate::command::atomic_write(&path, &txt)
 }
 
 #[tauri::command]

--- a/widgetsack/src/secure_config.rs
+++ b/widgetsack/src/secure_config.rs
@@ -1,0 +1,193 @@
+//! Credential-bearing config persistence. On Windows the whole JSON document is encrypted with
+//! the current user's DPAPI key before the existing atomic file replacement; legacy plaintext JSON
+//! is migrated on first successful read. The non-Windows implementation stays plaintext so pure
+//! backend tests can run on CI even though the application itself is Windows-only.
+
+use std::path::Path;
+
+const PREFIX: &str = "widgetsack-dpapi-v1:";
+
+pub fn read(path: &Path) -> Result<Option<String>, String> {
+    let raw = match std::fs::read_to_string(path) {
+        Ok(raw) => raw,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(err.to_string()),
+    };
+    if let Some(encoded) = raw.strip_prefix(PREFIX) {
+        let encrypted = hex_decode(encoded)?;
+        let clear = unprotect(&encrypted)?;
+        return String::from_utf8(clear)
+            .map(Some)
+            .map_err(|e| format!("decrypted config is not UTF-8: {e}"));
+    }
+
+    // Existing installs have plaintext JSON. Return it only after replacing the file with the
+    // protected representation, so merely launching the upgraded app completes the migration.
+    write(path, &raw)?;
+    Ok(Some(raw))
+}
+
+pub fn write(path: &Path, contents: &str) -> Result<(), String> {
+    let protected = protect(contents.as_bytes())?;
+    let payload = format!("{PREFIX}{}", hex_encode(&protected));
+    crate::command::atomic_write(path, &payload)
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for &byte in bytes {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    out
+}
+
+fn hex_decode(value: &str) -> Result<Vec<u8>, String> {
+    if !value.len().is_multiple_of(2) {
+        return Err("protected config has odd-length hex data".into());
+    }
+    value
+        .as_bytes()
+        .chunks_exact(2)
+        .map(|pair| {
+            let hi = hex_nibble(pair[0])?;
+            let lo = hex_nibble(pair[1])?;
+            Ok((hi << 4) | lo)
+        })
+        .collect()
+}
+
+fn hex_nibble(byte: u8) -> Result<u8, String> {
+    match byte {
+        b'0'..=b'9' => Ok(byte - b'0'),
+        b'a'..=b'f' => Ok(byte - b'a' + 10),
+        b'A'..=b'F' => Ok(byte - b'A' + 10),
+        _ => Err("protected config contains non-hex data".into()),
+    }
+}
+
+#[cfg(not(windows))]
+fn protect(clear: &[u8]) -> Result<Vec<u8>, String> {
+    Ok(clear.to_vec())
+}
+
+#[cfg(not(windows))]
+fn unprotect(encrypted: &[u8]) -> Result<Vec<u8>, String> {
+    Ok(encrypted.to_vec())
+}
+
+#[cfg(windows)]
+fn protect(clear: &[u8]) -> Result<Vec<u8>, String> {
+    use windows::Win32::Foundation::{HLOCAL, LocalFree};
+    use windows::Win32::Security::Cryptography::{
+        CRYPT_INTEGER_BLOB, CRYPTPROTECT_UI_FORBIDDEN, CryptProtectData,
+    };
+    use windows::core::PCWSTR;
+
+    let input = CRYPT_INTEGER_BLOB {
+        cbData: clear
+            .len()
+            .try_into()
+            .map_err(|_| "config is too large for DPAPI".to_string())?,
+        pbData: clear.as_ptr().cast_mut(),
+    };
+    let mut output = CRYPT_INTEGER_BLOB::default();
+    unsafe {
+        CryptProtectData(
+            &input,
+            PCWSTR::null(),
+            None,
+            None,
+            None,
+            CRYPTPROTECT_UI_FORBIDDEN,
+            &mut output,
+        )
+    }
+    .map_err(|e| format!("DPAPI protect failed: {e}"))?;
+    let result =
+        unsafe { std::slice::from_raw_parts(output.pbData, output.cbData as usize).to_vec() };
+    unsafe {
+        let _ = LocalFree(Some(HLOCAL(output.pbData.cast())));
+    }
+    Ok(result)
+}
+
+#[cfg(windows)]
+fn unprotect(encrypted: &[u8]) -> Result<Vec<u8>, String> {
+    use windows::Win32::Foundation::{HLOCAL, LocalFree};
+    use windows::Win32::Security::Cryptography::{
+        CRYPT_INTEGER_BLOB, CRYPTPROTECT_UI_FORBIDDEN, CryptUnprotectData,
+    };
+
+    let input = CRYPT_INTEGER_BLOB {
+        cbData: encrypted
+            .len()
+            .try_into()
+            .map_err(|_| "protected config is too large for DPAPI".to_string())?,
+        pbData: encrypted.as_ptr().cast_mut(),
+    };
+    let mut output = CRYPT_INTEGER_BLOB::default();
+    unsafe {
+        CryptUnprotectData(
+            &input,
+            None,
+            None,
+            None,
+            None,
+            CRYPTPROTECT_UI_FORBIDDEN,
+            &mut output,
+        )
+    }
+    .map_err(|e| format!("DPAPI unprotect failed: {e}"))?;
+    let result =
+        unsafe { std::slice::from_raw_parts(output.pbData, output.cbData as usize).to_vec() };
+    unsafe {
+        std::ptr::write_bytes(output.pbData, 0, output.cbData as usize);
+        let _ = LocalFree(Some(HLOCAL(output.pbData.cast())));
+    }
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hex_round_trip_and_validation() {
+        let bytes = b"\0WidgetSack\xff";
+        assert_eq!(hex_decode(&hex_encode(bytes)).unwrap(), bytes);
+        assert!(hex_decode("abc").is_err());
+        assert!(hex_decode("zz").is_err());
+    }
+
+    #[test]
+    fn protection_round_trip() {
+        let clear = b"{\"token\":\"secret\"}";
+        assert_eq!(unprotect(&protect(clear).unwrap()).unwrap(), clear);
+    }
+
+    #[test]
+    fn legacy_plaintext_is_migrated_on_first_read() {
+        let dir = std::env::temp_dir().join(format!(
+            "widgetsack-secure-config-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("secret.json");
+        let clear = "{\"token\":\"secret\"}";
+        std::fs::write(&path, clear).unwrap();
+
+        assert_eq!(read(&path).unwrap().as_deref(), Some(clear));
+        let stored = std::fs::read_to_string(&path).unwrap();
+        assert!(stored.starts_with(PREFIX));
+        assert!(!stored.contains("secret"));
+        assert_eq!(read(&path).unwrap().as_deref(), Some(clear));
+
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+}

--- a/widgetsack/src/sensors.rs
+++ b/widgetsack/src/sensors.rs
@@ -681,6 +681,16 @@ fn net_link_samples(_ts: u64) -> Vec<SensorSample> {
 #[derive(Default)]
 pub struct ActiveSensors(pub Mutex<HashMap<String, HashSet<String>>>);
 
+/// Drop a destroyed window's demand record so its wildcard or concrete ids cannot keep expensive
+/// polling alive after the webview is gone.
+pub(crate) fn remove_active_window(state: &ActiveSensors, label: &str) {
+    state
+        .0
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .remove(label);
+}
+
 /// Record the set of sensor ids window `window.label()` is currently consuming.
 ///
 /// The frontend calls `invoke("set_active_sensors", { ids })` whenever its set of
@@ -1415,6 +1425,18 @@ mod tests {
                 )
             })
             .collect()
+    }
+
+    #[test]
+    fn destroyed_window_drops_its_sensor_demand() {
+        let state = ActiveSensors(Mutex::new(active(&[
+            ("studio", &["*"]),
+            ("overlay-1", &["gpu.util"]),
+        ])));
+        remove_active_window(&state, "studio");
+        let map = state.0.lock().unwrap();
+        assert!(!map.contains_key("studio"));
+        assert_eq!(map["overlay-1"], HashSet::from(["gpu.util".to_string()]));
     }
 
     #[test]

--- a/widgetsack/src/sensors.rs
+++ b/widgetsack/src/sensors.rs
@@ -39,6 +39,7 @@
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use nvml_wrapper::{
@@ -678,8 +679,19 @@ fn net_link_samples(_ts: u64) -> Vec<SensorSample> {
 ///
 /// A plain `std::sync::Mutex` (locks are brief and synchronous — never held across an
 /// `.await`). Managed in `main.rs` and updated by the `set_active_sensors` command.
-#[derive(Default)]
-pub struct ActiveSensors(pub Mutex<HashMap<String, HashSet<String>>>);
+pub struct ActiveSensors(pub Mutex<HashMap<String, HashSet<String>>>, AtomicBool);
+
+impl Default for ActiveSensors {
+    fn default() -> Self {
+        Self(Mutex::new(HashMap::new()), AtomicBool::new(false))
+    }
+}
+
+impl ActiveSensors {
+    fn has_reported(&self) -> bool {
+        self.1.load(Ordering::Acquire)
+    }
+}
 
 /// Drop a destroyed window's demand record so its wildcard or concrete ids cannot keep expensive
 /// polling alive after the webview is gone.
@@ -703,30 +715,35 @@ pub async fn set_active_sensors<R: Runtime>(
 ) -> Result<(), ()> {
     let mut map = state.0.lock().unwrap_or_else(|e| e.into_inner());
     map.insert(window.label().to_string(), ids.into_iter().collect());
+    state.1.store(true, Ordering::Release);
     Ok(())
 }
 
-/// True if any window's active set wants a sensor matching `pred`. Default-ON for safety: a match
-/// counts when the union of every window's reported set is EMPTY (nobody has reported yet, so don't
-/// blank sensors at startup), OR any window asked for everything (`"*"`), OR any window's id
-/// satisfies `pred`.
+/// True if any window's active set wants a sensor matching `pred`. The caller separately decides
+/// whether the pre-first-report startup fallback applies; once a report has arrived, an empty union
+/// correctly means no demand (including the zero-window state after every reporter was destroyed).
 pub(crate) fn any_wanted(
     active: &HashMap<String, HashSet<String>>,
     pred: impl Fn(&str) -> bool,
 ) -> bool {
-    if active.values().all(|ids| ids.is_empty()) {
-        return true;
-    }
     active
         .values()
         .any(|ids| ids.contains("*") || ids.iter().any(|id| pred(id)))
 }
 
+fn any_wanted_or_unreported(
+    active: &HashMap<String, HashSet<String>>,
+    reported: bool,
+    pred: impl Fn(&str) -> bool,
+) -> bool {
+    !reported || any_wanted(active, pred)
+}
+
 /// Should the GPU be sampled this tick? Any active `gpu.*` id (or the `"*"` wildcard) turns the
 /// whole NVML block on; nothing else pays for it. A prefix test (not a fixed id list) so new
 /// `gpu.*` sensors are covered automatically.
-fn gpu_wanted(active: &HashMap<String, HashSet<String>>) -> bool {
-    any_wanted(active, |id| id.starts_with("gpu."))
+fn gpu_wanted(active: &HashMap<String, HashSet<String>>, reported: bool) -> bool {
+    any_wanted_or_unreported(active, reported, |id| id.starts_with("gpu."))
 }
 
 /// Per-metric demand for the "top process" sensors (`proc.<metric>.top.*`). The (gated, expensive)
@@ -917,12 +934,13 @@ pub async fn run_system_sensors<R: Runtime>(app: AppHandle<R>) {
         ) = {
             let active: tauri::State<ActiveSensors> = app.state();
             let g = active.0.lock().unwrap_or_else(|e| e.into_inner());
-            let pw = |p: &str| any_wanted(&g, |id| id.starts_with(p));
+            let reported = active.has_reported();
+            let pw = |p: &str| any_wanted_or_unreported(&g, reported, |id| id.starts_with(p));
             (
-                gpu_wanted(&g),
-                any_wanted(&g, |id| id.starts_with("disk.")),
-                any_wanted(&g, is_disk_io_id),
-                any_wanted(&g, |id| id == "host.procs"),
+                gpu_wanted(&g, reported),
+                any_wanted_or_unreported(&g, reported, |id| id.starts_with("disk.")),
+                any_wanted_or_unreported(&g, reported, is_disk_io_id),
+                any_wanted_or_unreported(&g, reported, |id| id == "host.procs"),
                 ProcWants {
                     cpu: pw("proc.cpu.top"),
                     mem: pw("proc.mem.top"),
@@ -930,13 +948,13 @@ pub async fn run_system_sensors<R: Runtime>(app: AppHandle<R>) {
                     gpu: pw("proc.gpu.top"),
                 },
                 proc_watch_names(&g),
-                any_wanted(&g, |id| id == "cpu.freq"),
-                any_wanted(&g, is_perf_id),
-                any_wanted(&g, is_cpufreq_id),
-                any_wanted(&g, is_netlink_id),
-                any_wanted(&g, |id| id.starts_with("net.conn")),
-                any_wanted(&g, is_wifi_id),
-                any_wanted(&g, |id| id.starts_with("recyclebin")),
+                any_wanted_or_unreported(&g, reported, |id| id == "cpu.freq"),
+                any_wanted_or_unreported(&g, reported, is_perf_id),
+                any_wanted_or_unreported(&g, reported, is_cpufreq_id),
+                any_wanted_or_unreported(&g, reported, is_netlink_id),
+                any_wanted_or_unreported(&g, reported, |id| id.starts_with("net.conn")),
+                any_wanted_or_unreported(&g, reported, is_wifi_id),
+                any_wanted_or_unreported(&g, reported, |id| id.starts_with("recyclebin")),
             )
         };
         let want_proctop = proc_w.any();
@@ -1429,10 +1447,10 @@ mod tests {
 
     #[test]
     fn destroyed_window_drops_its_sensor_demand() {
-        let state = ActiveSensors(Mutex::new(active(&[
-            ("studio", &["*"]),
-            ("overlay-1", &["gpu.util"]),
-        ])));
+        let state = ActiveSensors(
+            Mutex::new(active(&[("studio", &["*"]), ("overlay-1", &["gpu.util"])])),
+            AtomicBool::new(true),
+        );
         remove_active_window(&state, "studio");
         let map = state.0.lock().unwrap();
         assert!(!map.contains_key("studio"));
@@ -1440,34 +1458,50 @@ mod tests {
     }
 
     #[test]
-    fn gpu_wanted_defaults_on_when_nobody_reported() {
-        // Empty map: no window has reported yet → sample everything for safety.
-        assert!(gpu_wanted(&HashMap::new()));
-        // A window that reported an empty set is treated like "not reported yet".
-        assert!(gpu_wanted(&active(&[("main", &[])])));
+    fn destroying_the_last_reporter_keeps_expensive_demand_off() {
+        let state = ActiveSensors(
+            Mutex::new(active(&[("main", &["gpu.util"])])),
+            AtomicBool::new(true),
+        );
+        remove_active_window(&state, "main");
+        let map = state.0.lock().unwrap();
+        assert!(!gpu_wanted(&map, state.has_reported()));
+    }
+
+    #[test]
+    fn gpu_wanted_defaults_on_only_before_the_first_demand_report() {
+        // Before any webview reports, preserve the startup safety fallback.
+        assert!(gpu_wanted(&HashMap::new(), false));
+        // Once a live window has explicitly reported an empty set, expensive polling is off.
+        assert!(!gpu_wanted(&active(&[("main", &[])]), true));
+        // The remembered report state also keeps a later zero-window map off.
+        assert!(!gpu_wanted(&HashMap::new(), true));
     }
 
     #[test]
     fn gpu_wanted_false_when_only_cheap_sensors() {
-        assert!(!gpu_wanted(&active(&[("main", &["cpu.total"])])));
-        assert!(!gpu_wanted(&active(&[
-            ("main", &["cpu.total", "mem.used"]),
-            ("overlay-1", &["net.down"])
-        ])));
+        assert!(!gpu_wanted(&active(&[("main", &["cpu.total"])]), true));
+        assert!(!gpu_wanted(
+            &active(&[
+                ("main", &["cpu.total", "mem.used"]),
+                ("overlay-1", &["net.down"])
+            ]),
+            true
+        ));
     }
 
     #[test]
     fn gpu_wanted_true_for_any_gpu_prefixed_id() {
         // The prefix gate covers both the original and the new gpu.* ids.
-        assert!(gpu_wanted(&active(&[("main", &["gpu.util"])])));
-        assert!(gpu_wanted(&active(&[("main", &["gpu.vram.total"])])));
-        assert!(gpu_wanted(&active(&[("main", &["gpu.clock.core"])])));
-        assert!(gpu_wanted(&active(&[("main", &["gpu.power"])])));
+        assert!(gpu_wanted(&active(&[("main", &["gpu.util"])]), true));
+        assert!(gpu_wanted(&active(&[("main", &["gpu.vram.total"])]), true));
+        assert!(gpu_wanted(&active(&[("main", &["gpu.clock.core"])]), true));
+        assert!(gpu_wanted(&active(&[("main", &["gpu.power"])]), true));
     }
 
     #[test]
     fn gpu_wanted_true_for_star_sentinel() {
-        assert!(gpu_wanted(&active(&[("studio", &["*"])])));
+        assert!(gpu_wanted(&active(&[("studio", &["*"])]), true));
     }
 
     #[test]

--- a/widgetsack/src/stocks.rs
+++ b/widgetsack/src/stocks.rs
@@ -414,7 +414,7 @@ pub async fn save_stocks_config(
         poll_interval_secs: poll_seconds.clamp(MIN_INTERVAL, MAX_INTERVAL),
     };
     let txt = serde_json::to_string_pretty(&cfg).map_err(|e| e.to_string())?;
-    std::fs::write(&path, txt).map_err(|e| e.to_string())
+    crate::command::atomic_write(&path, &txt)
 }
 
 /// The (non-secret) config.

--- a/widgetsack/src/weather.rs
+++ b/widgetsack/src/weather.rs
@@ -341,7 +341,7 @@ pub async fn save_weather_config(
         poll_interval_secs: poll_seconds.clamp(MIN_INTERVAL, MAX_INTERVAL),
     };
     let txt = serde_json::to_string_pretty(&cfg).map_err(|e| e.to_string())?;
-    std::fs::write(&path, txt).map_err(|e| e.to_string())
+    crate::command::atomic_write(&path, &txt)
 }
 
 /// The (non-secret) config.

--- a/widgetsack/tauri.conf.json
+++ b/widgetsack/tauri.conf.json
@@ -50,7 +50,7 @@
     "createUpdaterArtifacts": false
   },
   "productName": "widgetsack",
-  "version": "0.0.51",
+  "version": "0.0.52",
   "identifier": "io.github.gyng",
   "plugins": {},
   "app": {

--- a/widgetsack/tauri.conf.json
+++ b/widgetsack/tauri.conf.json
@@ -84,7 +84,7 @@
         },
         "enable": true
       },
-      "csp": "default-src 'self'; img-src 'self' asset: http://asset.localhost http://art.localhost blob: data:; media-src 'self' asset: http://asset.localhost blob: data:; font-src 'self' asset: http://asset.localhost; style-src 'self' 'unsafe-inline'; connect-src 'self' ipc: http://ipc.localhost; script-src 'self' 'wasm-unsafe-eval'; frame-src 'self' http: https:"
+      "csp": "default-src 'self'; img-src 'self' asset: http://asset.localhost http://art.localhost blob: data: http: https:; media-src 'self' asset: http://asset.localhost blob: data:; font-src 'self' asset: http://asset.localhost; style-src 'self' 'unsafe-inline'; connect-src 'self' ipc: http://ipc.localhost; script-src 'self' 'wasm-unsafe-eval'; frame-src 'self' http: https:"
     }
   }
 }


### PR DESCRIPTION
## What changed

- harden plugin package refresh/removal, CSS consent storage, source cleanup, package fetch reuse, and Windows filename validation
- make theme persistence errors visible and preserve editor state; prevent stale asynchronous theme CSS from winning
- stop expensive sensor polling after the last demand reporter disappears while retaining safe startup behavior
- allow explicitly supported remote widget images through the production CSP
- add high-value regression coverage for each failure mode and document plugin consent behavior
- prepare the lockstep Cargo/Tauri `v0.0.52` release version

## Why

The follow-up review found several fail-open or stale-state edges: same-ID plugin refreshes could retain removed capabilities, failed deletes could lose approvals, theme writes could report success after backend failures, asynchronous theme loads could race, and zero-window sensor demand could keep expensive polling alive.

## Validation

- client type-check and lint
- 3,176 Vitest tests across 277 files with coverage thresholds passing (99.57% statements, 98.93% branches, 99.83% functions, 99.91% lines)
- production client build and generated-doc freshness check
- 34 Playwright E2E tests
- 218 Rust tests (216 passed, 2 ignored manual smoke tests)
- Windows `cargo clippy -- -D warnings`
- `cargo fmt --check`
- Windows Cargo check for `widgetsack v0.0.52`